### PR TITLE
1. 修复IB报错 2. 修复在MAC上编码错误, 默认设置位UTF8 3. 设置底部任务栏图标只在windows显示

### DIFF
--- a/vn.trader/ibGateway/ibGateway.py
+++ b/vn.trader/ibGateway/ibGateway.py
@@ -11,6 +11,7 @@ ibpy的gateway接入
 5. 海外市场的交易规则和国内有很多细节上的不同，所以一些字段类型的映射可能不合理，如果发现问题欢迎指出
 '''
 
+import os
 import json
 from time import sleep, strftime, localtime
 from copy import copy

--- a/vn.trader/vtFunction.py
+++ b/vn.trader/vtFunction.py
@@ -6,6 +6,7 @@
 
 import decimal
 import json
+import sys
 
 MAX_NUMBER = 10000000000000
 MAX_DECIMAL = 4
@@ -24,6 +25,9 @@ def safeUnicode(value):
         if abs(d.as_tuple().exponent) > MAX_DECIMAL:
             value = round(value, ndigits=MAX_DECIMAL)
     
+    # Reload sys, Set default encode to UTF8
+    reload(sys)
+    sys.setdefaultencoding('utf8')
     return unicode(value)
 
 #----------------------------------------------------------------------

--- a/vn.trader/vtFunction.py
+++ b/vn.trader/vtFunction.py
@@ -6,7 +6,6 @@
 
 import decimal
 import json
-import sys
 
 MAX_NUMBER = 10000000000000
 MAX_DECIMAL = 4
@@ -25,9 +24,6 @@ def safeUnicode(value):
         if abs(d.as_tuple().exponent) > MAX_DECIMAL:
             value = round(value, ndigits=MAX_DECIMAL)
     
-    # Reload sys, Set default encode to UTF8
-    reload(sys)
-    sys.setdefaultencoding('utf8')
     return unicode(value)
 
 #----------------------------------------------------------------------

--- a/vn.trader/vtMain.py
+++ b/vn.trader/vtMain.py
@@ -2,6 +2,7 @@
 
 import sys
 import ctypes
+import platform
 
 from vtEngine import MainEngine
 from uiMainWindow import *
@@ -10,7 +11,8 @@ from uiMainWindow import *
 def main():
     """主程序入口"""
     # 设置底部任务栏图标，win7以下请注释掉
-    ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID('vn.py demo')  
+    if platform.uname() == 'Windows':
+        ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID('vn.py demo')  
     
     # 初始化Qt应用对象
     app = QtGui.QApplication(sys.argv)

--- a/vn.trader/vtMain.py
+++ b/vn.trader/vtMain.py
@@ -14,6 +14,10 @@ def main():
     if platform.uname() == 'Windows':
         ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID('vn.py demo')  
     
+    # Reload sys, Set default encode to UTF8
+    reload(sys)
+    sys.setdefaultencoding('utf8')
+
     # 初始化Qt应用对象
     app = QtGui.QApplication(sys.argv)
     app.setWindowIcon(QtGui.QIcon('vnpy.ico'))


### PR DESCRIPTION
1. 修复IB报错 2. 修复在MAC上编码错误, 默认设置位UTF8 3. 设置底部任务栏图标只在windows显示