### PR TITLE
补齐链行返回框架对象的时间毫秒部分

### DIFF
--- a/vnpy/trader/gateway/lhangGateway/lhangGateway.py
+++ b/vnpy/trader/gateway/lhangGateway/lhangGateway.py
@@ -180,7 +180,7 @@ class LhangApi(LhangApi):
         err = VtErrorData()
         err.gatewayName = self.gatewayName
         err.errorMsg = str(error)
-        err.errorTime = datetime.now().strftime('%H:%M:%S')
+        err.errorTime = datetime.now().strftime('%H:%M:%S.%f')[:-3]
         self.gateway.onError(err)
 
     #----------------------------------------------------------------------
@@ -236,7 +236,7 @@ class LhangApi(LhangApi):
         tick.askPrice5, tick.askVolume5 = data['asks'][4]
 
         now = datetime.now()
-        tick.time = now.strftime('%H:%M:%S')
+        tick.time = now.strftime('%H:%M:%S.%f')[:-3]
         tick.date = now.strftime('%Y%m%d')
 
         self.gateway.onTick(tick)
@@ -356,7 +356,7 @@ class LhangApi(LhangApi):
                     trade.direction = order.direction
                     trade.offset = order.offset
                     trade.exchange = order.exchange
-                    trade.tradeTime = datetime.now().strftime('%H:%M:%S')
+                    trade.tradeTime = datetime.now().strftime('%H:%M:%S.%f')[:-3]
 
                     self.gateway.onTrade(trade)
 
@@ -447,7 +447,7 @@ class LhangApi(LhangApi):
             err = VtErrorData()
             err.gatewayName = self.gatewayName
             err.errorMsg = u'链行接口仅支持限价单'
-            err.errorTime = datetime.now().strftime('%H:%M:%S')
+            err.errorTime = datetime.now().strftime('%H:%M:%S.%f')[:-3]
             self.gateway.onError(err)
             return None
 
@@ -480,7 +480,7 @@ class LhangApi(LhangApi):
         order.offset = OFFSET_UNKNOWN
         order.price = req.price
         order.volume = req.volume
-        order.orderTime = datetime.now().strftime('%H:%M:%S')
+        order.orderTime = datetime.now().strftime('%H:%M:%S.%f')[:-3]
         order.status = STATUS_UNKNOWN
 
         self.workingOrderDict[localID] = order


### PR DESCRIPTION
针对数据记录、Cta引擎等需要order\tick\error等对象时间字符串中毫秒部分来格式化时间，否则会出现异常。
此pr修复这个问题。