### PR TITLE
此处语言配置文件夹名应为小写，否则可能加载失败

### DIFF
--- a/vn.trader/language/__init__.py
+++ b/vn.trader/language/__init__.py
@@ -4,7 +4,7 @@ import json
 import os
 
 # 默认设置
-from Chinese import text, constant
+from chinese import text, constant
 
 # 获取目录上级路径
 path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -16,7 +16,7 @@ try:
     f = file(SETTING_FILENAME)
     setting = json.load(f)
     if setting['language'] == 'English':
-        from English import text, constant
+        from english import text, constant
     f.close()
 except:
     pass


### PR DESCRIPTION
或者修改文件夹名与策略模块等的语言配置文件夹名统一为大写