### PR TITLE
解决回测时设置结束时间后缺失最后一天数据的Bug

### DIFF
--- a/vn.trader/ctaStrategy/ctaBacktesting.py
+++ b/vn.trader/ctaStrategy/ctaBacktesting.py
@@ -103,7 +103,7 @@ class BacktestingEngine(object):
         if endDate:
             self.dataEndDate= datetime.strptime(endDate, '%Y%m%d')
             # 若不修改时间则会导致不包含dataEndDate当天数据
-            self.dataEndDate.replace(hour=23, minute=59)    
+            self.dataEndDate = self.dataEndDate.replace(hour=23, minute=59)
         
     #----------------------------------------------------------------------
     def setBacktestingMode(self, mode):


### PR DESCRIPTION
解决回测时设置结束时间后缺失最后一天数据的Bug