### PR TITLE
使用 loggingg 来作为日志输出模块

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,5 @@ vn.trader/ctaAlgo/data/*
 vn.trader/build/*
 vn.trader/dist/*
 *.bak
+tmp/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pymongo
 websocket-client
 msgpack-python
 qdarkstyle
+log4mongo>=1.6.1

--- a/vnpy/event/eventEngine.py
+++ b/vnpy/event/eventEngine.py
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
 # 系统模块
+import logging
 from Queue import Queue, Empty
 from threading import Thread
 from time import sleep
@@ -54,6 +55,7 @@ class EventEngine(object):
     def __init__(self):
         """初始化事件引擎"""
         # 事件队列
+        self.log = logging.getLogger('root')
         self.__queue = Queue()
         
         # 事件引擎开关

--- a/vnpy/event/eventEngine.py
+++ b/vnpy/event/eventEngine.py
@@ -55,7 +55,6 @@ class EventEngine(object):
     def __init__(self):
         """初始化事件引擎"""
         # 事件队列
-        self.log = logging.getLogger('root')
         self.__queue = Queue()
         
         # 事件引擎开关
@@ -190,6 +189,7 @@ class EventEngine2(object):
     #----------------------------------------------------------------------
     def __init__(self):
         """初始化事件引擎"""
+        self.log = logging.getLogger('root')
         # 事件队列
         self.__queue = Queue()
         

--- a/vnpy/trader/app/ctaStrategy/ctaEngine.py
+++ b/vnpy/trader/app/ctaStrategy/ctaEngine.py
@@ -18,6 +18,7 @@
 
 from __future__ import division
 
+import logging
 import json
 import os
 import traceback
@@ -46,6 +47,7 @@ class CtaEngine(object):
     #----------------------------------------------------------------------
     def __init__(self, mainEngine, eventEngine):
         """Constructor"""
+        self.log = logging.getLogger('cta')
         self.mainEngine = mainEngine
         self.eventEngine = eventEngine
         

--- a/vnpy/trader/logging.conf
+++ b/vnpy/trader/logging.conf
@@ -34,12 +34,12 @@ args=('vnpy.log', 'a')
 class=log4mongo.handlers.MongoHandler
 level=DEBUG
 # MongHandler 不可以指定formatter
-args=("DEBUG", 'localhost', 27017, 'Vnpy_Log', 'sys')
+args=("DEBUG", 'localhost', 27017, 'VnTrader_Log_Db', 'sys')
 
 [handler_mhcta]
 class=log4mongo.handlers.MongoHandler
 level=DEBUG
-args=("DEBUG", 'localhost', 27017, 'Vnpy_Log', 'cta')
+args=("DEBUG", 'localhost', 27017, 'VnTrader_Log_Db', 'cta')
 
 # 输入出的日志文本格式
 [formatters]

--- a/vnpy/trader/logging.conf
+++ b/vnpy/trader/logging.conf
@@ -1,0 +1,52 @@
+# logging 的配置文件
+# 配置说明见: http://python.usyiyi.cn/translate/python_278/library/logging.config.html#logging.config.fileConfig
+[loggers]
+keys=root,example01
+
+[logger_root]
+level=DEBUG
+handlers=fh,sh,mhsys
+
+[logger_example01]
+handlers=fh,sh,mhcta
+qualname=cta
+propagate=0
+
+[handlers]
+keys=fh,sh,mhsys,mhcta
+
+# 在终端输出
+[handler_sh]
+class=StreamHandler
+level=INFO
+formatter=form02
+args=(sys.stderr,) # logging.StreamHandler() 需要的参数
+
+# 日志文件
+[handler_fh]
+class=FileHandler
+level=DEBUG
+formatter=form01
+args=('vnpy.log', 'a')
+
+# MongoDb 来保存日志
+[handler_mhsys]
+class=log4mongo.handlers.MongoHandler
+level=DEBUG
+# MongHandler 不可以指定formatter
+args=("DEBUG", 'localhost', 27017, 'Vnpy_Log', 'sys')
+
+[handler_mhcta]
+class=log4mongo.handlers.MongoHandler
+level=DEBUG
+args=("DEBUG", 'localhost', 27017, 'Vnpy_Log', 'cta')
+
+# 输入出的日志文本格式
+[formatters]
+keys=form01,form02
+
+[formatter_form01]
+format=%(asctime)s %(filename)s[line:%(lineno)d] %(levelname)s %(message)s
+
+[formatter_form02]
+format=%(asctime)s %(filename)s[line:%(lineno)d] %(levelname)s %(message)s

--- a/vnpy/trader/vtEngine.py
+++ b/vnpy/trader/vtEngine.py
@@ -17,6 +17,10 @@ from vnpy.trader.vtGateway import *
 from vnpy.trader.language import text
 from vnpy.trader.vtFunction import getTempPath, getJsonPath
 
+# 读取日志配置文件
+loggingConFile = 'logging.conf'
+loggingConFile = getJsonPath(loggingConFile, __file__)
+logging.config.fileConfig(loggingConFile)
 
 ########################################################################
 class MainEngine(object):
@@ -25,11 +29,8 @@ class MainEngine(object):
     #----------------------------------------------------------------------
     def __init__(self, eventEngine):
         """Constructor"""
-        # 记录今日日期
-        loggingConFile = 'logging.conf'
-        loggingConFile = getJsonPath(loggingConFile, __file__)
-        logging.config.fileConfig(loggingConFile)
         self.log = logging.getLogger('root')
+        # 记录今日日期
 
         self.todayDate = datetime.now().strftime('%Y%m%d')
 

--- a/vnpy/trader/vtEngine.py
+++ b/vnpy/trader/vtEngine.py
@@ -4,6 +4,8 @@ import os
 import shelve
 from collections import OrderedDict
 from datetime import datetime
+import logging.config
+import logging
 
 from pymongo import MongoClient, ASCENDING
 from pymongo.errors import ConnectionFailure
@@ -13,7 +15,7 @@ from vnpy.trader.vtGlobal import globalSetting
 from vnpy.trader.vtEvent import *
 from vnpy.trader.vtGateway import *
 from vnpy.trader.language import text
-from vnpy.trader.vtFunction import getTempPath
+from vnpy.trader.vtFunction import getTempPath, getJsonPath
 
 
 ########################################################################
@@ -24,8 +26,13 @@ class MainEngine(object):
     def __init__(self, eventEngine):
         """Constructor"""
         # 记录今日日期
+        loggingConFile = 'logging.conf'
+        loggingConFile = getJsonPath(loggingConFile, __file__)
+        logging.config.fileConfig(loggingConFile)
+        self.log = logging.getLogger('root')
+
         self.todayDate = datetime.now().strftime('%Y%m%d')
-        
+
         # 绑定事件引擎
         self.eventEngine = eventEngine
         self.eventEngine.start()


### PR DESCRIPTION
1. 使用`logging.conf`文件来定义`logging`的参数。
2. 使用`log4mongo`模块来将日志保存到`MongoDB`。
3. 仅完成基础，尚未全面替换原有的日志接口。