### PR TITLE
fix ImportError: No module named ctaBase

### DIFF
--- a/vn.trader/ctaAlgo/strategy/strategyAtrRsi.py
+++ b/vn.trader/ctaAlgo/strategy/strategyAtrRsi.py
@@ -10,6 +10,13 @@
 
 """
 
+import os, sys
+curpath = os.path.dirname(__file__)
+parpath = os.path.dirname(curpath)
+parparpath = os.path.dirname(parpath)
+sys.path.append(parpath)
+sys.path.append(parparpath)
+
 
 from ctaBase import *
 from ctaTemplate import CtaTemplate

--- a/vn.trader/ctaAlgo/strategy/strategyEmaDemo.py
+++ b/vn.trader/ctaAlgo/strategy/strategyEmaDemo.py
@@ -11,6 +11,12 @@
 也希望社区能做出一个解决了以上潜在风险的Demo出来。
 """
 
+import os, sys
+curpath = os.path.dirname(__file__)
+parpath = os.path.dirname(curpath)
+parparpath = os.path.dirname(parpath)
+sys.path.append(parpath)
+sys.path.append(parparpath)
 
 from ctaBase import *
 from ctaTemplate import CtaTemplate


### PR DESCRIPTION
由于策略路径调整，出现 ImportError: No module named ctaBase 的问题，主要涉及两个文件：
1. vn.trader/ctaAlgo/strategy/strategyAtrRsi.py
2. vn.trader/ctaAlgo/strategy/strategyEmaDemo.py
对应于https://github.com/vnpy/vnpy/issues/230这个issue，希望提交者在做修改时做一遍测试