### PR TITLE
websocket-client才是真正支持OKCoin的库

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ git clone https://github.com/blampe/IbPy.git
 
 cd IbPy
 python setup.py install
-```
 
-* OKCOIN - ```pip install websocket``` or ```conda install websocket```
+```
+* OKCOIN - ```pip install websocket-client``` or ```conda install websocket-client```
 
 
 ---


### PR DESCRIPTION
websocket虽然提供了相同的namespace，去掉了启动时时的错误，但真正能够连接okcoin的是websocket-client