### PR TITLE
修正GUI中仓位变量pos不能实时更新的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ vn.ctp/build/*
 vn.lts/build/*
 .idea
 >>>>>>> 65aac25731772259bf2d4049e7adbe92750ea01d
+
+vn.trader/ctaAlgo/data/*
+vn.trader/build/*
+vn.trader/dist/*

--- a/vn.trader/ctaAlgo/strategyAtrRsi.py
+++ b/vn.trader/ctaAlgo/strategyAtrRsi.py
@@ -233,8 +233,8 @@ class AtrRsiStrategy(CtaTemplate):
 
     #----------------------------------------------------------------------
     def onTrade(self, trade):
-        pass
-
+        # 发出状态更新事件
+        self.putEvent()
 
 if __name__ == '__main__':
     # 提供直接双击回测的功能

--- a/vn.trader/uiBasicWidget.py
+++ b/vn.trader/uiBasicWidget.py
@@ -702,6 +702,7 @@ class TradingWidget(QtGui.QFrame):
         labelDirection = QtGui.QLabel(u'方向类型')
         labelOffset = QtGui.QLabel(u'开平')
         labelPrice = QtGui.QLabel(u'价格')
+        self.checkFixed = QtGui.QCheckBox(u'')  # 价格固定选择框
         labelVolume = QtGui.QLabel(u'数量')
         labelPriceType = QtGui.QLabel(u'价格类型')
         labelExchange = QtGui.QLabel(u'交易所') 
@@ -755,17 +756,18 @@ class TradingWidget(QtGui.QFrame):
         gridleft.addWidget(labelProductClass, 9, 0)   
         gridleft.addWidget(labelGateway, 10, 0)
         
-        gridleft.addWidget(self.lineSymbol, 0, 1)
-        gridleft.addWidget(self.lineName, 1, 1)
-        gridleft.addWidget(self.comboDirection, 2, 1)
-        gridleft.addWidget(self.comboOffset, 3, 1)
-        gridleft.addWidget(self.spinPrice, 4, 1)
-        gridleft.addWidget(self.spinVolume, 5, 1)
-        gridleft.addWidget(self.comboPriceType, 6, 1)	
-        gridleft.addWidget(self.comboExchange, 7, 1)
-        gridleft.addWidget(self.comboCurrency, 8, 1)	
-        gridleft.addWidget(self.comboProductClass, 9, 1) 
-        gridleft.addWidget(self.comboGateway, 10, 1)
+        gridleft.addWidget(self.lineSymbol, 0, 1, 1, -1)
+        gridleft.addWidget(self.lineName, 1, 1, 1, -1)
+        gridleft.addWidget(self.comboDirection, 2, 1, 1, -1)
+        gridleft.addWidget(self.comboOffset, 3, 1, 1, -1)
+        gridleft.addWidget(self.checkFixed, 4, 1)
+        gridleft.addWidget(self.spinPrice, 4, 2)
+        gridleft.addWidget(self.spinVolume, 5, 1, 1, -1)
+        gridleft.addWidget(self.comboPriceType, 6, 1, 1, -1)
+        gridleft.addWidget(self.comboExchange, 7, 1, 1, -1)
+        gridleft.addWidget(self.comboCurrency, 8, 1, 1, -1)
+        gridleft.addWidget(self.comboProductClass, 9, 1, 1, -1)
+        gridleft.addWidget(self.comboGateway, 10, 1, 1, -1)
 
         # 右边部分
         labelBid1 = QtGui.QLabel(u'买一')
@@ -934,7 +936,10 @@ class TradingWidget(QtGui.QFrame):
         req.exchange = exchange
         req.currency = currency
         req.productClass = productClass
-        
+
+        # 默认跟随价
+        self.checkFixed.setChecked(False)
+
         self.mainEngine.subscribe(req, gatewayName)
 
         # 更新组件当前交易的合约
@@ -946,6 +951,8 @@ class TradingWidget(QtGui.QFrame):
         tick = event.dict_['data']
 
         if tick.vtSymbol == self.symbol:
+            if not self.checkFixed.isChecked():
+                self.spinPrice.setValue(tick.lastPrice)
             self.labelBidPrice1.setText(str(tick.bidPrice1))
             self.labelAskPrice1.setText(str(tick.askPrice1))
             self.labelBidVolume1.setText(str(tick.bidVolume1))


### PR DESCRIPTION
原版demo策略strategyAtrRsi中，在onBar后更新仓位变量pos，这样会导致仓位变动后直到下根bar生成才更新GUI的仓位变量。
修改为在onTrade中更新GUI。