### PR TITLE
兼容新版本的qtpy: 在新版本的qtpy中，已经删除了pyqtSignal的方法，使用Signal方法，这里是为了兼容，ugly! 应该…

### DIFF
--- a/vnpy/trader/app/spreadTrading/uiStWidget.py
+++ b/vnpy/trader/app/spreadTrading/uiStWidget.py
@@ -72,7 +72,7 @@ class StPosMonitor(BasicMonitor):
 ########################################################################
 class StLogMonitor(QtWidgets.QTextEdit):
     """价差日志监控"""
-    signal = QtCore.pyqtSignal(type(Event()))
+    signal = QtCore.Signal(type(Event()))
     
     #----------------------------------------------------------------------
     def __init__(self, mainEngine, eventEngine, parent=None):
@@ -300,7 +300,7 @@ class StModeComboBox(QtWidgets.QComboBox):
 ########################################################################
 class StActiveButton(QtWidgets.QPushButton):
     """"""
-    signalActive = QtCore.pyqtSignal(bool)
+    signalActive = QtCore.Signal(bool)
 
     #----------------------------------------------------------------------
     def __init__(self, algoEngine, spreadName, parent=None):


### PR DESCRIPTION
Anaconda无意中升级了qtpy的版本，发现vntrader无法运行，确认是qtpy的版本兼容性问题。
兼容新版本的qtpy: 在新版本的qtpy中，已经删除了pyqtSignal的方法，使用Signal方法，这里是为了兼容，ugly! 应该仅适用qtpy的API。