### PR TITLE
shcifco data api: use natural day instead of trading day

### DIFF
--- a/vnpy/data/shcifco/vnshcifco.py
+++ b/vnpy/data/shcifco/vnshcifco.py
@@ -132,14 +132,15 @@ class ShcifcoApi(object):
             barData = barStr.split(',')
             d = {
                 'symbol': barData[0],
-                'date': barData[1],
+                # 'date': barData[1],   # trading day
                 'time': barData[2],
                 'open': float(barData[3]),
                 'high': float(barData[4]),
                 'low': float(barData[5]),
                 'close': float(barData[6]),
                 'volume': int(barData[7]),
-                'openInterest': int(barData[8])
+                'openInterest': int(barData[8]),
+                'date': barData[9]  # natural day
             }
             barList.append(d)
             


### PR DESCRIPTION
#432 
中期已在数据接口hisbar的返回值中增加了自然日字段