### PR TITLE
修复OKCoin行情中ask数据异常

### DIFF
--- a/vn.trader/okcoinGateway/okcoinGateway.py
+++ b/vn.trader/okcoinGateway/okcoinGateway.py
@@ -406,11 +406,11 @@ class Api(vnokcoin.OkCoinApi):
         tick.bidPrice4, tick.bidVolume4 = rawData['bids'][3]
         tick.bidPrice5, tick.bidVolume5 = rawData['bids'][4]
         
-        tick.askPrice1, tick.askVolume1 = rawData['asks'][0]
-        tick.askPrice2, tick.askVolume2 = rawData['asks'][1]
-        tick.askPrice3, tick.askVolume3 = rawData['asks'][2]
-        tick.askPrice4, tick.askVolume4 = rawData['asks'][3]
-        tick.askPrice5, tick.askVolume5 = rawData['asks'][4]            
+        tick.askPrice1, tick.askVolume1 = rawData['asks'][-1]
+        tick.askPrice2, tick.askVolume2 = rawData['asks'][-2]
+        tick.askPrice3, tick.askVolume3 = rawData['asks'][-3]
+        tick.askPrice4, tick.askVolume4 = rawData['asks'][-4]
+        tick.askPrice5, tick.askVolume5 = rawData['asks'][-5]            
         
         newtick = copy(tick)
         self.gateway.onTick(newtick)


### PR DESCRIPTION
从okcoin获得深度行情数据中，原始版本对ask的处理有误，ask数据也是从高到低的,所以访问次序应该与bid相反.