### PR TITLE
修复两个bug，添加一个测试

### DIFF
--- a/vn.rpc/testClient.py
+++ b/vn.rpc/testClient.py
@@ -22,7 +22,7 @@ class TestClient(RpcClient):
 
 if __name__ == '__main__':
     reqAddress = 'tcp://localhost:2014'
-    subAddress = 'tcp://localhost:0602'
+    subAddress = 'tcp://localhost:6602'
     
     tc = TestClient(reqAddress, subAddress)
     tc.subscribeTopic('')

--- a/vn.rpc/testServer.py
+++ b/vn.rpc/testServer.py
@@ -25,7 +25,7 @@ class TestServer(RpcServer):
 
 if __name__ == '__main__':
     repAddress = 'tcp://*:2014'
-    pubAddress = 'tcp://*:0602'
+    pubAddress = 'tcp://*:6602'
     
     ts = TestServer(repAddress, pubAddress)
     ts.start()

--- a/vn.trader/ctaAlgo/strategy/strategyAtrRsi.py
+++ b/vn.trader/ctaAlgo/strategy/strategyAtrRsi.py
@@ -10,6 +10,9 @@
 
 """
 
+import sys
+sys.path.append("..")
+sys.path.append("../..")
 
 from ctaBase import *
 from ctaTemplate import CtaTemplate

--- a/vn.trader/ctaAlgo/strategy/strategyEmaDemo.py
+++ b/vn.trader/ctaAlgo/strategy/strategyEmaDemo.py
@@ -295,3 +295,56 @@ class OrderManagementDemoStrategy(CtaTemplate):
         """收到成交推送（必须由用户继承实现）"""
         # 对于无需做细粒度委托控制的策略，可以忽略onOrder
         pass
+
+if __name__ == '__main__':
+    # 提供直接双击回测的功能
+    # 导入PyQt4的包是为了保证matplotlib使用PyQt4而不是PySide，防止初始化出错
+    from ctaBacktesting import *
+    from PyQt4 import QtCore, QtGui
+
+    # 创建回测引擎
+    engine = BacktestingEngine()
+
+    # 设置引擎的回测模式为K线
+    engine.setBacktestingMode(engine.BAR_MODE)
+
+    # 设置回测用的数据起始日期
+    engine.setStartDate('20120101')
+
+    # 设置产品相关参数
+    engine.setSlippage(0.2)  # 股指1跳
+    engine.setRate(0.3 / 10000)  # 万0.3
+    engine.setSize(300)  # 股指合约大小
+
+    # 设置使用的历史数据库
+    engine.setDatabase(MINUTE_DB_NAME, 'IF0000')
+
+    # 在引擎中创建策略对象
+    d = {'atrLength': 11}
+    engine.initStrategy(EmaDemoStrategy, d)
+
+    # 开始跑回测
+    engine.runBacktesting()
+
+    # 显示回测结果
+    engine.showBacktestingResult()
+
+    ## 跑优化
+    # setting = OptimizationSetting()                 # 新建一个优化任务设置对象
+    # setting.setOptimizeTarget('capital')            # 设置优化排序的目标是策略净盈利
+    # setting.addParameter('atrLength', 12, 20, 2)    # 增加第一个优化参数atrLength，起始11，结束12，步进1
+    # setting.addParameter('atrMa', 20, 30, 5)        # 增加第二个优化参数atrMa，起始20，结束30，步进1
+    # setting.addParameter('rsiLength', 5)            # 增加一个固定数值的参数
+
+    ## 性能测试环境：I7-3770，主频3.4G, 8核心，内存16G，Windows 7 专业版
+    ## 测试时还跑着一堆其他的程序，性能仅供参考
+    # import time
+    # start = time.time()
+
+    ## 运行单进程优化函数，自动输出结果，耗时：359秒
+    # engine.runOptimization(AtrRsiStrategy, setting)
+
+    ## 多进程优化，耗时：89秒
+    ##engine.runParallelOptimization(AtrRsiStrategy, setting)
+
+    # print u'耗时：%s' %(time.time()-start)

--- a/vn.trader/ctaAlgo/strategy/strategyEmaDemo.py
+++ b/vn.trader/ctaAlgo/strategy/strategyEmaDemo.py
@@ -11,6 +11,9 @@
 也希望社区能做出一个解决了以上潜在风险的Demo出来。
 """
 
+import sys
+sys.path.append("..")
+sys.path.append("../..")
 
 from ctaBase import *
 from ctaTemplate import CtaTemplate

--- a/vn.trader/vtClient.py
+++ b/vn.trader/vtClient.py
@@ -170,7 +170,7 @@ def main():
 
     # 创建客户端
     reqAddress = 'tcp://localhost:2014'
-    subAddress = 'tcp://localhost:0602'
+    subAddress = 'tcp://localhost:6602'
     client = VtClient(reqAddress, subAddress, eventEngine)
 
     client.subscribeTopic('')

--- a/vn.trader/vtServer.py
+++ b/vn.trader/vtServer.py
@@ -72,7 +72,7 @@ def printLog(content):
 def runServer():
     """运行服务器"""
     repAddress = 'tcp://*:2014'
-    pubAddress = 'tcp://*:0602'
+    pubAddress = 'tcp://*:6602'
     
     # 创建并启动服务器
     server = VtServer(repAddress, pubAddress)


### PR DESCRIPTION
1. 解决linux下绑定1024以下端口需要超级管理员权限的问题，绑定端口改成6602，已经进行了全局替换。
2. 解决No module named ctaBase的问题，将父目录添加到path
3. 添加strategyEmaDemo.py的测试用例