### PR TITLE
增加中文字符的字符集转换，兼容Python35

### DIFF
--- a/vn.ctp/vnctpmd/vnctpmd/vnctpmd.cpp
+++ b/vn.ctp/vnctpmd/vnctpmd/vnctpmd.cpp
@@ -1,21 +1,21 @@
-// vnctpmd.cpp : ¶¨Òå DLL Ó¦ÓÃ³ÌĞòµÄµ¼³öº¯Êı¡£
+// vnctpmd.cpp : å®šä¹‰ DLL åº”ç”¨ç¨‹åºçš„å¯¼å‡ºå‡½æ•°ã€‚
 //
 
 #include "vnctpmd.h"
 
 ///-------------------------------------------------------------------------------------
-///´ÓPython¶ÔÏóµ½C++ÀàĞÍ×ª»»ÓÃµÄº¯Êı
+///ä»Pythonå¯¹è±¡åˆ°C++ç±»å‹è½¬æ¢ç”¨çš„å‡½æ•°
 ///-------------------------------------------------------------------------------------
 
 void getInt(dict d, string key, int *value)
 {
-	if (d.has_key(key))		//¼ì²é×ÖµäÖĞÊÇ·ñ´æÔÚ¸Ã¼üÖµ
+	if (d.has_key(key))		//æ£€æŸ¥å­—å…¸ä¸­æ˜¯å¦å­˜åœ¨è¯¥é”®å€¼
 	{
-		object o = d[key];	//»ñÈ¡¸Ã¼üÖµ
-		extract<int> x(o);	//´´½¨ÌáÈ¡Æ÷
-		if (x.check())		//Èç¹û¿ÉÒÔÌáÈ¡
+		object o = d[key];	//è·å–è¯¥é”®å€¼
+		extract<int> x(o);	//åˆ›å»ºæå–å™¨
+		if (x.check())		//å¦‚æœå¯ä»¥æå–
 		{
-			*value = x();	//¶ÔÄ¿±êÕûÊıÖ¸Õë¸³Öµ
+			*value = x();	//å¯¹ç›®æ ‡æ•´æ•°æŒ‡é’ˆèµ‹å€¼
 		}
 	}
 };
@@ -43,8 +43,8 @@ void getStr(dict d, string key, char *value)
 		{
 			string s = x();
 			const char *buffer = s.c_str();
-			//¶Ô×Ö·û´®Ö¸Õë¸³Öµ±ØĞëÊ¹ÓÃstrcpy_s, vs2013Ê¹ÓÃstrcpy±àÒëÍ¨²»¹ı
-			//+1Ó¦¸ÃÊÇÒòÎªC++×Ö·û´®µÄ½áÎ²·ûºÅ£¿²»ÊÇÌØ±ğÈ·¶¨£¬²»¼ÓÕâ¸ö1»á³ö´í
+			//å¯¹å­—ç¬¦ä¸²æŒ‡é’ˆèµ‹å€¼å¿…é¡»ä½¿ç”¨strcpy_s, vs2013ä½¿ç”¨strcpyç¼–è¯‘é€šä¸è¿‡
+			//+1åº”è¯¥æ˜¯å› ä¸ºC++å­—ç¬¦ä¸²çš„ç»“å°¾ç¬¦å·ï¼Ÿä¸æ˜¯ç‰¹åˆ«ç¡®å®šï¼Œä¸åŠ è¿™ä¸ª1ä¼šå‡ºé”™
 #ifdef _MSC_VER //WIN32
 			strcpy_s(value, strlen(buffer) + 1, buffer);
 #elif __GNUC__
@@ -71,7 +71,7 @@ void getChar(dict d, string key, char *value)
 
 
 ///-------------------------------------------------------------------------------------
-///C++µÄ»Øµ÷º¯Êı½«Êı¾İ±£´æµ½¶ÓÁĞÖĞ
+///C++çš„å›è°ƒå‡½æ•°å°†æ•°æ®ä¿å­˜åˆ°é˜Ÿåˆ—ä¸­
 ///-------------------------------------------------------------------------------------
 
 void MdApi::OnFrontConnected()
@@ -342,7 +342,7 @@ void MdApi::OnRtnForQuoteRsp(CThostFtdcForQuoteRspField *pForQuoteRsp)
 
 
 ///-------------------------------------------------------------------------------------
-///¹¤×÷Ïß³Ì´Ó¶ÓÁĞÖĞÈ¡³öÊı¾İ£¬×ª»¯Îªpython¶ÔÏóºó£¬½øĞĞÍÆËÍ
+///å·¥ä½œçº¿ç¨‹ä»é˜Ÿåˆ—ä¸­å–å‡ºæ•°æ®ï¼Œè½¬åŒ–ä¸ºpythonå¯¹è±¡åï¼Œè¿›è¡Œæ¨é€
 ///-------------------------------------------------------------------------------------
 
 void MdApi::processTask()
@@ -467,7 +467,8 @@ void MdApi::processRspUserLogin(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspUserLogin(data, error, task.task_id, task.task_last);
@@ -483,7 +484,8 @@ void MdApi::processRspUserLogout(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspUserLogout(data, error, task.task_id, task.task_last);
@@ -494,7 +496,8 @@ void MdApi::processRspError(Task task)
 	PyLock lock;
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspError(error, task.task_id, task.task_last);
@@ -509,7 +512,8 @@ void MdApi::processRspSubMarketData(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspSubMarketData(data, error, task.task_id, task.task_last);
@@ -524,7 +528,8 @@ void MdApi::processRspUnSubMarketData(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspUnSubMarketData(data, error, task.task_id, task.task_last);
@@ -539,7 +544,8 @@ void MdApi::processRspSubForQuoteRsp(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspSubForQuoteRsp(data, error, task.task_id, task.task_last);
@@ -554,7 +560,8 @@ void MdApi::processRspUnSubForQuoteRsp(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspUnSubForQuoteRsp(data, error, task.task_id, task.task_last);
@@ -631,7 +638,7 @@ void MdApi::processRtnForQuoteRsp(Task task)
 
 
 ///-------------------------------------------------------------------------------------
-///Ö÷¶¯º¯Êı
+///ä¸»åŠ¨å‡½æ•°
 ///-------------------------------------------------------------------------------------
 
 void MdApi::createFtdcMdApi(string pszFlowPath)
@@ -658,7 +665,7 @@ int MdApi::join()
 
 int MdApi::exit()
 {
-	//¸Ãº¯ÊıÔÚÔ­ÉúAPIÀïÃ»ÓĞ£¬ÓÃÓÚ°²È«ÍË³öAPIÓÃ£¬Ô­ÉúµÄjoinËÆºõ²»Ì«ÎÈ¶¨
+	//è¯¥å‡½æ•°åœ¨åŸç”ŸAPIé‡Œæ²¡æœ‰ï¼Œç”¨äºå®‰å…¨é€€å‡ºAPIç”¨ï¼ŒåŸç”Ÿçš„joinä¼¼ä¹ä¸å¤ªç¨³å®š
 	this->api->RegisterSpi(NULL);
 	this->api->Release();
 	this->api = NULL;
@@ -739,14 +746,14 @@ int MdApi::reqUserLogout(dict req, int nRequestID)
 
 
 ///-------------------------------------------------------------------------------------
-///Boost.Python·â×°
+///Boost.Pythonå°è£…
 ///-------------------------------------------------------------------------------------
 
 struct MdApiWrap : MdApi, wrapper < MdApi >
 {
 	virtual void onFrontConnected()
 	{
-		//ÒÔÏÂµÄtry...catch...¿ÉÒÔÊµÏÖ²¶×½python»·¾³ÖĞ´íÎóµÄ¹¦ÄÜ£¬·ÀÖ¹C++Ö±½Ó³öÏÖÔ­ÒòÎ´ÖªµÄ±ÀÀ£
+		//ä»¥ä¸‹çš„try...catch...å¯ä»¥å®ç°æ•æ‰pythonç¯å¢ƒä¸­é”™è¯¯çš„åŠŸèƒ½ï¼Œé˜²æ­¢C++ç›´æ¥å‡ºç°åŸå› æœªçŸ¥çš„å´©æºƒ
 		try
 		{
 			this->get_override("onFrontConnected")();
@@ -893,7 +900,7 @@ struct MdApiWrap : MdApi, wrapper < MdApi >
 
 BOOST_PYTHON_MODULE(vnctpmd)
 {
-	PyEval_InitThreads();	//µ¼ÈëÊ±ÔËĞĞ£¬±£Ö¤ÏÈ´´½¨GIL
+	PyEval_InitThreads();	//å¯¼å…¥æ—¶è¿è¡Œï¼Œä¿è¯å…ˆåˆ›å»ºGIL
 
 	class_<MdApiWrap, boost::noncopyable>("MdApi")
 		.def("createFtdcMdApi", &MdApiWrap::createFtdcMdApi)

--- a/vn.ctp/vnctpmd/vnctpmd/vnctpmd.h
+++ b/vn.ctp/vnctpmd/vnctpmd/vnctpmd.h
@@ -1,6 +1,6 @@
-//ËµÃ÷²¿·Ö
+//è¯´æ˜éƒ¨åˆ†
 
-//ÏµÍ³
+//ç³»ç»Ÿ
 #ifdef WIN32
 #include "stdafx.h"
 #endif
@@ -9,24 +9,25 @@
 
 //Boost
 #define BOOST_PYTHON_STATIC_LIB
-#include <boost/python/module.hpp>	//python·â×°
-#include <boost/python/def.hpp>		//python·â×°
-#include <boost/python/dict.hpp>	//python·â×°
-#include <boost/python/object.hpp>	//python·â×°
-#include <boost/python.hpp>			//python·â×°
-#include <boost/thread.hpp>			//ÈÎÎñ¶ÓÁĞµÄÏß³Ì¹¦ÄÜ
-#include <boost/bind.hpp>			//ÈÎÎñ¶ÓÁĞµÄÏß³Ì¹¦ÄÜ
-#include <boost/any.hpp>			//ÈÎÎñ¶ÓÁĞµÄÈÎÎñÊµÏÖ
+#include <boost/python/module.hpp>	//pythonå°è£…
+#include <boost/python/def.hpp>		//pythonå°è£…
+#include <boost/python/dict.hpp>	//pythonå°è£…
+#include <boost/python/object.hpp>	//pythonå°è£…
+#include <boost/python.hpp>			//pythonå°è£…
+#include <boost/thread.hpp>			//ä»»åŠ¡é˜Ÿåˆ—çš„çº¿ç¨‹åŠŸèƒ½
+#include <boost/bind.hpp>			//ä»»åŠ¡é˜Ÿåˆ—çš„çº¿ç¨‹åŠŸèƒ½
+#include <boost/any.hpp>			//ä»»åŠ¡é˜Ÿåˆ—çš„ä»»åŠ¡å®ç°
+#include <boost/locale.hpp>            //å­—ç¬¦é›†è½¬æ¢
 
 //API
 #include "ThostFtdcMdApi.h"
 
-//ÃüÃû¿Õ¼ä
+//å‘½åç©ºé—´
 using namespace std;
 using namespace boost::python;
 using namespace boost;
 
-//³£Á¿
+//å¸¸é‡
 #define ONFRONTCONNECTED 1
 #define ONFRONTDISCONNECTED 2
 #define ONHEARTBEATWARNING 3
@@ -43,24 +44,24 @@ using namespace boost;
 
 
 ///-------------------------------------------------------------------------------------
-///APIÖĞµÄ²¿·Ö×é¼ş
+///APIä¸­çš„éƒ¨åˆ†ç»„ä»¶
 ///-------------------------------------------------------------------------------------
 
-//GILÈ«¾ÖËø¼ò»¯»ñÈ¡ÓÃ£¬
-//ÓÃÓÚ°ïÖúC++Ïß³Ì»ñµÃGILËø£¬´Ó¶ø·ÀÖ¹python±ÀÀ£
+//GILå…¨å±€é”ç®€åŒ–è·å–ç”¨ï¼Œ
+//ç”¨äºå¸®åŠ©C++çº¿ç¨‹è·å¾—GILé”ï¼Œä»è€Œé˜²æ­¢pythonå´©æºƒ
 class PyLock
 {
 private:
 	PyGILState_STATE gil_state;
 
 public:
-	//ÔÚÄ³¸öº¯Êı·½·¨ÖĞ´´½¨¸Ã¶ÔÏóÊ±£¬»ñµÃGILËø
+	//åœ¨æŸä¸ªå‡½æ•°æ–¹æ³•ä¸­åˆ›å»ºè¯¥å¯¹è±¡æ—¶ï¼Œè·å¾—GILé”
 	PyLock()
 	{
 		gil_state = PyGILState_Ensure();
 	}
 
-	//ÔÚÄ³¸öº¯ÊıÍê³ÉºóÏú»Ù¸Ã¶ÔÏóÊ±£¬½â·ÅGILËø
+	//åœ¨æŸä¸ªå‡½æ•°å®Œæˆåé”€æ¯è¯¥å¯¹è±¡æ—¶ï¼Œè§£æ”¾GILé”
 	~PyLock()
 	{
 		PyGILState_Release(gil_state);
@@ -68,90 +69,90 @@ public:
 };
 
 
-//ÈÎÎñ½á¹¹Ìå
+//ä»»åŠ¡ç»“æ„ä½“
 struct Task
 {
-	int task_name;		//»Øµ÷º¯ÊıÃû³Æ¶ÔÓ¦µÄ³£Á¿
-	any task_data;		//Êı¾İ½á¹¹Ìå
-	any task_error;		//´íÎó½á¹¹Ìå
-	int task_id;		//ÇëÇóid
-	bool task_last;		//ÊÇ·ñÎª×îºó·µ»Ø
+	int task_name;		//å›è°ƒå‡½æ•°åç§°å¯¹åº”çš„å¸¸é‡
+	any task_data;		//æ•°æ®ç»“æ„ä½“
+	any task_error;		//é”™è¯¯ç»“æ„ä½“
+	int task_id;		//è¯·æ±‚id
+	bool task_last;		//æ˜¯å¦ä¸ºæœ€åè¿”å›
 };
 
 
-///Ïß³Ì°²È«µÄ¶ÓÁĞ
+///çº¿ç¨‹å®‰å…¨çš„é˜Ÿåˆ—
 template<typename Data>
 
 class ConcurrentQueue
 {
 private:
-	queue<Data> the_queue;								//±ê×¼¿â¶ÓÁĞ
-	mutable mutex the_mutex;							//boost»¥³âËø
-	condition_variable the_condition_variable;			//boostÌõ¼ş±äÁ¿
+	queue<Data> the_queue;								//æ ‡å‡†åº“é˜Ÿåˆ—
+	mutable mutex the_mutex;							//boostäº’æ–¥é”
+	condition_variable the_condition_variable;			//boostæ¡ä»¶å˜é‡
 
 public:
 
-	//´æÈëĞÂµÄÈÎÎñ
+	//å­˜å…¥æ–°çš„ä»»åŠ¡
 	void push(Data const& data)
 	{
-		mutex::scoped_lock lock(the_mutex);				//»ñÈ¡»¥³âËø
-		the_queue.push(data);							//Ïò¶ÓÁĞÖĞ´æÈëÊı¾İ
-		lock.unlock();									//ÊÍ·ÅËø
-		the_condition_variable.notify_one();			//Í¨ÖªÕıÔÚ×èÈûµÈ´ıµÄÏß³Ì
+		mutex::scoped_lock lock(the_mutex);				//è·å–äº’æ–¥é”
+		the_queue.push(data);							//å‘é˜Ÿåˆ—ä¸­å­˜å…¥æ•°æ®
+		lock.unlock();									//é‡Šæ”¾é”
+		the_condition_variable.notify_one();			//é€šçŸ¥æ­£åœ¨é˜»å¡ç­‰å¾…çš„çº¿ç¨‹
 	}
 
-	//¼ì²é¶ÓÁĞÊÇ·ñÎª¿Õ
+	//æ£€æŸ¥é˜Ÿåˆ—æ˜¯å¦ä¸ºç©º
 	bool empty() const
 	{
 		mutex::scoped_lock lock(the_mutex);
 		return the_queue.empty();
 	}
 
-	//È¡³ö
+	//å–å‡º
 	Data wait_and_pop()
 	{
 		mutex::scoped_lock lock(the_mutex);
 
-		while (the_queue.empty())						//µ±¶ÓÁĞÎª¿ÕÊ±
+		while (the_queue.empty())						//å½“é˜Ÿåˆ—ä¸ºç©ºæ—¶
 		{
-			the_condition_variable.wait(lock);			//µÈ´ıÌõ¼ş±äÁ¿Í¨Öª
+			the_condition_variable.wait(lock);			//ç­‰å¾…æ¡ä»¶å˜é‡é€šçŸ¥
 		}
 
-		Data popped_value = the_queue.front();			//»ñÈ¡¶ÓÁĞÖĞµÄ×îºóÒ»¸öÈÎÎñ
-		the_queue.pop();								//É¾³ı¸ÃÈÎÎñ
-		return popped_value;							//·µ»Ø¸ÃÈÎÎñ
+		Data popped_value = the_queue.front();			//è·å–é˜Ÿåˆ—ä¸­çš„æœ€åä¸€ä¸ªä»»åŠ¡
+		the_queue.pop();								//åˆ é™¤è¯¥ä»»åŠ¡
+		return popped_value;							//è¿”å›è¯¥ä»»åŠ¡
 	}
 
 };
 
 
-//´Ó×ÖµäÖĞ»ñÈ¡Ä³¸ö½¨Öµ¶ÔÓ¦µÄÕûÊı£¬²¢¸³Öµµ½ÇëÇó½á¹¹Ìå¶ÔÏóµÄÖµÉÏ
+//ä»å­—å…¸ä¸­è·å–æŸä¸ªå»ºå€¼å¯¹åº”çš„æ•´æ•°ï¼Œå¹¶èµ‹å€¼åˆ°è¯·æ±‚ç»“æ„ä½“å¯¹è±¡çš„å€¼ä¸Š
 void getInt(dict d, string key, int* value);
 
 
-//´Ó×ÖµäÖĞ»ñÈ¡Ä³¸ö½¨Öµ¶ÔÓ¦µÄ¸¡µãÊı£¬²¢¸³Öµµ½ÇëÇó½á¹¹Ìå¶ÔÏóµÄÖµÉÏ
+//ä»å­—å…¸ä¸­è·å–æŸä¸ªå»ºå€¼å¯¹åº”çš„æµ®ç‚¹æ•°ï¼Œå¹¶èµ‹å€¼åˆ°è¯·æ±‚ç»“æ„ä½“å¯¹è±¡çš„å€¼ä¸Š
 void getDouble(dict d, string key, double* value);
 
 
-//´Ó×ÖµäÖĞ»ñÈ¡Ä³¸ö½¨Öµ¶ÔÓ¦µÄ×Ö·û£¬²¢¸³Öµµ½ÇëÇó½á¹¹Ìå¶ÔÏóµÄÖµÉÏ
+//ä»å­—å…¸ä¸­è·å–æŸä¸ªå»ºå€¼å¯¹åº”çš„å­—ç¬¦ï¼Œå¹¶èµ‹å€¼åˆ°è¯·æ±‚ç»“æ„ä½“å¯¹è±¡çš„å€¼ä¸Š
 void getChar(dict d, string key, char* value);
 
 
-//´Ó×ÖµäÖĞ»ñÈ¡Ä³¸ö½¨Öµ¶ÔÓ¦µÄ×Ö·û´®£¬²¢¸³Öµµ½ÇëÇó½á¹¹Ìå¶ÔÏóµÄÖµÉÏ
+//ä»å­—å…¸ä¸­è·å–æŸä¸ªå»ºå€¼å¯¹åº”çš„å­—ç¬¦ä¸²ï¼Œå¹¶èµ‹å€¼åˆ°è¯·æ±‚ç»“æ„ä½“å¯¹è±¡çš„å€¼ä¸Š
 void getStr(dict d, string key, char* value);
 
 
 ///-------------------------------------------------------------------------------------
-///C++ SPIµÄ»Øµ÷º¯Êı·½·¨ÊµÏÖ
+///C++ SPIçš„å›è°ƒå‡½æ•°æ–¹æ³•å®ç°
 ///-------------------------------------------------------------------------------------
 
-//APIµÄ¼Ì³ĞÊµÏÖ
+//APIçš„ç»§æ‰¿å®ç°
 class MdApi : public CThostFtdcMdSpi
 {
 private:
-	CThostFtdcMdApi* api;				//API¶ÔÏó
-	thread *task_thread;				//¹¤×÷Ïß³ÌÖ¸Õë£¨ÏòpythonÖĞÍÆËÍÊı¾İ£©
-	ConcurrentQueue<Task> task_queue;	//ÈÎÎñ¶ÓÁĞ
+	CThostFtdcMdApi* api;				//APIå¯¹è±¡
+	thread *task_thread;				//å·¥ä½œçº¿ç¨‹æŒ‡é’ˆï¼ˆå‘pythonä¸­æ¨é€æ•°æ®ï¼‰
+	ConcurrentQueue<Task> task_queue;	//ä»»åŠ¡é˜Ÿåˆ—
 
 public:
 	MdApi()
@@ -166,54 +167,54 @@ public:
 	};
 
 	//-------------------------------------------------------------------------------------
-	//API»Øµ÷º¯Êı
+	//APIå›è°ƒå‡½æ•°
 	//-------------------------------------------------------------------------------------
 
-	///µ±¿Í»§¶ËÓë½»Ò×ºóÌ¨½¨Á¢ÆğÍ¨ĞÅÁ¬½ÓÊ±£¨»¹Î´µÇÂ¼Ç°£©£¬¸Ã·½·¨±»µ÷ÓÃ¡£
+	///å½“å®¢æˆ·ç«¯ä¸äº¤æ˜“åå°å»ºç«‹èµ·é€šä¿¡è¿æ¥æ—¶ï¼ˆè¿˜æœªç™»å½•å‰ï¼‰ï¼Œè¯¥æ–¹æ³•è¢«è°ƒç”¨ã€‚
 	virtual void OnFrontConnected();
 
-	///µ±¿Í»§¶ËÓë½»Ò×ºóÌ¨Í¨ĞÅÁ¬½Ó¶Ï¿ªÊ±£¬¸Ã·½·¨±»µ÷ÓÃ¡£µ±·¢ÉúÕâ¸öÇé¿öºó£¬API»á×Ô¶¯ÖØĞÂÁ¬½Ó£¬¿Í»§¶Ë¿É²»×ö´¦Àí¡£
-	///@param nReason ´íÎóÔ­Òò
-	///        0x1001 ÍøÂç¶ÁÊ§°Ü
-	///        0x1002 ÍøÂçĞ´Ê§°Ü
-	///        0x2001 ½ÓÊÕĞÄÌø³¬Ê±
-	///        0x2002 ·¢ËÍĞÄÌøÊ§°Ü
-	///        0x2003 ÊÕµ½´íÎó±¨ÎÄ
+	///å½“å®¢æˆ·ç«¯ä¸äº¤æ˜“åå°é€šä¿¡è¿æ¥æ–­å¼€æ—¶ï¼Œè¯¥æ–¹æ³•è¢«è°ƒç”¨ã€‚å½“å‘ç”Ÿè¿™ä¸ªæƒ…å†µåï¼ŒAPIä¼šè‡ªåŠ¨é‡æ–°è¿æ¥ï¼Œå®¢æˆ·ç«¯å¯ä¸åšå¤„ç†ã€‚
+	///@param nReason é”™è¯¯åŸå› 
+	///        0x1001 ç½‘ç»œè¯»å¤±è´¥
+	///        0x1002 ç½‘ç»œå†™å¤±è´¥
+	///        0x2001 æ¥æ”¶å¿ƒè·³è¶…æ—¶
+	///        0x2002 å‘é€å¿ƒè·³å¤±è´¥
+	///        0x2003 æ”¶åˆ°é”™è¯¯æŠ¥æ–‡
 	virtual void OnFrontDisconnected(int nReason);
 
-	///ĞÄÌø³¬Ê±¾¯¸æ¡£µ±³¤Ê±¼äÎ´ÊÕµ½±¨ÎÄÊ±£¬¸Ã·½·¨±»µ÷ÓÃ¡£
-	///@param nTimeLapse ¾àÀëÉÏ´Î½ÓÊÕ±¨ÎÄµÄÊ±¼ä
+	///å¿ƒè·³è¶…æ—¶è­¦å‘Šã€‚å½“é•¿æ—¶é—´æœªæ”¶åˆ°æŠ¥æ–‡æ—¶ï¼Œè¯¥æ–¹æ³•è¢«è°ƒç”¨ã€‚
+	///@param nTimeLapse è·ç¦»ä¸Šæ¬¡æ¥æ”¶æŠ¥æ–‡çš„æ—¶é—´
 	virtual void OnHeartBeatWarning(int nTimeLapse);
 
-	///µÇÂ¼ÇëÇóÏìÓ¦
+	///ç™»å½•è¯·æ±‚å“åº”
 	virtual void OnRspUserLogin(CThostFtdcRspUserLoginField *pRspUserLogin, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast);
 
-	///µÇ³öÇëÇóÏìÓ¦
+	///ç™»å‡ºè¯·æ±‚å“åº”
 	virtual void OnRspUserLogout(CThostFtdcUserLogoutField *pUserLogout, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast);
 
-	///´íÎóÓ¦´ğ
+	///é”™è¯¯åº”ç­”
 	virtual void OnRspError(CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast);
 
-	///¶©ÔÄĞĞÇéÓ¦´ğ
+	///è®¢é˜…è¡Œæƒ…åº”ç­”
 	virtual void OnRspSubMarketData(CThostFtdcSpecificInstrumentField *pSpecificInstrument, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast);
 
-	///È¡Ïû¶©ÔÄĞĞÇéÓ¦´ğ
+	///å–æ¶ˆè®¢é˜…è¡Œæƒ…åº”ç­”
 	virtual void OnRspUnSubMarketData(CThostFtdcSpecificInstrumentField *pSpecificInstrument, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast);
 
-	///¶©ÔÄÑ¯¼ÛÓ¦´ğ
+	///è®¢é˜…è¯¢ä»·åº”ç­”
 	virtual void OnRspSubForQuoteRsp(CThostFtdcSpecificInstrumentField *pSpecificInstrument, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast);
 
-	///È¡Ïû¶©ÔÄÑ¯¼ÛÓ¦´ğ
+	///å–æ¶ˆè®¢é˜…è¯¢ä»·åº”ç­”
 	virtual void OnRspUnSubForQuoteRsp(CThostFtdcSpecificInstrumentField *pSpecificInstrument, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast);
 
-	///Éî¶ÈĞĞÇéÍ¨Öª
+	///æ·±åº¦è¡Œæƒ…é€šçŸ¥
 	virtual void OnRtnDepthMarketData(CThostFtdcDepthMarketDataField *pDepthMarketData);
 
-	///Ñ¯¼ÛÍ¨Öª
+	///è¯¢ä»·é€šçŸ¥
 	virtual void OnRtnForQuoteRsp(CThostFtdcForQuoteRspField *pForQuoteRsp);
 
 	//-------------------------------------------------------------------------------------
-	//task£ºÈÎÎñ
+	//taskï¼šä»»åŠ¡
 	//-------------------------------------------------------------------------------------
 
 	void processTask();
@@ -243,11 +244,11 @@ public:
 	void processRtnForQuoteRsp(Task task);
 
 	//-------------------------------------------------------------------------------------
-	//data£º»Øµ÷º¯ÊıµÄÊı¾İ×Öµä
-	//error£º»Øµ÷º¯ÊıµÄ´íÎó×Öµä
-	//id£ºÇëÇóid
-	//last£ºÊÇ·ñÎª×îºó·µ»Ø
-	//i£ºÕûÊı
+	//dataï¼šå›è°ƒå‡½æ•°çš„æ•°æ®å­—å…¸
+	//errorï¼šå›è°ƒå‡½æ•°çš„é”™è¯¯å­—å…¸
+	//idï¼šè¯·æ±‚id
+	//lastï¼šæ˜¯å¦ä¸ºæœ€åè¿”å›
+	//iï¼šæ•´æ•°
 	//-------------------------------------------------------------------------------------
 
 	virtual void onFrontConnected(){};
@@ -275,7 +276,7 @@ public:
 	virtual void onRtnForQuoteRsp(dict data) {};
 
 	//-------------------------------------------------------------------------------------
-	//req:Ö÷¶¯º¯ÊıµÄÇëÇó×Öµä
+	//req:ä¸»åŠ¨å‡½æ•°çš„è¯·æ±‚å­—å…¸
 	//-------------------------------------------------------------------------------------
 
 	void createFtdcMdApi(string pszFlowPath = "");

--- a/vn.ctp/vnctptd/vnctptd/vnctptd.cpp
+++ b/vn.ctp/vnctptd/vnctptd/vnctptd.cpp
@@ -1,22 +1,22 @@
-// vnctptd.cpp : ∂®“Â DLL ”¶”√≥Ã–Úµƒµº≥ˆ∫Ø ˝°£
+// vnctptd.cpp : ÂÆö‰πâ DLL Â∫îÁî®Á®ãÂ∫èÁöÑÂØºÂá∫ÂáΩÊï∞„ÄÇ
 //
 
 #include "vnctptd.h"
 
 
 ///-------------------------------------------------------------------------------------
-///¥”Python∂‘œÛµΩC++¿‡–Õ◊™ªª”√µƒ∫Ø ˝
+///‰ªéPythonÂØπË±°Âà∞C++Á±ªÂûãËΩ¨Êç¢Áî®ÁöÑÂáΩÊï∞
 ///-------------------------------------------------------------------------------------
 
 void getInt(dict d, string key, int *value)
 {
-	if (d.has_key(key))		//ºÏ≤È◊÷µ‰÷– «∑Ò¥Ê‘⁄∏√º¸÷µ
+	if (d.has_key(key))		//Ê£ÄÊü•Â≠óÂÖ∏‰∏≠ÊòØÂê¶Â≠òÂú®ËØ•ÈîÆÂÄº
 	{
-		object o = d[key];	//ªÒ»°∏√º¸÷µ
-		extract<int> x(o);	//¥¥Ω®Ã·»°∆˜
-		if (x.check())		//»Áπ˚ø…“‘Ã·»°
+		object o = d[key];	//Ëé∑ÂèñËØ•ÈîÆÂÄº
+		extract<int> x(o);	//ÂàõÂª∫ÊèêÂèñÂô®
+		if (x.check())		//Â¶ÇÊûúÂèØ‰ª•ÊèêÂèñ
 		{
-			*value = x();	//∂‘ƒø±Í’˚ ˝÷∏’Î∏≥÷µ
+			*value = x();	//ÂØπÁõÆÊ†áÊï¥Êï∞ÊåáÈíàËµãÂÄº
 		}
 	}
 }
@@ -44,8 +44,8 @@ void getStr(dict d, string key, char *value)
 		{
 			string s = x();
 			const char *buffer = s.c_str();
-			//∂‘◊÷∑˚¥Æ÷∏’Î∏≥÷µ±ÿ–Î π”√strcpy_s, vs2013 π”√strcpy±‡“ÎÕ®≤ªπ˝
-			//+1”¶∏√ «“ÚŒ™C++◊÷∑˚¥ÆµƒΩ·Œ≤∑˚∫≈£ø≤ª «Ãÿ±»∑∂®£¨≤ªº”’‚∏ˆ1ª·≥ˆ¥Ì
+			//ÂØπÂ≠óÁ¨¶‰∏≤ÊåáÈíàËµãÂÄºÂøÖÈ°ª‰ΩøÁî®strcpy_s, vs2013‰ΩøÁî®strcpyÁºñËØëÈÄö‰∏çËøá
+			//+1Â∫îËØ•ÊòØÂõ†‰∏∫C++Â≠óÁ¨¶‰∏≤ÁöÑÁªìÂ∞æÁ¨¶Âè∑Ôºü‰∏çÊòØÁâπÂà´Á°ÆÂÆöÔºå‰∏çÂä†Ëøô‰∏™1‰ºöÂá∫Èîô
 #ifdef _MSC_VER //WIN32
 			strcpy_s(value, strlen(buffer) + 1, buffer);
 #elif __GNUC__
@@ -72,7 +72,7 @@ void getChar(dict d, string key, char *value)
 
 
 ///-------------------------------------------------------------------------------------
-///C++µƒªÿµ˜∫Ø ˝Ω´ ˝æ›±£¥ÊµΩ∂”¡–÷–
+///C++ÁöÑÂõûË∞ÉÂáΩÊï∞Â∞ÜÊï∞ÊçÆ‰øùÂ≠òÂà∞ÈòüÂàó‰∏≠
 ///-------------------------------------------------------------------------------------
 
 void TdApi::OnFrontConnected()
@@ -3147,7 +3147,7 @@ void TdApi::OnRtnChangeAccountByBank(CThostFtdcChangeAccountField *pChangeAccoun
 
 
 ///-------------------------------------------------------------------------------------
-///π§◊˜œﬂ≥Ã¥”∂”¡–÷–»°≥ˆ ˝æ›£¨◊™ªØŒ™python∂‘œÛ∫Û£¨Ω¯––Õ∆ÀÕ
+///Â∑•‰ΩúÁ∫øÁ®ã‰ªéÈòüÂàó‰∏≠ÂèñÂá∫Êï∞ÊçÆÔºåËΩ¨Âåñ‰∏∫pythonÂØπË±°ÂêéÔºåËøõË°åÊé®ÈÄÅ
 ///-------------------------------------------------------------------------------------
 
 void TdApi::processTask()
@@ -3868,7 +3868,8 @@ void TdApi::processRspAuthenticate(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspAuthenticate(data, error, task.task_id, task.task_last);
@@ -3895,7 +3896,8 @@ void TdApi::processRspUserLogin(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspUserLogin(data, error, task.task_id, task.task_last);
@@ -3911,7 +3913,8 @@ void TdApi::processRspUserLogout(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspUserLogout(data, error, task.task_id, task.task_last);
@@ -3929,7 +3932,8 @@ void TdApi::processRspUserPasswordUpdate(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspUserPasswordUpdate(data, error, task.task_id, task.task_last);
@@ -3948,7 +3952,8 @@ void TdApi::processRspTradingAccountPasswordUpdate(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspTradingAccountPasswordUpdate(data, error, task.task_id, task.task_last);
@@ -3986,7 +3991,8 @@ void TdApi::processRspOrderInsert(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspOrderInsert(data, error, task.task_id, task.task_last);
@@ -4021,7 +4027,10 @@ void TdApi::processRspParkedOrderInsert(Task task)
 	data["CombHedgeFlag"] = task_data.CombHedgeFlag;
 	data["GTDDate"] = task_data.GTDDate;
 	data["BusinessUnit"] = task_data.BusinessUnit;
-	data["ErrorMsg"] = task_data.ErrorMsg;
+
+	std::string ErrorMsg1 = boost::locale::conv::to_utf<char>(task_data.ErrorMsg, std::string("GB2312"));
+	data["ErrorMsg"] = ErrorMsg1;
+
 	data["OrderRef"] = task_data.OrderRef;
 	data["InvestorID"] = task_data.InvestorID;
 	data["VolumeCondition"] = task_data.VolumeCondition;
@@ -4029,7 +4038,8 @@ void TdApi::processRspParkedOrderInsert(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg2 = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg2;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspParkedOrderInsert(data, error, task.task_id, task.task_last);
@@ -4046,7 +4056,10 @@ void TdApi::processRspParkedOrderAction(Task task)
 	data["ActionFlag"] = task_data.ActionFlag;
 	data["OrderActionRef"] = task_data.OrderActionRef;
 	data["UserType"] = task_data.UserType;
-	data["ErrorMsg"] = task_data.ErrorMsg;
+
+	std::string ErrorMsg1 = boost::locale::conv::to_utf<char>(task_data.ErrorMsg, std::string("GB2312"));
+	data["ErrorMsg"] = ErrorMsg1;
+
 	data["UserID"] = task_data.UserID;
 	data["LimitPrice"] = task_data.LimitPrice;
 	data["OrderRef"] = task_data.OrderRef;
@@ -4062,7 +4075,8 @@ void TdApi::processRspParkedOrderAction(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg2 = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg2;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspParkedOrderAction(data, error, task.task_id, task.task_last);
@@ -4090,7 +4104,8 @@ void TdApi::processRspOrderAction(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspOrderAction(data, error, task.task_id, task.task_last);
@@ -4112,7 +4127,8 @@ void TdApi::processRspQueryMaxOrderVolume(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQueryMaxOrderVolume(data, error, task.task_id, task.task_last);
@@ -4130,7 +4146,8 @@ void TdApi::processRspSettlementInfoConfirm(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspSettlementInfoConfirm(data, error, task.task_id, task.task_last);
@@ -4147,7 +4164,8 @@ void TdApi::processRspRemoveParkedOrder(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspRemoveParkedOrder(data, error, task.task_id, task.task_last);
@@ -4164,7 +4182,8 @@ void TdApi::processRspRemoveParkedOrderAction(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspRemoveParkedOrderAction(data, error, task.task_id, task.task_last);
@@ -4193,7 +4212,8 @@ void TdApi::processRspExecOrderInsert(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspExecOrderInsert(data, error, task.task_id, task.task_last);
@@ -4219,7 +4239,8 @@ void TdApi::processRspExecOrderAction(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspExecOrderAction(data, error, task.task_id, task.task_last);
@@ -4239,7 +4260,8 @@ void TdApi::processRspForQuoteInsert(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspForQuoteInsert(data, error, task.task_id, task.task_last);
@@ -4272,7 +4294,8 @@ void TdApi::processRspQuoteInsert(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQuoteInsert(data, error, task.task_id, task.task_last);
@@ -4298,7 +4321,8 @@ void TdApi::processRspQuoteAction(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQuoteAction(data, error, task.task_id, task.task_last);
@@ -4322,7 +4346,8 @@ void TdApi::processRspLockInsert(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspLockInsert(data, error, task.task_id, task.task_last);
@@ -4346,7 +4371,8 @@ void TdApi::processRspCombActionInsert(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspCombActionInsert(data, error, task.task_id, task.task_last);
@@ -4418,7 +4444,8 @@ void TdApi::processRspQryOrder(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryOrder(data, error, task.task_id, task.task_last);
@@ -4462,7 +4489,8 @@ void TdApi::processRspQryTrade(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryTrade(data, error, task.task_id, task.task_last);
@@ -4521,7 +4549,8 @@ void TdApi::processRspQryInvestorPosition(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryInvestorPosition(data, error, task.task_id, task.task_last);
@@ -4582,7 +4611,8 @@ void TdApi::processRspQryTradingAccount(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryTradingAccount(data, error, task.task_id, task.task_last);
@@ -4609,7 +4639,8 @@ void TdApi::processRspQryInvestor(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryInvestor(data, error, task.task_id, task.task_last);
@@ -4631,7 +4662,8 @@ void TdApi::processRspQryTradingCode(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryTradingCode(data, error, task.task_id, task.task_last);
@@ -4655,7 +4687,8 @@ void TdApi::processRspQryInstrumentMarginRate(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryInstrumentMarginRate(data, error, task.task_id, task.task_last);
@@ -4681,7 +4714,8 @@ void TdApi::processRspQryInstrumentCommissionRate(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryInstrumentCommissionRate(data, error, task.task_id, task.task_last);
@@ -4698,7 +4732,8 @@ void TdApi::processRspQryExchange(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryExchange(data, error, task.task_id, task.task_last);
@@ -4729,7 +4764,8 @@ void TdApi::processRspQryProduct(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryProduct(data, error, task.task_id, task.task_last);
@@ -4749,7 +4785,10 @@ void TdApi::processRspQryInstrument(Task task)
 	data["PositionType"] = task_data.PositionType;
 	data["ProductClass"] = task_data.ProductClass;
 	data["MinSellVolume"] = task_data.MinSellVolume;
-	data["InstrumentName"] = task_data.InstrumentName;
+
+	std::string InstrumentName = boost::locale::conv::to_utf<char>(task_data.InstrumentName, std::string("GB2312"));
+	data["InstrumentName"] = InstrumentName;
+
 	data["ShortMarginRatio"] = task_data.ShortMarginRatio;
 	data["VolumeMultiple"] = task_data.VolumeMultiple;
 	data["MaxMarginSideAlgorithm"] = task_data.MaxMarginSideAlgorithm;
@@ -4777,7 +4816,8 @@ void TdApi::processRspQryInstrument(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryInstrument(data, error, task.task_id, task.task_last);
@@ -4835,7 +4875,8 @@ void TdApi::processRspQryDepthMarketData(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryDepthMarketData(data, error, task.task_id, task.task_last);
@@ -4855,7 +4896,8 @@ void TdApi::processRspQrySettlementInfo(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQrySettlementInfo(data, error, task.task_id, task.task_last);
@@ -4873,7 +4915,8 @@ void TdApi::processRspQryTransferBank(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryTransferBank(data, error, task.task_id, task.task_last);
@@ -4913,7 +4956,8 @@ void TdApi::processRspQryInvestorPositionDetail(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryInvestorPositionDetail(data, error, task.task_id, task.task_last);
@@ -4930,7 +4974,8 @@ void TdApi::processRspQryNotice(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryNotice(data, error, task.task_id, task.task_last);
@@ -4948,7 +4993,8 @@ void TdApi::processRspQrySettlementInfoConfirm(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQrySettlementInfoConfirm(data, error, task.task_id, task.task_last);
@@ -4982,7 +5028,8 @@ void TdApi::processRspQryInvestorPositionCombineDetail(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryInvestorPositionCombineDetail(data, error, task.task_id, task.task_last);
@@ -5001,7 +5048,8 @@ void TdApi::processRspQryCFMMCTradingAccountKey(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryCFMMCTradingAccountKey(data, error, task.task_id, task.task_last);
@@ -5023,7 +5071,8 @@ void TdApi::processRspQryEWarrantOffset(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryEWarrantOffset(data, error, task.task_id, task.task_last);
@@ -5064,7 +5113,8 @@ void TdApi::processRspQryInvestorProductGroupMargin(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryInvestorProductGroupMargin(data, error, task.task_id, task.task_last);
@@ -5085,7 +5135,8 @@ void TdApi::processRspQryExchangeMarginRate(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryExchangeMarginRate(data, error, task.task_id, task.task_last);
@@ -5114,7 +5165,8 @@ void TdApi::processRspQryExchangeMarginRateAdjust(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryExchangeMarginRateAdjust(data, error, task.task_id, task.task_last);
@@ -5133,7 +5185,8 @@ void TdApi::processRspQryExchangeRate(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryExchangeRate(data, error, task.task_id, task.task_last);
@@ -5152,7 +5205,8 @@ void TdApi::processRspQrySecAgentACIDMap(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQrySecAgentACIDMap(data, error, task.task_id, task.task_last);
@@ -5169,7 +5223,8 @@ void TdApi::processRspQryProductExchRate(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryProductExchRate(data, error, task.task_id, task.task_last);
@@ -5186,7 +5241,8 @@ void TdApi::processRspQryProductGroup(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryProductGroup(data, error, task.task_id, task.task_last);
@@ -5210,7 +5266,8 @@ void TdApi::processRspQryOptionInstrTradeCost(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryOptionInstrTradeCost(data, error, task.task_id, task.task_last);
@@ -5237,7 +5294,8 @@ void TdApi::processRspQryOptionInstrCommRate(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryOptionInstrCommRate(data, error, task.task_id, task.task_last);
@@ -5290,7 +5348,8 @@ void TdApi::processRspQryExecOrder(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryExecOrder(data, error, task.task_id, task.task_last);
@@ -5324,7 +5383,8 @@ void TdApi::processRspQryForQuote(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryForQuote(data, error, task.task_id, task.task_last);
@@ -5383,7 +5443,8 @@ void TdApi::processRspQryQuote(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryQuote(data, error, task.task_id, task.task_last);
@@ -5431,7 +5492,8 @@ void TdApi::processRspQryLock(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryLock(data, error, task.task_id, task.task_last);
@@ -5451,7 +5513,8 @@ void TdApi::processRspQryLockPosition(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryLockPosition(data, error, task.task_id, task.task_last);
@@ -5469,7 +5532,8 @@ void TdApi::processRspQryInvestorLevel(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryInvestorLevel(data, error, task.task_id, task.task_last);
@@ -5491,7 +5555,8 @@ void TdApi::processRspQryExecFreeze(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryExecFreeze(data, error, task.task_id, task.task_last);
@@ -5508,7 +5573,8 @@ void TdApi::processRspQryCombInstrumentGuard(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryCombInstrumentGuard(data, error, task.task_id, task.task_last);
@@ -5547,7 +5613,8 @@ void TdApi::processRspQryCombAction(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryCombAction(data, error, task.task_id, task.task_last);
@@ -5582,14 +5649,18 @@ void TdApi::processRspQryTransferSerial(Task task)
 	data["BankAccType"] = task_data.BankAccType;
 	data["FutureSerial"] = task_data.FutureSerial;
 	data["InvestorID"] = task_data.InvestorID;
-	data["ErrorMsg"] = task_data.ErrorMsg;
+
+	std::string ErrorMsg1 = boost::locale::conv::to_utf<char>(task_data.ErrorMsg, std::string("GB2312"));
+	data["ErrorMsg"] = ErrorMsg1;
+
 	data["CustFee"] = task_data.CustFee;
 	data["TradeAmount"] = task_data.TradeAmount;
 	data["AvailabilityFlag"] = task_data.AvailabilityFlag;
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryTransferSerial(data, error, task.task_id, task.task_last);
@@ -5620,7 +5691,8 @@ void TdApi::processRspQryAccountregister(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryAccountregister(data, error, task.task_id, task.task_last);
@@ -5631,7 +5703,8 @@ void TdApi::processRspError(Task task)
 	PyLock lock;
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspError(error, task.task_id, task.task_last);
@@ -5775,7 +5848,8 @@ void TdApi::processErrRtnOrderInsert(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onErrRtnOrderInsert(data, error);
@@ -5815,7 +5889,8 @@ void TdApi::processErrRtnOrderAction(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onErrRtnOrderAction(data, error);
@@ -5914,7 +5989,10 @@ void TdApi::processRtnErrorConditionalOrder(Task task)
 	data["InvestorID"] = task_data.InvestorID;
 	data["VolumeCondition"] = task_data.VolumeCondition;
 	data["RequestID"] = task_data.RequestID;
-	data["ErrorMsg"] = task_data.ErrorMsg;
+
+	std::string ErrorMsg1 = boost::locale::conv::to_utf<char>(task_data.ErrorMsg, std::string("GB2312"));
+	data["ErrorMsg"] = ErrorMsg1;
+
 	data["OrderSource"] = task_data.OrderSource;
 	data["ZCETotalTradedVolume"] = task_data.ZCETotalTradedVolume;
 	data["ActiveTraderID"] = task_data.ActiveTraderID;
@@ -5993,7 +6071,8 @@ void TdApi::processErrRtnExecOrderInsert(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onErrRtnExecOrderInsert(data, error);
@@ -6032,7 +6111,8 @@ void TdApi::processErrRtnExecOrderAction(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onErrRtnExecOrderAction(data, error);
@@ -6052,7 +6132,8 @@ void TdApi::processErrRtnForQuoteInsert(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onErrRtnForQuoteInsert(data, error);
@@ -6139,7 +6220,8 @@ void TdApi::processErrRtnQuoteInsert(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onErrRtnQuoteInsert(data, error);
@@ -6177,7 +6259,8 @@ void TdApi::processErrRtnQuoteAction(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onErrRtnQuoteAction(data, error);
@@ -6273,7 +6356,8 @@ void TdApi::processErrRtnLockInsert(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onErrRtnLockInsert(data, error);
@@ -6331,7 +6415,8 @@ void TdApi::processErrRtnCombActionInsert(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onErrRtnCombActionInsert(data, error);
@@ -6349,7 +6434,8 @@ void TdApi::processRspQryContractBank(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryContractBank(data, error, task.task_id, task.task_last);
@@ -6384,7 +6470,10 @@ void TdApi::processRspQryParkedOrder(Task task)
 	data["CombHedgeFlag"] = task_data.CombHedgeFlag;
 	data["GTDDate"] = task_data.GTDDate;
 	data["BusinessUnit"] = task_data.BusinessUnit;
-	data["ErrorMsg"] = task_data.ErrorMsg;
+
+	std::string ErrorMsg1 = boost::locale::conv::to_utf<char>(task_data.ErrorMsg, std::string("GB2312"));
+	data["ErrorMsg"] = ErrorMsg1;
+
 	data["OrderRef"] = task_data.OrderRef;
 	data["InvestorID"] = task_data.InvestorID;
 	data["VolumeCondition"] = task_data.VolumeCondition;
@@ -6392,7 +6481,8 @@ void TdApi::processRspQryParkedOrder(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryParkedOrder(data, error, task.task_id, task.task_last);
@@ -6409,7 +6499,10 @@ void TdApi::processRspQryParkedOrderAction(Task task)
 	data["ActionFlag"] = task_data.ActionFlag;
 	data["OrderActionRef"] = task_data.OrderActionRef;
 	data["UserType"] = task_data.UserType;
-	data["ErrorMsg"] = task_data.ErrorMsg;
+
+	std::string ErrorMsg1 = boost::locale::conv::to_utf<char>(task_data.ErrorMsg, std::string("GB2312"));
+	data["ErrorMsg"] = ErrorMsg1;
+
 	data["UserID"] = task_data.UserID;
 	data["LimitPrice"] = task_data.LimitPrice;
 	data["OrderRef"] = task_data.OrderRef;
@@ -6425,7 +6518,8 @@ void TdApi::processRspQryParkedOrderAction(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryParkedOrderAction(data, error, task.task_id, task.task_last);
@@ -6447,7 +6541,8 @@ void TdApi::processRspQryTradingNotice(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryTradingNotice(data, error, task.task_id, task.task_last);
@@ -6468,7 +6563,8 @@ void TdApi::processRspQryBrokerTradingParams(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryBrokerTradingParams(data, error, task.task_id, task.task_last);
@@ -6488,7 +6584,8 @@ void TdApi::processRspQryBrokerTradingAlgos(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQryBrokerTradingAlgos(data, error, task.task_id, task.task_last);
@@ -6504,7 +6601,8 @@ void TdApi::processRspQueryCFMMCTradingAccountToken(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQueryCFMMCTradingAccountToken(data, error, task.task_id, task.task_last);
@@ -6552,7 +6650,10 @@ void TdApi::processRtnFromBankToFutureByBank(Task task)
 	data["BankAccType"] = task_data.BankAccType;
 	data["LastFragment"] = task_data.LastFragment;
 	data["FutureSerial"] = task_data.FutureSerial;
-	data["ErrorMsg"] = task_data.ErrorMsg;
+
+	std::string ErrorMsg1 = boost::locale::conv::to_utf<char>(task_data.ErrorMsg, std::string("GB2312"));
+	data["ErrorMsg"] = ErrorMsg1;
+
 	data["BankSecuAccType"] = task_data.BankSecuAccType;
 	data["BrokerIDByBank"] = task_data.BrokerIDByBank;
 	data["SecuPwdFlag"] = task_data.SecuPwdFlag;
@@ -6606,7 +6707,10 @@ void TdApi::processRtnFromFutureToBankByBank(Task task)
 	data["BankAccType"] = task_data.BankAccType;
 	data["LastFragment"] = task_data.LastFragment;
 	data["FutureSerial"] = task_data.FutureSerial;
-	data["ErrorMsg"] = task_data.ErrorMsg;
+
+	std::string ErrorMsg1 = boost::locale::conv::to_utf<char>(task_data.ErrorMsg, std::string("GB2312"));
+	data["ErrorMsg"] = ErrorMsg1;
+
 	data["BankSecuAccType"] = task_data.BankSecuAccType;
 	data["BrokerIDByBank"] = task_data.BrokerIDByBank;
 	data["SecuPwdFlag"] = task_data.SecuPwdFlag;
@@ -6666,7 +6770,10 @@ void TdApi::processRtnRepealFromBankToFutureByBank(Task task)
 	data["LastFragment"] = task_data.LastFragment;
 	data["FutureSerial"] = task_data.FutureSerial;
 	data["BankRepealSerial"] = task_data.BankRepealSerial;
-	data["ErrorMsg"] = task_data.ErrorMsg;
+
+	std::string ErrorMsg1 = boost::locale::conv::to_utf<char>(task_data.ErrorMsg, std::string("GB2312"));
+	data["ErrorMsg"] = ErrorMsg1;
+
 	data["RepealTimeInterval"] = task_data.RepealTimeInterval;
 	data["BankSecuAccType"] = task_data.BankSecuAccType;
 	data["BrokerIDByBank"] = task_data.BrokerIDByBank;
@@ -6727,7 +6834,10 @@ void TdApi::processRtnRepealFromFutureToBankByBank(Task task)
 	data["LastFragment"] = task_data.LastFragment;
 	data["FutureSerial"] = task_data.FutureSerial;
 	data["BankRepealSerial"] = task_data.BankRepealSerial;
-	data["ErrorMsg"] = task_data.ErrorMsg;
+
+	std::string ErrorMsg1 = boost::locale::conv::to_utf<char>(task_data.ErrorMsg, std::string("GB2312"));
+	data["ErrorMsg"] = ErrorMsg1;
+
 	data["RepealTimeInterval"] = task_data.RepealTimeInterval;
 	data["BankSecuAccType"] = task_data.BankSecuAccType;
 	data["BrokerIDByBank"] = task_data.BrokerIDByBank;
@@ -6782,7 +6892,10 @@ void TdApi::processRtnFromBankToFutureByFuture(Task task)
 	data["BankAccType"] = task_data.BankAccType;
 	data["LastFragment"] = task_data.LastFragment;
 	data["FutureSerial"] = task_data.FutureSerial;
-	data["ErrorMsg"] = task_data.ErrorMsg;
+
+	std::string ErrorMsg1 = boost::locale::conv::to_utf<char>(task_data.ErrorMsg, std::string("GB2312"));
+	data["ErrorMsg"] = ErrorMsg1;
+
 	data["BankSecuAccType"] = task_data.BankSecuAccType;
 	data["BrokerIDByBank"] = task_data.BrokerIDByBank;
 	data["SecuPwdFlag"] = task_data.SecuPwdFlag;
@@ -6836,7 +6949,10 @@ void TdApi::processRtnFromFutureToBankByFuture(Task task)
 	data["BankAccType"] = task_data.BankAccType;
 	data["LastFragment"] = task_data.LastFragment;
 	data["FutureSerial"] = task_data.FutureSerial;
-	data["ErrorMsg"] = task_data.ErrorMsg;
+
+	std::string ErrorMsg1 = boost::locale::conv::to_utf<char>(task_data.ErrorMsg, std::string("GB2312"));
+	data["ErrorMsg"] = ErrorMsg1;
+
 	data["BankSecuAccType"] = task_data.BankSecuAccType;
 	data["BrokerIDByBank"] = task_data.BrokerIDByBank;
 	data["SecuPwdFlag"] = task_data.SecuPwdFlag;
@@ -6896,7 +7012,10 @@ void TdApi::processRtnRepealFromBankToFutureByFutureManual(Task task)
 	data["LastFragment"] = task_data.LastFragment;
 	data["FutureSerial"] = task_data.FutureSerial;
 	data["BankRepealSerial"] = task_data.BankRepealSerial;
-	data["ErrorMsg"] = task_data.ErrorMsg;
+
+	std::string ErrorMsg1 = boost::locale::conv::to_utf<char>(task_data.ErrorMsg, std::string("GB2312"));
+	data["ErrorMsg"] = ErrorMsg1;
+
 	data["RepealTimeInterval"] = task_data.RepealTimeInterval;
 	data["BankSecuAccType"] = task_data.BankSecuAccType;
 	data["BrokerIDByBank"] = task_data.BrokerIDByBank;
@@ -6957,7 +7076,10 @@ void TdApi::processRtnRepealFromFutureToBankByFutureManual(Task task)
 	data["LastFragment"] = task_data.LastFragment;
 	data["FutureSerial"] = task_data.FutureSerial;
 	data["BankRepealSerial"] = task_data.BankRepealSerial;
-	data["ErrorMsg"] = task_data.ErrorMsg;
+
+	std::string ErrorMsg1 = boost::locale::conv::to_utf<char>(task_data.ErrorMsg, std::string("GB2312"));
+	data["ErrorMsg"] = ErrorMsg1;
+
 	data["RepealTimeInterval"] = task_data.RepealTimeInterval;
 	data["BankSecuAccType"] = task_data.BankSecuAccType;
 	data["BrokerIDByBank"] = task_data.BrokerIDByBank;
@@ -7006,7 +7128,10 @@ void TdApi::processRtnQueryBankBalanceByFuture(Task task)
 	data["PlateSerial"] = task_data.PlateSerial;
 	data["TradeDate"] = task_data.TradeDate;
 	data["CurrencyID"] = task_data.CurrencyID;
-	data["ErrorMsg"] = task_data.ErrorMsg;
+
+	std::string ErrorMsg1 = boost::locale::conv::to_utf<char>(task_data.ErrorMsg, std::string("GB2312"));
+	data["ErrorMsg"] = ErrorMsg1;
+
 	data["BankAccType"] = task_data.BankAccType;
 	data["LastFragment"] = task_data.LastFragment;
 	data["FutureSerial"] = task_data.FutureSerial;
@@ -7070,7 +7195,8 @@ void TdApi::processErrRtnBankToFutureByFuture(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onErrRtnBankToFutureByFuture(data, error);
@@ -7127,7 +7253,8 @@ void TdApi::processErrRtnFutureToBankByFuture(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onErrRtnFutureToBankByFuture(data, error);
@@ -7191,7 +7318,8 @@ void TdApi::processErrRtnRepealBankToFutureByFutureManual(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onErrRtnRepealBankToFutureByFutureManual(data, error);
@@ -7255,7 +7383,8 @@ void TdApi::processErrRtnRepealFutureToBankByFutureManual(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onErrRtnRepealFutureToBankByFutureManual(data, error);
@@ -7305,7 +7434,8 @@ void TdApi::processErrRtnQueryBankBalanceByFuture(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onErrRtnQueryBankBalanceByFuture(data, error);
@@ -7359,7 +7489,10 @@ void TdApi::processRtnRepealFromBankToFutureByFuture(Task task)
 	data["LastFragment"] = task_data.LastFragment;
 	data["FutureSerial"] = task_data.FutureSerial;
 	data["BankRepealSerial"] = task_data.BankRepealSerial;
-	data["ErrorMsg"] = task_data.ErrorMsg;
+
+	std::string ErrorMsg1 = boost::locale::conv::to_utf<char>(task_data.ErrorMsg, std::string("GB2312"));
+	data["ErrorMsg"] = ErrorMsg1;
+
 	data["RepealTimeInterval"] = task_data.RepealTimeInterval;
 	data["BankSecuAccType"] = task_data.BankSecuAccType;
 	data["BrokerIDByBank"] = task_data.BrokerIDByBank;
@@ -7420,7 +7553,10 @@ void TdApi::processRtnRepealFromFutureToBankByFuture(Task task)
 	data["LastFragment"] = task_data.LastFragment;
 	data["FutureSerial"] = task_data.FutureSerial;
 	data["BankRepealSerial"] = task_data.BankRepealSerial;
-	data["ErrorMsg"] = task_data.ErrorMsg;
+
+	std::string ErrorMsg1 = boost::locale::conv::to_utf<char>(task_data.ErrorMsg, std::string("GB2312"));
+	data["ErrorMsg"] = ErrorMsg1;
+
 	data["RepealTimeInterval"] = task_data.RepealTimeInterval;
 	data["BankSecuAccType"] = task_data.BankSecuAccType;
 	data["BrokerIDByBank"] = task_data.BrokerIDByBank;
@@ -7484,7 +7620,8 @@ void TdApi::processRspFromBankToFutureByFuture(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspFromBankToFutureByFuture(data, error, task.task_id, task.task_last);
@@ -7541,7 +7678,8 @@ void TdApi::processRspFromFutureToBankByFuture(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspFromFutureToBankByFuture(data, error, task.task_id, task.task_last);
@@ -7591,7 +7729,8 @@ void TdApi::processRspQueryBankAccountMoneyByFuture(Task task)
 
 	CThostFtdcRspInfoField task_error = any_cast<CThostFtdcRspInfoField>(task.task_error);
 	dict error;
-	error["ErrorMsg"] = task_error.ErrorMsg;
+	std::string ErrorMsg = boost::locale::conv::to_utf<char>(task_error.ErrorMsg, std::string("GB2312"));
+	error["ErrorMsg"] = ErrorMsg;
 	error["ErrorID"] = task_error.ErrorID;
 
 	this->onRspQueryBankAccountMoneyByFuture(data, error, task.task_id, task.task_last);
@@ -7638,7 +7777,10 @@ void TdApi::processRtnOpenAccountByBank(Task task)
 	data["MobilePhone"] = task_data.MobilePhone;
 	data["TradeDate"] = task_data.TradeDate;
 	data["CurrencyID"] = task_data.CurrencyID;
-	data["ErrorMsg"] = task_data.ErrorMsg;
+
+	std::string ErrorMsg1 = boost::locale::conv::to_utf<char>(task_data.ErrorMsg, std::string("GB2312"));
+	data["ErrorMsg"] = ErrorMsg1;
+
 	data["BankAccType"] = task_data.BankAccType;
 	data["LastFragment"] = task_data.LastFragment;
 	data["ZipCode"] = task_data.ZipCode;
@@ -7693,7 +7835,10 @@ void TdApi::processRtnCancelAccountByBank(Task task)
 	data["MobilePhone"] = task_data.MobilePhone;
 	data["TradeDate"] = task_data.TradeDate;
 	data["CurrencyID"] = task_data.CurrencyID;
-	data["ErrorMsg"] = task_data.ErrorMsg;
+
+	std::string ErrorMsg1 = boost::locale::conv::to_utf<char>(task_data.ErrorMsg, std::string("GB2312"));
+	data["ErrorMsg"] = ErrorMsg1;
+
 	data["BankAccType"] = task_data.BankAccType;
 	data["LastFragment"] = task_data.LastFragment;
 	data["ZipCode"] = task_data.ZipCode;
@@ -7746,7 +7891,10 @@ void TdApi::processRtnChangeAccountByBank(Task task)
 	data["MobilePhone"] = task_data.MobilePhone;
 	data["TradeDate"] = task_data.TradeDate;
 	data["CurrencyID"] = task_data.CurrencyID;
-	data["ErrorMsg"] = task_data.ErrorMsg;
+
+	std::string ErrorMsg1 = boost::locale::conv::to_utf<char>(task_data.ErrorMsg, std::string("GB2312"));
+	data["ErrorMsg"] = ErrorMsg1;
+
 	data["BankAccType"] = task_data.BankAccType;
 	data["LastFragment"] = task_data.LastFragment;
 	data["ZipCode"] = task_data.ZipCode;
@@ -7761,7 +7909,7 @@ void TdApi::processRtnChangeAccountByBank(Task task)
 
 
 ///-------------------------------------------------------------------------------------
-///÷˜∂Ø∫Ø ˝
+///‰∏ªÂä®ÂáΩÊï∞
 ///-------------------------------------------------------------------------------------
 
 void TdApi::createFtdcTraderApi(string pszFlowPath)
@@ -7788,7 +7936,7 @@ int TdApi::join()
 
 int TdApi::exit()
 {
-	//∏√∫Ø ˝‘⁄‘≠…˙API¿Ô√ª”–£¨”√”⁄∞≤»´ÕÀ≥ˆAPI”√£¨‘≠…˙µƒjoinÀ∆∫ı≤ªÃ´Œ»∂®
+	//ËØ•ÂáΩÊï∞Âú®ÂéüÁîüAPIÈáåÊ≤°ÊúâÔºåÁî®‰∫éÂÆâÂÖ®ÈÄÄÂá∫APIÁî®ÔºåÂéüÁîüÁöÑjoin‰ºº‰πé‰∏çÂ§™Á®≥ÂÆö
 	this->api->RegisterSpi(NULL);
 	this->api->Release();
 	this->api = NULL;
@@ -7808,7 +7956,7 @@ void TdApi::registerFront(string pszFrontAddress)
 
 void TdApi::subscribePrivateTopic(int nType)
 {
-	//∏√∫Ø ˝Œ™ ÷∂Ø±‡–¥
+	//ËØ•ÂáΩÊï∞‰∏∫ÊâãÂä®ÁºñÂÜô
 	THOST_TE_RESUME_TYPE type;
 
 	switch (nType)
@@ -7837,7 +7985,7 @@ void TdApi::subscribePrivateTopic(int nType)
 
 void TdApi::subscribePublicTopic(int nType)
 {
-	//∏√∫Ø ˝Œ™ ÷∂Ø±‡–¥
+	//ËØ•ÂáΩÊï∞‰∏∫ÊâãÂä®ÁºñÂÜô
 	THOST_TE_RESUME_TYPE type;
 
 	switch (nType)
@@ -8934,17 +9082,17 @@ int TdApi::reqQueryBankAccountMoneyByFuture(dict req, int nRequestID)
 
 
 ///-------------------------------------------------------------------------------------
-///Boost.Python∑‚◊∞
+///Boost.PythonÂ∞ÅË£Ö
 ///-------------------------------------------------------------------------------------
 
 struct TdApiWrap : TdApi, wrapper < TdApi >
 {
 	virtual void onFrontConnected()
 	{
-		//‘⁄œÚpythonª∑æ≥÷–µ˜”√ªÿµ˜∫Ø ˝Õ∆ÀÕ ˝æ›«∞£¨–Ë“™œ»ªÒ»°»´æ÷À¯GIL£¨∑¿÷πΩ‚ Õ∆˜±¿¿£
+		//Âú®ÂêëpythonÁéØÂ¢É‰∏≠Ë∞ÉÁî®ÂõûË∞ÉÂáΩÊï∞Êé®ÈÄÅÊï∞ÊçÆÂâçÔºåÈúÄË¶ÅÂÖàËé∑ÂèñÂÖ®Â±ÄÈîÅGILÔºåÈò≤Ê≠¢Ëß£ÈáäÂô®Â¥©Ê∫É
 		PyLock lock;
 
-		//“‘œ¬µƒtry...catch...ø…“‘ µœ÷≤∂◊Ωpythonª∑æ≥÷–¥ÌŒÛµƒπ¶ƒ‹£¨∑¿÷πC++÷±Ω”≥ˆœ÷‘≠“ÚŒ¥÷™µƒ±¿¿£
+		//‰ª•‰∏ãÁöÑtry...catch...ÂèØ‰ª•ÂÆûÁé∞ÊçïÊçâpythonÁéØÂ¢É‰∏≠ÈîôËØØÁöÑÂäüËÉΩÔºåÈò≤Ê≠¢C++Áõ¥Êé•Âá∫Áé∞ÂéüÂõ†Êú™Áü•ÁöÑÂ¥©Ê∫É
 		try
 		{
 			this->get_override("onFrontConnected")();
@@ -10307,7 +10455,7 @@ struct TdApiWrap : TdApi, wrapper < TdApi >
 
 BOOST_PYTHON_MODULE(vnctptd)
 {
-	PyEval_InitThreads();	//µº»Î ±‘À––£¨±£÷§œ»¥¥Ω®GIL
+	PyEval_InitThreads();	//ÂØºÂÖ•Êó∂ËøêË°åÔºå‰øùËØÅÂÖàÂàõÂª∫GIL
 
 	class_<TdApiWrap, boost::noncopyable>("TdApi")
 		.def("createFtdcTraderApi", &TdApiWrap::createFtdcTraderApi)

--- a/vn.ctp/vnctptd/vnctptd/vnctptd.h
+++ b/vn.ctp/vnctptd/vnctptd/vnctptd.h
@@ -1,12 +1,12 @@
-//ËµÃ÷²¿·Ö
+//è¯´æ˜éƒ¨åˆ†
 /*
-ÓÉÓÚCTP APIÖĞºÍ×Ê½ğ×ªÕËÏà¹ØµÄº¯ÊıÌ«¶à£¬
-Í¬Ê±Ò²ÒÑ¾­ÓĞ´óÁ¿µÄ¿Í»§¶ËÖ§³ÖÕâĞ©¹¦ÄÜ£¬
-Òò´ËÔÚÕâ¸öPython·â×°ÖĞÔİÊ±Ñ¡ÔñÖ»Ö§³Ö½»Ò×¹¦ÄÜ
+ç”±äºCTP APIä¸­å’Œèµ„é‡‘è½¬è´¦ç›¸å…³çš„å‡½æ•°å¤ªå¤šï¼Œ
+åŒæ—¶ä¹Ÿå·²ç»æœ‰å¤§é‡çš„å®¢æˆ·ç«¯æ”¯æŒè¿™äº›åŠŸèƒ½ï¼Œ
+å› æ­¤åœ¨è¿™ä¸ªPythonå°è£…ä¸­æš‚æ—¶é€‰æ‹©åªæ”¯æŒäº¤æ˜“åŠŸèƒ½
 */
 
 
-//ÏµÍ³
+//ç³»ç»Ÿ
 #ifdef WIN32
 #include "stdafx.h"
 #endif
@@ -15,24 +15,25 @@
 
 //Boost
 #define BOOST_PYTHON_STATIC_LIB
-#include <boost/python/module.hpp>	//python·â×°
-#include <boost/python/def.hpp>		//python·â×°
-#include <boost/python/dict.hpp>	//python·â×°
-#include <boost/python/object.hpp>	//python·â×°
-#include <boost/python.hpp>			//python·â×°
-#include <boost/thread.hpp>			//ÈÎÎñ¶ÓÁĞµÄÏß³Ì¹¦ÄÜ
-#include <boost/bind.hpp>			//ÈÎÎñ¶ÓÁĞµÄÏß³Ì¹¦ÄÜ
-#include <boost/any.hpp>			//ÈÎÎñ¶ÓÁĞµÄÈÎÎñÊµÏÖ
+#include <boost/python/module.hpp>	//pythonå°è£…
+#include <boost/python/def.hpp>		//pythonå°è£…
+#include <boost/python/dict.hpp>	//pythonå°è£…
+#include <boost/python/object.hpp>	//pythonå°è£…
+#include <boost/python.hpp>			//pythonå°è£…
+#include <boost/thread.hpp>			//ä»»åŠ¡é˜Ÿåˆ—çš„çº¿ç¨‹åŠŸèƒ½
+#include <boost/bind.hpp>			//ä»»åŠ¡é˜Ÿåˆ—çš„çº¿ç¨‹åŠŸèƒ½
+#include <boost/any.hpp>			//ä»»åŠ¡é˜Ÿåˆ—çš„ä»»åŠ¡å®ç°
+#include <boost/locale.hpp>            //å­—ç¬¦é›†è½¬æ¢
 
 //API
 #include "ThostFtdcTraderApi.h"
 
-//ÃüÃû¿Õ¼ä
+//å‘½åç©ºé—´
 using namespace std;
 using namespace boost::python;
 using namespace boost;
 
-//³£Á¿
+//å¸¸é‡
 #define ONFRONTCONNECTED 1
 #define ONFRONTDISCONNECTED 2
 #define ONHEARTBEATWARNING 3
@@ -150,24 +151,24 @@ using namespace boost;
 
 
 ///-------------------------------------------------------------------------------------
-///APIÖĞµÄ²¿·Ö×é¼ş
+///APIä¸­çš„éƒ¨åˆ†ç»„ä»¶
 ///-------------------------------------------------------------------------------------
 
-//GILÈ«¾ÖËø¼ò»¯»ñÈ¡ÓÃ£¬
-//ÓÃÓÚ°ïÖúC++Ïß³Ì»ñµÃGILËø£¬´Ó¶ø·ÀÖ¹python±ÀÀ£
+//GILå…¨å±€é”ç®€åŒ–è·å–ç”¨ï¼Œ
+//ç”¨äºå¸®åŠ©C++çº¿ç¨‹è·å¾—GILé”ï¼Œä»è€Œé˜²æ­¢pythonå´©æºƒ
 class PyLock
 {
 private:
 	PyGILState_STATE gil_state;
 
 public:
-	//ÔÚÄ³¸öº¯Êı·½·¨ÖĞ´´½¨¸Ã¶ÔÏóÊ±£¬»ñµÃGILËø
+	//åœ¨æŸä¸ªå‡½æ•°æ–¹æ³•ä¸­åˆ›å»ºè¯¥å¯¹è±¡æ—¶ï¼Œè·å¾—GILé”
 	PyLock()
 	{
 		gil_state = PyGILState_Ensure();
 	}
 
-	//ÔÚÄ³¸öº¯ÊıÍê³ÉºóÏú»Ù¸Ã¶ÔÏóÊ±£¬½â·ÅGILËø
+	//åœ¨æŸä¸ªå‡½æ•°å®Œæˆåé”€æ¯è¯¥å¯¹è±¡æ—¶ï¼Œè§£æ”¾GILé”
 	~PyLock()
 	{
 		PyGILState_Release(gil_state);
@@ -175,90 +176,90 @@ public:
 };
 
 
-//ÈÎÎñ½á¹¹Ìå
+//ä»»åŠ¡ç»“æ„ä½“
 struct Task
 {
-	int task_name;		//»Øµ÷º¯ÊıÃû³Æ¶ÔÓ¦µÄ³£Á¿
-	any task_data;		//Êı¾İ½á¹¹Ìå
-	any task_error;		//´íÎó½á¹¹Ìå
-	int task_id;		//ÇëÇóid
-	bool task_last;		//ÊÇ·ñÎª×îºó·µ»Ø
+	int task_name;		//å›è°ƒå‡½æ•°åç§°å¯¹åº”çš„å¸¸é‡
+	any task_data;		//æ•°æ®ç»“æ„ä½“
+	any task_error;		//é”™è¯¯ç»“æ„ä½“
+	int task_id;		//è¯·æ±‚id
+	bool task_last;		//æ˜¯å¦ä¸ºæœ€åè¿”å›
 };
 
 
-///Ïß³Ì°²È«µÄ¶ÓÁĞ
+///çº¿ç¨‹å®‰å…¨çš„é˜Ÿåˆ—
 template<typename Data>
 
 class ConcurrentQueue
 {
 private:
-	queue<Data> the_queue;								//±ê×¼¿â¶ÓÁĞ
-	mutable mutex the_mutex;							//boost»¥³âËø
-	condition_variable the_condition_variable;			//boostÌõ¼ş±äÁ¿
+	queue<Data> the_queue;								//æ ‡å‡†åº“é˜Ÿåˆ—
+	mutable mutex the_mutex;							//boostäº’æ–¥é”
+	condition_variable the_condition_variable;			//boostæ¡ä»¶å˜é‡
 
 public:
 
-	//´æÈëĞÂµÄÈÎÎñ
+	//å­˜å…¥æ–°çš„ä»»åŠ¡
 	void push(Data const& data)
 	{
-		mutex::scoped_lock lock(the_mutex);				//»ñÈ¡»¥³âËø
-		the_queue.push(data);							//Ïò¶ÓÁĞÖĞ´æÈëÊı¾İ
-		lock.unlock();									//ÊÍ·ÅËø
-		the_condition_variable.notify_one();			//Í¨ÖªÕıÔÚ×èÈûµÈ´ıµÄÏß³Ì
+		mutex::scoped_lock lock(the_mutex);				//è·å–äº’æ–¥é”
+		the_queue.push(data);							//å‘é˜Ÿåˆ—ä¸­å­˜å…¥æ•°æ®
+		lock.unlock();									//é‡Šæ”¾é”
+		the_condition_variable.notify_one();			//é€šçŸ¥æ­£åœ¨é˜»å¡ç­‰å¾…çš„çº¿ç¨‹
 	}
 
-	//¼ì²é¶ÓÁĞÊÇ·ñÎª¿Õ
+	//æ£€æŸ¥é˜Ÿåˆ—æ˜¯å¦ä¸ºç©º
 	bool empty() const
 	{
 		mutex::scoped_lock lock(the_mutex);
 		return the_queue.empty();
 	}
 
-	//È¡³ö
+	//å–å‡º
 	Data wait_and_pop()
 	{
 		mutex::scoped_lock lock(the_mutex);
 
-		while (the_queue.empty())						//µ±¶ÓÁĞÎª¿ÕÊ±
+		while (the_queue.empty())						//å½“é˜Ÿåˆ—ä¸ºç©ºæ—¶
 		{
-			the_condition_variable.wait(lock);			//µÈ´ıÌõ¼ş±äÁ¿Í¨Öª
+			the_condition_variable.wait(lock);			//ç­‰å¾…æ¡ä»¶å˜é‡é€šçŸ¥
 		}
 
-		Data popped_value = the_queue.front();			//»ñÈ¡¶ÓÁĞÖĞµÄ×îºóÒ»¸öÈÎÎñ
-		the_queue.pop();								//É¾³ı¸ÃÈÎÎñ
-		return popped_value;							//·µ»Ø¸ÃÈÎÎñ
+		Data popped_value = the_queue.front();			//è·å–é˜Ÿåˆ—ä¸­çš„æœ€åä¸€ä¸ªä»»åŠ¡
+		the_queue.pop();								//åˆ é™¤è¯¥ä»»åŠ¡
+		return popped_value;							//è¿”å›è¯¥ä»»åŠ¡
 	}
 
 };
 
 
-//´Ó×ÖµäÖĞ»ñÈ¡Ä³¸ö½¨Öµ¶ÔÓ¦µÄÕûÊı£¬²¢¸³Öµµ½ÇëÇó½á¹¹Ìå¶ÔÏóµÄÖµÉÏ
+//ä»å­—å…¸ä¸­è·å–æŸä¸ªå»ºå€¼å¯¹åº”çš„æ•´æ•°ï¼Œå¹¶èµ‹å€¼åˆ°è¯·æ±‚ç»“æ„ä½“å¯¹è±¡çš„å€¼ä¸Š
 void getInt(dict d, string key, int* value);
 
 
-//´Ó×ÖµäÖĞ»ñÈ¡Ä³¸ö½¨Öµ¶ÔÓ¦µÄ¸¡µãÊı£¬²¢¸³Öµµ½ÇëÇó½á¹¹Ìå¶ÔÏóµÄÖµÉÏ
+//ä»å­—å…¸ä¸­è·å–æŸä¸ªå»ºå€¼å¯¹åº”çš„æµ®ç‚¹æ•°ï¼Œå¹¶èµ‹å€¼åˆ°è¯·æ±‚ç»“æ„ä½“å¯¹è±¡çš„å€¼ä¸Š
 void getDouble(dict d, string key, double* value);
 
 
-//´Ó×ÖµäÖĞ»ñÈ¡Ä³¸ö½¨Öµ¶ÔÓ¦µÄ×Ö·û£¬²¢¸³Öµµ½ÇëÇó½á¹¹Ìå¶ÔÏóµÄÖµÉÏ
+//ä»å­—å…¸ä¸­è·å–æŸä¸ªå»ºå€¼å¯¹åº”çš„å­—ç¬¦ï¼Œå¹¶èµ‹å€¼åˆ°è¯·æ±‚ç»“æ„ä½“å¯¹è±¡çš„å€¼ä¸Š
 void getChar(dict d, string key, char* value);
 
 
-//´Ó×ÖµäÖĞ»ñÈ¡Ä³¸ö½¨Öµ¶ÔÓ¦µÄ×Ö·û´®£¬²¢¸³Öµµ½ÇëÇó½á¹¹Ìå¶ÔÏóµÄÖµÉÏ
+//ä»å­—å…¸ä¸­è·å–æŸä¸ªå»ºå€¼å¯¹åº”çš„å­—ç¬¦ä¸²ï¼Œå¹¶èµ‹å€¼åˆ°è¯·æ±‚ç»“æ„ä½“å¯¹è±¡çš„å€¼ä¸Š
 void getStr(dict d, string key, char* value);
 
 
 ///-------------------------------------------------------------------------------------
-///C++ SPIµÄ»Øµ÷º¯Êı·½·¨ÊµÏÖ
+///C++ SPIçš„å›è°ƒå‡½æ•°æ–¹æ³•å®ç°
 ///-------------------------------------------------------------------------------------
 
-//APIµÄ¼Ì³ĞÊµÏÖ
+//APIçš„ç»§æ‰¿å®ç°
 class TdApi : public CThostFtdcTraderSpi
 {
 private:
-	CThostFtdcTraderApi* api;			//API¶ÔÏó
-	thread *task_thread;				//¹¤×÷Ïß³ÌÖ¸Õë£¨ÏòpythonÖĞÍÆËÍÊı¾İ£©
-	ConcurrentQueue<Task> task_queue;	//ÈÎÎñ¶ÓÁĞ
+	CThostFtdcTraderApi* api;			//APIå¯¹è±¡
+	thread *task_thread;				//å·¥ä½œçº¿ç¨‹æŒ‡é’ˆï¼ˆå‘pythonä¸­æ¨é€æ•°æ®ï¼‰
+	ConcurrentQueue<Task> task_queue;	//ä»»åŠ¡é˜Ÿåˆ—
 
 public:
 	TdApi()
@@ -273,358 +274,358 @@ public:
 	};
 
 	//-------------------------------------------------------------------------------------
-	//API»Øµ÷º¯Êı
+	//APIå›è°ƒå‡½æ•°
 	//-------------------------------------------------------------------------------------
 
-	///µ±¿Í»§¶ËÓë½»Ò×ºóÌ¨½¨Á¢ÆğÍ¨ĞÅÁ¬½ÓÊ±£¨»¹Î´µÇÂ¼Ç°£©£¬¸Ã·½·¨±»µ÷ÓÃ¡£
+	///å½“å®¢æˆ·ç«¯ä¸äº¤æ˜“åå°å»ºç«‹èµ·é€šä¿¡è¿æ¥æ—¶ï¼ˆè¿˜æœªç™»å½•å‰ï¼‰ï¼Œè¯¥æ–¹æ³•è¢«è°ƒç”¨ã€‚
 	virtual void OnFrontConnected();
 
-	///µ±¿Í»§¶ËÓë½»Ò×ºóÌ¨Í¨ĞÅÁ¬½Ó¶Ï¿ªÊ±£¬¸Ã·½·¨±»µ÷ÓÃ¡£µ±·¢ÉúÕâ¸öÇé¿öºó£¬API»á×Ô¶¯ÖØĞÂÁ¬½Ó£¬¿Í»§¶Ë¿É²»×ö´¦Àí¡£
-	///@param nReason ´íÎóÔ­Òò
-	///        0x1001 ÍøÂç¶ÁÊ§°Ü
-	///        0x1002 ÍøÂçĞ´Ê§°Ü
-	///        0x2001 ½ÓÊÕĞÄÌø³¬Ê±
-	///        0x2002 ·¢ËÍĞÄÌøÊ§°Ü
-	///        0x2003 ÊÕµ½´íÎó±¨ÎÄ
+	///å½“å®¢æˆ·ç«¯ä¸äº¤æ˜“åå°é€šä¿¡è¿æ¥æ–­å¼€æ—¶ï¼Œè¯¥æ–¹æ³•è¢«è°ƒç”¨ã€‚å½“å‘ç”Ÿè¿™ä¸ªæƒ…å†µåï¼ŒAPIä¼šè‡ªåŠ¨é‡æ–°è¿æ¥ï¼Œå®¢æˆ·ç«¯å¯ä¸åšå¤„ç†ã€‚
+	///@param nReason é”™è¯¯åŸå› 
+	///        0x1001 ç½‘ç»œè¯»å¤±è´¥
+	///        0x1002 ç½‘ç»œå†™å¤±è´¥
+	///        0x2001 æ¥æ”¶å¿ƒè·³è¶…æ—¶
+	///        0x2002 å‘é€å¿ƒè·³å¤±è´¥
+	///        0x2003 æ”¶åˆ°é”™è¯¯æŠ¥æ–‡
 	virtual void OnFrontDisconnected(int nReason);
 
-	///ĞÄÌø³¬Ê±¾¯¸æ¡£µ±³¤Ê±¼äÎ´ÊÕµ½±¨ÎÄÊ±£¬¸Ã·½·¨±»µ÷ÓÃ¡£
-	///@param nTimeLapse ¾àÀëÉÏ´Î½ÓÊÕ±¨ÎÄµÄÊ±¼ä
+	///å¿ƒè·³è¶…æ—¶è­¦å‘Šã€‚å½“é•¿æ—¶é—´æœªæ”¶åˆ°æŠ¥æ–‡æ—¶ï¼Œè¯¥æ–¹æ³•è¢«è°ƒç”¨ã€‚
+	///@param nTimeLapse è·ç¦»ä¸Šæ¬¡æ¥æ”¶æŠ¥æ–‡çš„æ—¶é—´
 	virtual void OnHeartBeatWarning(int nTimeLapse);
 
-	///¿Í»§¶ËÈÏÖ¤ÏìÓ¦
+	///å®¢æˆ·ç«¯è®¤è¯å“åº”
 	virtual void OnRspAuthenticate(CThostFtdcRspAuthenticateField *pRspAuthenticateField, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
 
-	///µÇÂ¼ÇëÇóÏìÓ¦
+	///ç™»å½•è¯·æ±‚å“åº”
 	virtual void OnRspUserLogin(CThostFtdcRspUserLoginField *pRspUserLogin, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///µÇ³öÇëÇóÏìÓ¦
+	///ç™»å‡ºè¯·æ±‚å“åº”
 	virtual void OnRspUserLogout(CThostFtdcUserLogoutField *pUserLogout, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÓÃ»§¿ÚÁî¸üĞÂÇëÇóÏìÓ¦
+	///ç”¨æˆ·å£ä»¤æ›´æ–°è¯·æ±‚å“åº”
 	virtual void OnRspUserPasswordUpdate(CThostFtdcUserPasswordUpdateField *pUserPasswordUpdate, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///×Ê½ğÕË»§¿ÚÁî¸üĞÂÇëÇóÏìÓ¦
+	///èµ„é‡‘è´¦æˆ·å£ä»¤æ›´æ–°è¯·æ±‚å“åº”
 	virtual void OnRspTradingAccountPasswordUpdate(CThostFtdcTradingAccountPasswordUpdateField *pTradingAccountPasswordUpdate, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///±¨µ¥Â¼ÈëÇëÇóÏìÓ¦
+	///æŠ¥å•å½•å…¥è¯·æ±‚å“åº”
 	virtual void OnRspOrderInsert(CThostFtdcInputOrderField *pInputOrder, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///Ô¤Âñµ¥Â¼ÈëÇëÇóÏìÓ¦
+	///é¢„åŸ‹å•å½•å…¥è¯·æ±‚å“åº”
 	virtual void OnRspParkedOrderInsert(CThostFtdcParkedOrderField *pParkedOrder, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///Ô¤Âñ³·µ¥Â¼ÈëÇëÇóÏìÓ¦
+	///é¢„åŸ‹æ’¤å•å½•å…¥è¯·æ±‚å“åº”
 	virtual void OnRspParkedOrderAction(CThostFtdcParkedOrderActionField *pParkedOrderAction, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///±¨µ¥²Ù×÷ÇëÇóÏìÓ¦
+	///æŠ¥å•æ“ä½œè¯·æ±‚å“åº”
 	virtual void OnRspOrderAction(CThostFtdcInputOrderActionField *pInputOrderAction, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///²éÑ¯×î´ó±¨µ¥ÊıÁ¿ÏìÓ¦
+	///æŸ¥è¯¢æœ€å¤§æŠ¥å•æ•°é‡å“åº”
 	virtual void OnRspQueryMaxOrderVolume(CThostFtdcQueryMaxOrderVolumeField *pQueryMaxOrderVolume, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///Í¶×ÊÕß½áËã½á¹ûÈ·ÈÏÏìÓ¦
+	///æŠ•èµ„è€…ç»“ç®—ç»“æœç¡®è®¤å“åº”
 	virtual void OnRspSettlementInfoConfirm(CThostFtdcSettlementInfoConfirmField *pSettlementInfoConfirm, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///É¾³ıÔ¤Âñµ¥ÏìÓ¦
+	///åˆ é™¤é¢„åŸ‹å•å“åº”
 	virtual void OnRspRemoveParkedOrder(CThostFtdcRemoveParkedOrderField *pRemoveParkedOrder, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///É¾³ıÔ¤Âñ³·µ¥ÏìÓ¦
+	///åˆ é™¤é¢„åŸ‹æ’¤å•å“åº”
 	virtual void OnRspRemoveParkedOrderAction(CThostFtdcRemoveParkedOrderActionField *pRemoveParkedOrderAction, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///Ö´ĞĞĞû¸æÂ¼ÈëÇëÇóÏìÓ¦
+	///æ‰§è¡Œå®£å‘Šå½•å…¥è¯·æ±‚å“åº”
 	virtual void OnRspExecOrderInsert(CThostFtdcInputExecOrderField *pInputExecOrder, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///Ö´ĞĞĞû¸æ²Ù×÷ÇëÇóÏìÓ¦
+	///æ‰§è¡Œå®£å‘Šæ“ä½œè¯·æ±‚å“åº”
 	virtual void OnRspExecOrderAction(CThostFtdcInputExecOrderActionField *pInputExecOrderAction, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///Ñ¯¼ÛÂ¼ÈëÇëÇóÏìÓ¦
+	///è¯¢ä»·å½•å…¥è¯·æ±‚å“åº”
 	virtual void OnRspForQuoteInsert(CThostFtdcInputForQuoteField *pInputForQuote, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///±¨¼ÛÂ¼ÈëÇëÇóÏìÓ¦
+	///æŠ¥ä»·å½•å…¥è¯·æ±‚å“åº”
 	virtual void OnRspQuoteInsert(CThostFtdcInputQuoteField *pInputQuote, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///±¨¼Û²Ù×÷ÇëÇóÏìÓ¦
+	///æŠ¥ä»·æ“ä½œè¯·æ±‚å“åº”
 	virtual void OnRspQuoteAction(CThostFtdcInputQuoteActionField *pInputQuoteAction, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///Ëø¶¨Ó¦´ğ
+	///é”å®šåº”ç­”
 	virtual void OnRspLockInsert(CThostFtdcInputLockField *pInputLock, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÉêÇë×éºÏÂ¼ÈëÇëÇóÏìÓ¦
+	///ç”³è¯·ç»„åˆå½•å…¥è¯·æ±‚å“åº”
 	virtual void OnRspCombActionInsert(CThostFtdcInputCombActionField *pInputCombAction, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯±¨µ¥ÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢æŠ¥å•å“åº”
 	virtual void OnRspQryOrder(CThostFtdcOrderField *pOrder, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯³É½»ÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢æˆäº¤å“åº”
 	virtual void OnRspQryTrade(CThostFtdcTradeField *pTrade, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯Í¶×ÊÕß³Ö²ÖÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢æŠ•èµ„è€…æŒä»“å“åº”
 	virtual void OnRspQryInvestorPosition(CThostFtdcInvestorPositionField *pInvestorPosition, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯×Ê½ğÕË»§ÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢èµ„é‡‘è´¦æˆ·å“åº”
 	virtual void OnRspQryTradingAccount(CThostFtdcTradingAccountField *pTradingAccount, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯Í¶×ÊÕßÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢æŠ•èµ„è€…å“åº”
 	virtual void OnRspQryInvestor(CThostFtdcInvestorField *pInvestor, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯½»Ò×±àÂëÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢äº¤æ˜“ç¼–ç å“åº”
 	virtual void OnRspQryTradingCode(CThostFtdcTradingCodeField *pTradingCode, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯ºÏÔ¼±£Ö¤½ğÂÊÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢åˆçº¦ä¿è¯é‡‘ç‡å“åº”
 	virtual void OnRspQryInstrumentMarginRate(CThostFtdcInstrumentMarginRateField *pInstrumentMarginRate, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯ºÏÔ¼ÊÖĞø·ÑÂÊÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢åˆçº¦æ‰‹ç»­è´¹ç‡å“åº”
 	virtual void OnRspQryInstrumentCommissionRate(CThostFtdcInstrumentCommissionRateField *pInstrumentCommissionRate, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯½»Ò×ËùÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢äº¤æ˜“æ‰€å“åº”
 	virtual void OnRspQryExchange(CThostFtdcExchangeField *pExchange, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯²úÆ·ÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢äº§å“å“åº”
 	virtual void OnRspQryProduct(CThostFtdcProductField *pProduct, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯ºÏÔ¼ÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢åˆçº¦å“åº”
 	virtual void OnRspQryInstrument(CThostFtdcInstrumentField *pInstrument, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯ĞĞÇéÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢è¡Œæƒ…å“åº”
 	virtual void OnRspQryDepthMarketData(CThostFtdcDepthMarketDataField *pDepthMarketData, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯Í¶×ÊÕß½áËã½á¹ûÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢æŠ•èµ„è€…ç»“ç®—ç»“æœå“åº”
 	virtual void OnRspQrySettlementInfo(CThostFtdcSettlementInfoField *pSettlementInfo, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯×ªÕÊÒøĞĞÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢è½¬å¸é“¶è¡Œå“åº”
 	virtual void OnRspQryTransferBank(CThostFtdcTransferBankField *pTransferBank, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯Í¶×ÊÕß³Ö²ÖÃ÷Ï¸ÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢æŠ•èµ„è€…æŒä»“æ˜ç»†å“åº”
 	virtual void OnRspQryInvestorPositionDetail(CThostFtdcInvestorPositionDetailField *pInvestorPositionDetail, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯¿Í»§Í¨ÖªÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢å®¢æˆ·é€šçŸ¥å“åº”
 	virtual void OnRspQryNotice(CThostFtdcNoticeField *pNotice, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯½áËãĞÅÏ¢È·ÈÏÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢ç»“ç®—ä¿¡æ¯ç¡®è®¤å“åº”
 	virtual void OnRspQrySettlementInfoConfirm(CThostFtdcSettlementInfoConfirmField *pSettlementInfoConfirm, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯Í¶×ÊÕß³Ö²ÖÃ÷Ï¸ÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢æŠ•èµ„è€…æŒä»“æ˜ç»†å“åº”
 	virtual void OnRspQryInvestorPositionCombineDetail(CThostFtdcInvestorPositionCombineDetailField *pInvestorPositionCombineDetail, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///²éÑ¯±£Ö¤½ğ¼à¹ÜÏµÍ³¾­¼Í¹«Ë¾×Ê½ğÕË»§ÃÜÔ¿ÏìÓ¦
+	///æŸ¥è¯¢ä¿è¯é‡‘ç›‘ç®¡ç³»ç»Ÿç»çºªå…¬å¸èµ„é‡‘è´¦æˆ·å¯†é’¥å“åº”
 	virtual void OnRspQryCFMMCTradingAccountKey(CThostFtdcCFMMCTradingAccountKeyField *pCFMMCTradingAccountKey, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯²Öµ¥ÕÛµÖĞÅÏ¢ÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢ä»“å•æŠ˜æŠµä¿¡æ¯å“åº”
 	virtual void OnRspQryEWarrantOffset(CThostFtdcEWarrantOffsetField *pEWarrantOffset, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯Í¶×ÊÕßÆ·ÖÖ/¿çÆ·ÖÖ±£Ö¤½ğÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢æŠ•èµ„è€…å“ç§/è·¨å“ç§ä¿è¯é‡‘å“åº”
 	virtual void OnRspQryInvestorProductGroupMargin(CThostFtdcInvestorProductGroupMarginField *pInvestorProductGroupMargin, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯½»Ò×Ëù±£Ö¤½ğÂÊÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢äº¤æ˜“æ‰€ä¿è¯é‡‘ç‡å“åº”
 	virtual void OnRspQryExchangeMarginRate(CThostFtdcExchangeMarginRateField *pExchangeMarginRate, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯½»Ò×Ëùµ÷Õû±£Ö¤½ğÂÊÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢äº¤æ˜“æ‰€è°ƒæ•´ä¿è¯é‡‘ç‡å“åº”
 	virtual void OnRspQryExchangeMarginRateAdjust(CThostFtdcExchangeMarginRateAdjustField *pExchangeMarginRateAdjust, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯»ãÂÊÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢æ±‡ç‡å“åº”
 	virtual void OnRspQryExchangeRate(CThostFtdcExchangeRateField *pExchangeRate, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯¶ş¼¶´úÀí²Ù×÷Ô±ÒøÆÚÈ¨ÏŞÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢äºŒçº§ä»£ç†æ“ä½œå‘˜é“¶æœŸæƒé™å“åº”
 	virtual void OnRspQrySecAgentACIDMap(CThostFtdcSecAgentACIDMapField *pSecAgentACIDMap, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯²úÆ·±¨¼Û»ãÂÊ
+	///è¯·æ±‚æŸ¥è¯¢äº§å“æŠ¥ä»·æ±‡ç‡
 	virtual void OnRspQryProductExchRate(CThostFtdcProductExchRateField *pProductExchRate, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯²úÆ·×é
+	///è¯·æ±‚æŸ¥è¯¢äº§å“ç»„
 	virtual void OnRspQryProductGroup(CThostFtdcProductGroupField *pProductGroup, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯ÆÚÈ¨½»Ò×³É±¾ÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢æœŸæƒäº¤æ˜“æˆæœ¬å“åº”
 	virtual void OnRspQryOptionInstrTradeCost(CThostFtdcOptionInstrTradeCostField *pOptionInstrTradeCost, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯ÆÚÈ¨ºÏÔ¼ÊÖĞø·ÑÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢æœŸæƒåˆçº¦æ‰‹ç»­è´¹å“åº”
 	virtual void OnRspQryOptionInstrCommRate(CThostFtdcOptionInstrCommRateField *pOptionInstrCommRate, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯Ö´ĞĞĞû¸æÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢æ‰§è¡Œå®£å‘Šå“åº”
 	virtual void OnRspQryExecOrder(CThostFtdcExecOrderField *pExecOrder, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯Ñ¯¼ÛÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢è¯¢ä»·å“åº”
 	virtual void OnRspQryForQuote(CThostFtdcForQuoteField *pForQuote, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯±¨¼ÛÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢æŠ¥ä»·å“åº”
 	virtual void OnRspQryQuote(CThostFtdcQuoteField *pQuote, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯Ëø¶¨Ó¦´ğ
+	///è¯·æ±‚æŸ¥è¯¢é”å®šåº”ç­”
 	virtual void OnRspQryLock(CThostFtdcLockField *pLock, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯Ëø¶¨Ö¤È¯²ÖÎ»Ó¦´ğ
+	///è¯·æ±‚æŸ¥è¯¢é”å®šè¯åˆ¸ä»“ä½åº”ç­”
 	virtual void OnRspQryLockPosition(CThostFtdcLockPositionField *pLockPosition, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯Í¶×ÊÕß·Ö¼¶
+	///è¯·æ±‚æŸ¥è¯¢æŠ•èµ„è€…åˆ†çº§
 	virtual void OnRspQryInvestorLevel(CThostFtdcInvestorLevelField *pInvestorLevel, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯E+1ÈÕĞĞÈ¨¶³½áÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢E+1æ—¥è¡Œæƒå†»ç»“å“åº”
 	virtual void OnRspQryExecFreeze(CThostFtdcExecFreezeField *pExecFreeze, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯×éºÏºÏÔ¼°²È«ÏµÊıÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢ç»„åˆåˆçº¦å®‰å…¨ç³»æ•°å“åº”
 	virtual void OnRspQryCombInstrumentGuard(CThostFtdcCombInstrumentGuardField *pCombInstrumentGuard, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯ÉêÇë×éºÏÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢ç”³è¯·ç»„åˆå“åº”
 	virtual void OnRspQryCombAction(CThostFtdcCombActionField *pCombAction, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯×ªÕÊÁ÷Ë®ÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢è½¬å¸æµæ°´å“åº”
 	virtual void OnRspQryTransferSerial(CThostFtdcTransferSerialField *pTransferSerial, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯ÒøÆÚÇ©Ô¼¹ØÏµÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢é“¶æœŸç­¾çº¦å…³ç³»å“åº”
 	virtual void OnRspQryAccountregister(CThostFtdcAccountregisterField *pAccountregister, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///´íÎóÓ¦´ğ
+	///é”™è¯¯åº”ç­”
 	virtual void OnRspError(CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///±¨µ¥Í¨Öª
+	///æŠ¥å•é€šçŸ¥
 	virtual void OnRtnOrder(CThostFtdcOrderField *pOrder) ;
 
-	///³É½»Í¨Öª
+	///æˆäº¤é€šçŸ¥
 	virtual void OnRtnTrade(CThostFtdcTradeField *pTrade) ;
 
-	///±¨µ¥Â¼Èë´íÎó»Ø±¨
+	///æŠ¥å•å½•å…¥é”™è¯¯å›æŠ¥
 	virtual void OnErrRtnOrderInsert(CThostFtdcInputOrderField *pInputOrder, CThostFtdcRspInfoField *pRspInfo) ;
 
-	///±¨µ¥²Ù×÷´íÎó»Ø±¨
+	///æŠ¥å•æ“ä½œé”™è¯¯å›æŠ¥
 	virtual void OnErrRtnOrderAction(CThostFtdcOrderActionField *pOrderAction, CThostFtdcRspInfoField *pRspInfo) ;
 
-	///ºÏÔ¼½»Ò××´Ì¬Í¨Öª
+	///åˆçº¦äº¤æ˜“çŠ¶æ€é€šçŸ¥
 	virtual void OnRtnInstrumentStatus(CThostFtdcInstrumentStatusField *pInstrumentStatus) ;
 
-	///½»Ò×Í¨Öª
+	///äº¤æ˜“é€šçŸ¥
 	virtual void OnRtnTradingNotice(CThostFtdcTradingNoticeInfoField *pTradingNoticeInfo) ;
 
-	///ÌáÊ¾Ìõ¼şµ¥Ğ£Ñé´íÎó
+	///æç¤ºæ¡ä»¶å•æ ¡éªŒé”™è¯¯
 	virtual void OnRtnErrorConditionalOrder(CThostFtdcErrorConditionalOrderField *pErrorConditionalOrder) ;
 
-	///Ö´ĞĞĞû¸æÍ¨Öª
+	///æ‰§è¡Œå®£å‘Šé€šçŸ¥
 	virtual void OnRtnExecOrder(CThostFtdcExecOrderField *pExecOrder) ;
 
-	///Ö´ĞĞĞû¸æÂ¼Èë´íÎó»Ø±¨
+	///æ‰§è¡Œå®£å‘Šå½•å…¥é”™è¯¯å›æŠ¥
 	virtual void OnErrRtnExecOrderInsert(CThostFtdcInputExecOrderField *pInputExecOrder, CThostFtdcRspInfoField *pRspInfo) ;
 
-	///Ö´ĞĞĞû¸æ²Ù×÷´íÎó»Ø±¨
+	///æ‰§è¡Œå®£å‘Šæ“ä½œé”™è¯¯å›æŠ¥
 	virtual void OnErrRtnExecOrderAction(CThostFtdcExecOrderActionField *pExecOrderAction, CThostFtdcRspInfoField *pRspInfo) ;
 
-	///Ñ¯¼ÛÂ¼Èë´íÎó»Ø±¨
+	///è¯¢ä»·å½•å…¥é”™è¯¯å›æŠ¥
 	virtual void OnErrRtnForQuoteInsert(CThostFtdcInputForQuoteField *pInputForQuote, CThostFtdcRspInfoField *pRspInfo) ;
 
-	///±¨¼ÛÍ¨Öª
+	///æŠ¥ä»·é€šçŸ¥
 	virtual void OnRtnQuote(CThostFtdcQuoteField *pQuote) ;
 
-	///±¨¼ÛÂ¼Èë´íÎó»Ø±¨
+	///æŠ¥ä»·å½•å…¥é”™è¯¯å›æŠ¥
 	virtual void OnErrRtnQuoteInsert(CThostFtdcInputQuoteField *pInputQuote, CThostFtdcRspInfoField *pRspInfo) ;
 
-	///±¨¼Û²Ù×÷´íÎó»Ø±¨
+	///æŠ¥ä»·æ“ä½œé”™è¯¯å›æŠ¥
 	virtual void OnErrRtnQuoteAction(CThostFtdcQuoteActionField *pQuoteAction, CThostFtdcRspInfoField *pRspInfo) ;
 
-	///Ñ¯¼ÛÍ¨Öª
+	///è¯¢ä»·é€šçŸ¥
 	virtual void OnRtnForQuoteRsp(CThostFtdcForQuoteRspField *pForQuoteRsp) ;
 
-	///±£Ö¤½ğ¼à¿ØÖĞĞÄÓÃ»§ÁîÅÆ
+	///ä¿è¯é‡‘ç›‘æ§ä¸­å¿ƒç”¨æˆ·ä»¤ç‰Œ
 	virtual void OnRtnCFMMCTradingAccountToken(CThostFtdcCFMMCTradingAccountTokenField *pCFMMCTradingAccountToken) ;
 
-	///Ëø¶¨Í¨Öª
+	///é”å®šé€šçŸ¥
 	virtual void OnRtnLock(CThostFtdcLockField *pLock) ;
 
-	///Ëø¶¨´íÎóÍ¨Öª
+	///é”å®šé”™è¯¯é€šçŸ¥
 	virtual void OnErrRtnLockInsert(CThostFtdcInputLockField *pInputLock, CThostFtdcRspInfoField *pRspInfo) ;
 
-	///ÉêÇë×éºÏÍ¨Öª
+	///ç”³è¯·ç»„åˆé€šçŸ¥
 	virtual void OnRtnCombAction(CThostFtdcCombActionField *pCombAction) ;
 
-	///ÉêÇë×éºÏÂ¼Èë´íÎó»Ø±¨
+	///ç”³è¯·ç»„åˆå½•å…¥é”™è¯¯å›æŠ¥
 	virtual void OnErrRtnCombActionInsert(CThostFtdcInputCombActionField *pInputCombAction, CThostFtdcRspInfoField *pRspInfo) ;
 
-	///ÇëÇó²éÑ¯Ç©Ô¼ÒøĞĞÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢ç­¾çº¦é“¶è¡Œå“åº”
 	virtual void OnRspQryContractBank(CThostFtdcContractBankField *pContractBank, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯Ô¤Âñµ¥ÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢é¢„åŸ‹å•å“åº”
 	virtual void OnRspQryParkedOrder(CThostFtdcParkedOrderField *pParkedOrder, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯Ô¤Âñ³·µ¥ÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢é¢„åŸ‹æ’¤å•å“åº”
 	virtual void OnRspQryParkedOrderAction(CThostFtdcParkedOrderActionField *pParkedOrderAction, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯½»Ò×Í¨ÖªÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢äº¤æ˜“é€šçŸ¥å“åº”
 	virtual void OnRspQryTradingNotice(CThostFtdcTradingNoticeField *pTradingNotice, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯¾­¼Í¹«Ë¾½»Ò×²ÎÊıÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢ç»çºªå…¬å¸äº¤æ˜“å‚æ•°å“åº”
 	virtual void OnRspQryBrokerTradingParams(CThostFtdcBrokerTradingParamsField *pBrokerTradingParams, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯¾­¼Í¹«Ë¾½»Ò×Ëã·¨ÏìÓ¦
+	///è¯·æ±‚æŸ¥è¯¢ç»çºªå…¬å¸äº¤æ˜“ç®—æ³•å“åº”
 	virtual void OnRspQryBrokerTradingAlgos(CThostFtdcBrokerTradingAlgosField *pBrokerTradingAlgos, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÇëÇó²éÑ¯¼à¿ØÖĞĞÄÓÃ»§ÁîÅÆ
+	///è¯·æ±‚æŸ¥è¯¢ç›‘æ§ä¸­å¿ƒç”¨æˆ·ä»¤ç‰Œ
 	virtual void OnRspQueryCFMMCTradingAccountToken(CThostFtdcQueryCFMMCTradingAccountTokenField *pQueryCFMMCTradingAccountToken, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÒøĞĞ·¢ÆğÒøĞĞ×Ê½ğ×ªÆÚ»õÍ¨Öª
+	///é“¶è¡Œå‘èµ·é“¶è¡Œèµ„é‡‘è½¬æœŸè´§é€šçŸ¥
 	virtual void OnRtnFromBankToFutureByBank(CThostFtdcRspTransferField *pRspTransfer) ;
 
-	///ÒøĞĞ·¢ÆğÆÚ»õ×Ê½ğ×ªÒøĞĞÍ¨Öª
+	///é“¶è¡Œå‘èµ·æœŸè´§èµ„é‡‘è½¬é“¶è¡Œé€šçŸ¥
 	virtual void OnRtnFromFutureToBankByBank(CThostFtdcRspTransferField *pRspTransfer) ;
 
-	///ÒøĞĞ·¢Æğ³åÕıÒøĞĞ×ªÆÚ»õÍ¨Öª
+	///é“¶è¡Œå‘èµ·å†²æ­£é“¶è¡Œè½¬æœŸè´§é€šçŸ¥
 	virtual void OnRtnRepealFromBankToFutureByBank(CThostFtdcRspRepealField *pRspRepeal) ;
 
-	///ÒøĞĞ·¢Æğ³åÕıÆÚ»õ×ªÒøĞĞÍ¨Öª
+	///é“¶è¡Œå‘èµ·å†²æ­£æœŸè´§è½¬é“¶è¡Œé€šçŸ¥
 	virtual void OnRtnRepealFromFutureToBankByBank(CThostFtdcRspRepealField *pRspRepeal) ;
 
-	///ÆÚ»õ·¢ÆğÒøĞĞ×Ê½ğ×ªÆÚ»õÍ¨Öª
+	///æœŸè´§å‘èµ·é“¶è¡Œèµ„é‡‘è½¬æœŸè´§é€šçŸ¥
 	virtual void OnRtnFromBankToFutureByFuture(CThostFtdcRspTransferField *pRspTransfer) ;
 
-	///ÆÚ»õ·¢ÆğÆÚ»õ×Ê½ğ×ªÒøĞĞÍ¨Öª
+	///æœŸè´§å‘èµ·æœŸè´§èµ„é‡‘è½¬é“¶è¡Œé€šçŸ¥
 	virtual void OnRtnFromFutureToBankByFuture(CThostFtdcRspTransferField *pRspTransfer) ;
 
-	///ÏµÍ³ÔËĞĞÊ±ÆÚ»õ¶ËÊÖ¹¤·¢Æğ³åÕıÒøĞĞ×ªÆÚ»õÇëÇó£¬ÒøĞĞ´¦ÀíÍê±Ïºó±¨ÅÌ·¢»ØµÄÍ¨Öª
+	///ç³»ç»Ÿè¿è¡Œæ—¶æœŸè´§ç«¯æ‰‹å·¥å‘èµ·å†²æ­£é“¶è¡Œè½¬æœŸè´§è¯·æ±‚ï¼Œé“¶è¡Œå¤„ç†å®Œæ¯•åæŠ¥ç›˜å‘å›çš„é€šçŸ¥
 	virtual void OnRtnRepealFromBankToFutureByFutureManual(CThostFtdcRspRepealField *pRspRepeal) ;
 
-	///ÏµÍ³ÔËĞĞÊ±ÆÚ»õ¶ËÊÖ¹¤·¢Æğ³åÕıÆÚ»õ×ªÒøĞĞÇëÇó£¬ÒøĞĞ´¦ÀíÍê±Ïºó±¨ÅÌ·¢»ØµÄÍ¨Öª
+	///ç³»ç»Ÿè¿è¡Œæ—¶æœŸè´§ç«¯æ‰‹å·¥å‘èµ·å†²æ­£æœŸè´§è½¬é“¶è¡Œè¯·æ±‚ï¼Œé“¶è¡Œå¤„ç†å®Œæ¯•åæŠ¥ç›˜å‘å›çš„é€šçŸ¥
 	virtual void OnRtnRepealFromFutureToBankByFutureManual(CThostFtdcRspRepealField *pRspRepeal) ;
 
-	///ÆÚ»õ·¢Æğ²éÑ¯ÒøĞĞÓà¶îÍ¨Öª
+	///æœŸè´§å‘èµ·æŸ¥è¯¢é“¶è¡Œä½™é¢é€šçŸ¥
 	virtual void OnRtnQueryBankBalanceByFuture(CThostFtdcNotifyQueryAccountField *pNotifyQueryAccount) ;
 
-	///ÆÚ»õ·¢ÆğÒøĞĞ×Ê½ğ×ªÆÚ»õ´íÎó»Ø±¨
+	///æœŸè´§å‘èµ·é“¶è¡Œèµ„é‡‘è½¬æœŸè´§é”™è¯¯å›æŠ¥
 	virtual void OnErrRtnBankToFutureByFuture(CThostFtdcReqTransferField *pReqTransfer, CThostFtdcRspInfoField *pRspInfo) ;
 
-	///ÆÚ»õ·¢ÆğÆÚ»õ×Ê½ğ×ªÒøĞĞ´íÎó»Ø±¨
+	///æœŸè´§å‘èµ·æœŸè´§èµ„é‡‘è½¬é“¶è¡Œé”™è¯¯å›æŠ¥
 	virtual void OnErrRtnFutureToBankByFuture(CThostFtdcReqTransferField *pReqTransfer, CThostFtdcRspInfoField *pRspInfo) ;
 
-	///ÏµÍ³ÔËĞĞÊ±ÆÚ»õ¶ËÊÖ¹¤·¢Æğ³åÕıÒøĞĞ×ªÆÚ»õ´íÎó»Ø±¨
+	///ç³»ç»Ÿè¿è¡Œæ—¶æœŸè´§ç«¯æ‰‹å·¥å‘èµ·å†²æ­£é“¶è¡Œè½¬æœŸè´§é”™è¯¯å›æŠ¥
 	virtual void OnErrRtnRepealBankToFutureByFutureManual(CThostFtdcReqRepealField *pReqRepeal, CThostFtdcRspInfoField *pRspInfo) ;
 
-	///ÏµÍ³ÔËĞĞÊ±ÆÚ»õ¶ËÊÖ¹¤·¢Æğ³åÕıÆÚ»õ×ªÒøĞĞ´íÎó»Ø±¨
+	///ç³»ç»Ÿè¿è¡Œæ—¶æœŸè´§ç«¯æ‰‹å·¥å‘èµ·å†²æ­£æœŸè´§è½¬é“¶è¡Œé”™è¯¯å›æŠ¥
 	virtual void OnErrRtnRepealFutureToBankByFutureManual(CThostFtdcReqRepealField *pReqRepeal, CThostFtdcRspInfoField *pRspInfo) ;
 
-	///ÆÚ»õ·¢Æğ²éÑ¯ÒøĞĞÓà¶î´íÎó»Ø±¨
+	///æœŸè´§å‘èµ·æŸ¥è¯¢é“¶è¡Œä½™é¢é”™è¯¯å›æŠ¥
 	virtual void OnErrRtnQueryBankBalanceByFuture(CThostFtdcReqQueryAccountField *pReqQueryAccount, CThostFtdcRspInfoField *pRspInfo) ;
 
-	///ÆÚ»õ·¢Æğ³åÕıÒøĞĞ×ªÆÚ»õÇëÇó£¬ÒøĞĞ´¦ÀíÍê±Ïºó±¨ÅÌ·¢»ØµÄÍ¨Öª
+	///æœŸè´§å‘èµ·å†²æ­£é“¶è¡Œè½¬æœŸè´§è¯·æ±‚ï¼Œé“¶è¡Œå¤„ç†å®Œæ¯•åæŠ¥ç›˜å‘å›çš„é€šçŸ¥
 	virtual void OnRtnRepealFromBankToFutureByFuture(CThostFtdcRspRepealField *pRspRepeal) ;
 
-	///ÆÚ»õ·¢Æğ³åÕıÆÚ»õ×ªÒøĞĞÇëÇó£¬ÒøĞĞ´¦ÀíÍê±Ïºó±¨ÅÌ·¢»ØµÄÍ¨Öª
+	///æœŸè´§å‘èµ·å†²æ­£æœŸè´§è½¬é“¶è¡Œè¯·æ±‚ï¼Œé“¶è¡Œå¤„ç†å®Œæ¯•åæŠ¥ç›˜å‘å›çš„é€šçŸ¥
 	virtual void OnRtnRepealFromFutureToBankByFuture(CThostFtdcRspRepealField *pRspRepeal) ;
 
-	///ÆÚ»õ·¢ÆğÒøĞĞ×Ê½ğ×ªÆÚ»õÓ¦´ğ
+	///æœŸè´§å‘èµ·é“¶è¡Œèµ„é‡‘è½¬æœŸè´§åº”ç­”
 	virtual void OnRspFromBankToFutureByFuture(CThostFtdcReqTransferField *pReqTransfer, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÆÚ»õ·¢ÆğÆÚ»õ×Ê½ğ×ªÒøĞĞÓ¦´ğ
+	///æœŸè´§å‘èµ·æœŸè´§èµ„é‡‘è½¬é“¶è¡Œåº”ç­”
 	virtual void OnRspFromFutureToBankByFuture(CThostFtdcReqTransferField *pReqTransfer, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÆÚ»õ·¢Æğ²éÑ¯ÒøĞĞÓà¶îÓ¦´ğ
+	///æœŸè´§å‘èµ·æŸ¥è¯¢é“¶è¡Œä½™é¢åº”ç­”
 	virtual void OnRspQueryBankAccountMoneyByFuture(CThostFtdcReqQueryAccountField *pReqQueryAccount, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) ;
 
-	///ÒøĞĞ·¢ÆğÒøÆÚ¿ª»§Í¨Öª
+	///é“¶è¡Œå‘èµ·é“¶æœŸå¼€æˆ·é€šçŸ¥
 	virtual void OnRtnOpenAccountByBank(CThostFtdcOpenAccountField *pOpenAccount) ;
 
-	///ÒøĞĞ·¢ÆğÒøÆÚÏú»§Í¨Öª
+	///é“¶è¡Œå‘èµ·é“¶æœŸé”€æˆ·é€šçŸ¥
 	virtual void OnRtnCancelAccountByBank(CThostFtdcCancelAccountField *pCancelAccount) ;
 
-	///ÒøĞĞ·¢Æğ±ä¸üÒøĞĞÕËºÅÍ¨Öª
+	///é“¶è¡Œå‘èµ·å˜æ›´é“¶è¡Œè´¦å·é€šçŸ¥
 	virtual void OnRtnChangeAccountByBank(CThostFtdcChangeAccountField *pChangeAccount) ;
 
 	//-------------------------------------------------------------------------------------
-	//task£ºÈÎÎñ
+	//taskï¼šä»»åŠ¡
 	//-------------------------------------------------------------------------------------
 
 	void processTask();
@@ -856,11 +857,11 @@ public:
 	void processRtnChangeAccountByBank(Task task);
 
 	//-------------------------------------------------------------------------------------
-	//data£º»Øµ÷º¯ÊıµÄÊı¾İ×Öµä
-	//error£º»Øµ÷º¯ÊıµÄ´íÎó×Öµä
-	//id£ºÇëÇóid
-	//last£ºÊÇ·ñÎª×îºó·µ»Ø
-	//i£ºÕûÊı
+	//dataï¼šå›è°ƒå‡½æ•°çš„æ•°æ®å­—å…¸
+	//errorï¼šå›è°ƒå‡½æ•°çš„é”™è¯¯å­—å…¸
+	//idï¼šè¯·æ±‚id
+	//lastï¼šæ˜¯å¦ä¸ºæœ€åè¿”å›
+	//iï¼šæ•´æ•°
 	//-------------------------------------------------------------------------------------
 
 	virtual void onFrontConnected(){};
@@ -1091,7 +1092,7 @@ public:
 
 
 	//-------------------------------------------------------------------------------------
-	//req:Ö÷¶¯º¯ÊıµÄÇëÇó×Öµä
+	//req:ä¸»åŠ¨å‡½æ•°çš„è¯·æ±‚å­—å…¸
 	//-------------------------------------------------------------------------------------
 
 	void createFtdcTraderApi(string pszFlowPath = "");


### PR DESCRIPTION
1. 将可能存在中文的字段进行字符集转换，从gb2312转换为utf8
2. 测试Python35 64位的兼容性，除发单发，其余均测试通过