### PR TITLE
 vtEngine.py中LogEngine单例模式变更， ctaEngine.py中saveSyncData函数中字符串格式变更

### DIFF
--- a/vnpy/trader/app/ctaStrategy/ctaEngine.py
+++ b/vnpy/trader/app/ctaStrategy/ctaEngine.py
@@ -590,7 +590,7 @@ class CtaEngine(object):
         self.mainEngine.dbUpdate(POSITION_DB_NAME, strategy.className,
                                  d, flt, True)
         
-        content = '策略%s同步数据保存成功，当前持仓%s' %(strategy.name, strategy.pos)
+        content = u'策略%s同步数据保存成功，当前持仓%s' %(strategy.name, strategy.pos)
         self.writeCtaLog(content)
     
     #----------------------------------------------------------------------

--- a/vnpy/trader/vtEngine.py
+++ b/vnpy/trader/vtEngine.py
@@ -535,8 +535,24 @@ class DataEngine(object):
         
         
 ########################################################################
+class Singleton(type):
+    """
+    单例，应用方式:静态变量 __metaclass__ = Singleton
+    """
+    def __init__(cls, name, bases, dict):
+        super(Singleton, cls).__init__(name, bases, dict)
+        cls._instance = None
+
+    def __call__(cls, *args, **kw):
+        if cls._instance is None:
+            cls._instance = super(Singleton, cls).__call__(*args, **kw)
+        return cls._instance
+    
 class LogEngine(object):
     """日志引擎"""
+    
+    # 单例模式
+    __metaclass__ = Singleton
     
     # 日志级别
     LEVEL_DEBUG = logging.DEBUG
@@ -544,16 +560,6 @@ class LogEngine(object):
     LEVEL_WARN = logging.WARN
     LEVEL_ERROR = logging.ERROR
     LEVEL_CRITICAL = logging.CRITICAL
-    
-    # 单例对象
-    instance = None
-    
-    #----------------------------------------------------------------------
-    def __new__(cls, *args, **kwargs):
-        """创建对象，保证单例"""
-        if not cls.instance:
-            cls.instance = super(LogEngine, cls).__new__(cls, *args, **kwargs)
-        return cls.instance
 
     #----------------------------------------------------------------------
     def __init__(self):


### PR DESCRIPTION
## 改进内容

1. ctaEngine.py saveSyncData中的content不是unicode字符串，和上下文不一致，而且在ubuntu上会有兼容问题
2. vtEngine.py 里面的单例模式，实测下来无效，初始化几次，打印日志时同一条信息就打印几条，已经改为新的单例模式，已经经过实盘测试，可用。

## 相关的Issue号（如有）

Close # 