### PR TITLE
增加批量订阅行情的接口subscribeMarketDataList

### DIFF
--- a/vn.ctp/vnctpmd/vnctpmd/vnctpmd.cpp
+++ b/vn.ctp/vnctpmd/vnctpmd/vnctpmd.cpp
@@ -692,6 +692,34 @@ int MdApi::unSubscribeMarketData(string instrumentID)
 	return i;
 };
 
+int MdApi::subscribeMarketDataList(boost::python::list instrumentIDs)
+{
+	vector<string> ids;
+	char** buffer = new char *[len(instrumentIDs)];
+	for (int i=0; i<len(instrumentIDs); i++) {
+		string s = boost::python::extract<string>(instrumentIDs[i]);
+		ids.push_back(s);
+		buffer[i] = (char*)s.c_str();
+	}
+	int i = this->api->SubscribeMarketData(buffer, len(instrumentIDs));
+	delete[] buffer;
+	return i;
+};
+
+int MdApi::unSubscribeMarketDataList(boost::python::list instrumentIDs)
+{
+	vector<string> ids;
+	char** buffer = new char *[len(instrumentIDs)];
+	for (int i=0; i<len(instrumentIDs); i++) {
+		string s = boost::python::extract<string>(instrumentIDs[i]);
+		ids.push_back(s);
+		buffer[i] = (char*)s.c_str();
+	}
+	int i = this->api->UnSubscribeMarketData(buffer, len(instrumentIDs));
+	delete[] buffer;
+	return i;
+};
+
 int MdApi::subscribeForQuoteRsp(string instrumentID)
 {
 	char* buffer = (char*)instrumentID.c_str();
@@ -905,6 +933,8 @@ BOOST_PYTHON_MODULE(vnctpmd)
 		.def("registerFront", &MdApiWrap::registerFront)
 		.def("subscribeMarketData", &MdApiWrap::subscribeMarketData)
 		.def("unSubscribeMarketData", &MdApiWrap::unSubscribeMarketData)
+		.def("subscribeMarketDataList", &MdApiWrap::subscribeMarketDataList)
+		.def("unSubscribeMarketDataList", &MdApiWrap::unSubscribeMarketDataList)
 		.def("subscribeForQuoteRsp", &MdApiWrap::subscribeForQuoteRsp)
 		.def("unSubscribeForQuoteRsp", &MdApiWrap::unSubscribeForQuoteRsp)
 		.def("reqUserLogin", &MdApiWrap::reqUserLogin)

--- a/vn.ctp/vnctpmd/vnctpmd/vnctpmd.h
+++ b/vn.ctp/vnctpmd/vnctpmd/vnctpmd.h
@@ -6,11 +6,13 @@
 #endif
 #include <string>
 #include <queue>
+#include <vector>
 
 //Boost
 #define BOOST_PYTHON_STATIC_LIB
 #include <boost/python/module.hpp>	//python封装
 #include <boost/python/def.hpp>		//python封装
+#include <boost/python/list.hpp>	//python封装
 #include <boost/python/dict.hpp>	//python封装
 #include <boost/python/object.hpp>	//python封装
 #include <boost/python.hpp>			//python封装
@@ -295,6 +297,10 @@ public:
 	int subscribeMarketData(string instrumentID);
 
 	int unSubscribeMarketData(string instrumentID);
+
+	int subscribeMarketDataList(boost::python::list instrumentIDs);
+
+	int unSubscribeMarketDataList(boost::python::list instrumentIDs);
 
 	int subscribeForQuoteRsp(string instrumentID);
 


### PR DESCRIPTION
usage:
    i = api.subscribeMarketDataList(['IF1605','IC1605','IH1605'])