### PR TITLE
增加双击合约自动填表功能。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# C++源代码
+﻿# C++源代码
 ipch/
 Release/
 
@@ -40,12 +40,11 @@ Release/
 *.vssettings
 *.klg
 
-<<<<<<< HEAD
 # 不想同步的
 *.local
-*.temp
-=======
 vn.ctp/build/*
 vn.lts/build/*
+vnctpmd/
+*。pyd
 .idea
->>>>>>> 65aac25731772259bf2d4049e7adbe92750ea01d
+

--- a/vn.trader/ctpGateway.py
+++ b/vn.trader/ctpGateway.py
@@ -7,6 +7,9 @@ vn.ctp的gateway接入
 vtSymbol直接使用symbol
 '''
 
+import sys
+reload(sys)
+sys.setdefaultencoding( "utf-8" )
 
 import os
 import json
@@ -82,15 +85,15 @@ class CtpGateway(VtGateway):
         fileName = self.gatewayName + '_connect.json'
         try:
             f = file(fileName)
+            # 解析json文件
+            setting = json.load(f, 'utf-8')
         except IOError:
             log = VtLogData()
             log.gatewayName = self.gatewayName
             log.logContent = u'读取连接配置出错，请检查'
             self.onLog(log)
             return
-        
-        # 解析json文件
-        setting = json.load(f)
+
         try:
             userID = str(setting['userID'])
             password = str(setting['password'])
@@ -715,7 +718,7 @@ class CtpTdApi(TdApi):
 
         contract.symbol = data['InstrumentID']
         contract.exchange = exchangeMapReverse[data['ExchangeID']]
-        contract.vtSymbol = contract.symbol #'.'.join([contract.symbol, contract.exchange])
+        contract.vtSymbol = contract.symbol #  '.'.join([contract.symbol, contract.exchange])
         contract.name = data['InstrumentName'].decode('GBK')
         
         # 合约数值
@@ -739,7 +742,7 @@ class CtpTdApi(TdApi):
             contract.optionType = OPTION_CALL
         elif data['OptionsType'] == '2':
             contract.optionType = OPTION_PUT
-        
+
         # 推送
         self.gateway.onContract(contract)
         

--- a/vn.trader/uiMainWindow.py
+++ b/vn.trader/uiMainWindow.py
@@ -42,7 +42,7 @@ class MainWindow(QtGui.QMainWindow):
         positionM = PositionMonitor(self.eventEngine)
         accountM = AccountMonitor(self.eventEngine)
         
-        tradingW = TradingWidget(self.mainEngine, self.mainEngine.eventEngine, self.mainEngine.dataEngine)
+        self.tradingW = TradingWidget(self.mainEngine, self.mainEngine.eventEngine, self.mainEngine.dataEngine)
         
         leftTab = QtGui.QTabWidget()
         leftTab.addTab(logM, u'日志')
@@ -55,7 +55,7 @@ class MainWindow(QtGui.QMainWindow):
         rightTab.addTab(positionM, u'持仓')
     
         hbox = QtGui.QHBoxLayout()
-        hbox.addWidget(tradingW)
+        hbox.addWidget(self.tradingW)
         hbox.addWidget(marketM)
         
         grid = QtGui.QGridLayout()
@@ -227,7 +227,9 @@ class MainWindow(QtGui.QMainWindow):
         except KeyError:
             self.widgetDict['contractM'] = ContractMonitor(self.mainEngine.dataEngine)
             self.widgetDict['contractM'].show()
-            
+
+        self.widgetDict['contractM'].click_item.connect(self.tradingW.set_tick_context)
+
     #----------------------------------------------------------------------
     def openCta(self):
         """打开CTA组件"""

--- a/vn.trader/vtMain.py
+++ b/vn.trader/vtMain.py
@@ -2,6 +2,7 @@
 
 import sys
 import ctypes
+import platform
 
 from vtEngine import MainEngine
 from uiMainWindow import *
@@ -9,8 +10,8 @@ from uiMainWindow import *
 #----------------------------------------------------------------------
 def main():
     """主程序入口"""
-    # 设置底部任务栏图标，win7以下请注释掉
-    ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID('vn.py demo')  
+    if platform.system() =="Windows" and platform.version() > '6':
+        ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID('vn.py demo')
     
     app = QtGui.QApplication(sys.argv)
     app.setWindowIcon(QtGui.QIcon('vnpy.ico'))


### PR DESCRIPTION
填表信息由合约界面提取（dataEngine.getcontract有的时候根据vtsysmol查不到），并在行情界面显示。
增加行情界面右键菜单-完全清除，现在清除后，行情推送到后，又会显示，没有找到取消评阅函数。
请忽略非py部分的更改。
建议之后把.gitignore完善下，非代码的太多了。