### PR TITLE
根据测试ib港股期货业务品种，添加对应数据字典及委托参数

### DIFF
--- a/vn.trader/ibGateway/ibGateway.py
+++ b/vn.trader/ibGateway/ibGateway.py
@@ -46,6 +46,8 @@ exchangeMap[EXCHANGE_SMART] = 'SMART'
 exchangeMap[EXCHANGE_NYMEX] = 'NYMEX'
 exchangeMap[EXCHANGE_GLOBEX] = 'GLOBEX'
 exchangeMap[EXCHANGE_IDEALPRO] = 'IDEALPRO'
+exchangeMap[EXCHANGE_HKEX] = 'HKEX'
+exchangeMap[EXCHANGE_HKFE] = 'HKFE'
 exchangeMapReverse = {v:k for k,v in exchangeMap.items()}
 
 # 报单状态映射
@@ -65,6 +67,7 @@ productClassMap[PRODUCT_EQUITY] = 'STK'
 productClassMap[PRODUCT_FUTURES] = 'FUT'
 productClassMap[PRODUCT_OPTION] = 'OPT'
 productClassMap[PRODUCT_FOREX] = 'CASH'
+productClassMap[PRODUCT_INDEX] = 'IND'
 productClassMapReverse = {v:k for k,v in productClassMap.items()}
 
 # 期权类型映射
@@ -77,6 +80,7 @@ optionTypeMap = {v:k for k,v in optionTypeMap.items()}
 currencyMap = {}
 currencyMap[CURRENCY_USD] = 'USD'
 currencyMap[CURRENCY_CNY] = 'CNY'
+currencyMap[CURRENCY_HKD] = 'HKD'
 currencyMap = {v:k for k,v in currencyMap.items()}
 
 # Tick数据的Field和名称映射
@@ -233,6 +237,8 @@ class IbGateway(VtGateway):
         contract.expiry = orderReq.expiry
         contract.strike = orderReq.strikePrice
         contract.right = optionTypeMap.get(orderReq.optionType, '')
+        contract.lastTradeDateOrContractMonth = str(orderReq.lastTradeDateOrContractMonth)
+        contract.multiplier = str(orderReq.multiplier)
         
         # 创建委托对象
         order = Order()

--- a/vn.trader/uiBasicWidget.py
+++ b/vn.trader/uiBasicWidget.py
@@ -655,6 +655,7 @@ class TradingWidget(QtGui.QFrame):
                     EXCHANGE_SZSE,
                     EXCHANGE_SGE,
                     EXCHANGE_HKEX,
+                    EXCHANGE_HKFE,
                     EXCHANGE_SMART,
                     EXCHANGE_ICE,
                     EXCHANGE_CME,
@@ -664,6 +665,7 @@ class TradingWidget(QtGui.QFrame):
     
     currencyList = [CURRENCY_NONE,
                     CURRENCY_CNY,
+                    CURRENCY_HKD,
                     CURRENCY_USD]
     
     productClassList = [PRODUCT_NONE,

--- a/vn.trader/vtConstant.py
+++ b/vn.trader/vtConstant.py
@@ -62,6 +62,7 @@ EXCHANGE_SGE = 'SGE'       # 上金所
 EXCHANGE_UNKNOWN = 'UNKNOWN'# 未知交易所
 EXCHANGE_NONE = ''          # 空交易所
 EXCHANGE_HKEX = 'HKEX'      # 港交所
+EXCHANGE_HKFE = 'HKFE'      # 香港期货交易所
 
 EXCHANGE_SMART = 'SMART'       # IB智能路由（股票、期权）
 EXCHANGE_NYMEX = 'NYMEX'       # IB 期货
@@ -77,5 +78,6 @@ EXCHANGE_OKCOIN = 'OKCOIN'     # OKCOIN比特币交易所
 # 货币类型
 CURRENCY_USD = 'USD'            # 美元
 CURRENCY_CNY = 'CNY'            # 人民币
+CURRENCY_HKD = 'HKD'            # 港币
 CURRENCY_UNKNOWN = 'UNKNOWN'    # 未知货币
 CURRENCY_NONE = ''              # 空货币

--- a/vn.trader/vtGateway.py
+++ b/vn.trader/vtGateway.py
@@ -411,7 +411,9 @@ class VtOrderReq(object):
         self.currency = EMPTY_STRING            # 合约货币
         self.expiry = EMPTY_STRING              # 到期日
         self.strikePrice = EMPTY_FLOAT          # 行权价
-        self.optionType = EMPTY_UNICODE         # 期权类型        
+        self.optionType = EMPTY_UNICODE         # 期权类型     
+        self.lastTradeDateOrContractMonth = EMPTY_STRING    # 合约月,IB专用
+        self.multiplier = EMPTY_STRING                      # 乘数,IB专用
         
 
 ########################################################################


### PR DESCRIPTION
1.添加了港币币种数据字典HKD，添加指数业务品种数据字典IND
2.添加了相关期货交易所数据字典HKEX、HXFE
3.由于测试了港股的股指期货，IbGateway中的sendorder函数添加了contract.lastTradeDateOrContractMonth、contract.multiplier两个参数的支持
