### PR TITLE
修复MongoDB连接bug

### DIFF
--- a/vn.trader/vtEngine.py
+++ b/vn.trader/vtEngine.py
@@ -208,7 +208,8 @@ class MainEngine(object):
             host, port = loadMongoSetting()
                 
             try:
-                self.dbClient = MongoClient(host, port)
+                self.dbClient = MongoClient(host, port, serverSelectionTimeoutMS=3000)
+                self.dbClient.server_info()
                 self.writeLog(u'MongoDB连接成功')
             except ConnectionFailure:
                 self.writeLog(u'MongoDB连接失败')


### PR DESCRIPTION
修复在MongoDB服务端异常情况下，启动vnpy依然显示MongoDB连接成功bug。
修改‘serverSelectionTimeoutMS’为3s(默认30s), 利用server_info()函数测试服务器是否正常。