### PR TITLE
从server版的linux安装的时候，需要安装qt的支持

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,9 @@ conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/f
 conda config --set show_channel_urls yes
 conda install -c quantopian ta-lib=0.4.9
 
+#Install pyqt
+conda install pyqt qtpy psutil
+
 #Install vn.py
 python setup.py install
 


### PR DESCRIPTION
如果是从server版本的linux安装，则默认是没有GUI相关支持的
需要安装pyqt相关库
