### PR TITLE
fix ISSUE 750

### DIFF
--- a/vnpy/trader/app/rpcService/rsClient.py
+++ b/vnpy/trader/app/rpcService/rsClient.py
@@ -104,4 +104,9 @@ class MainEngineProxy(object):
     def getApp(self, name):
         """获取应用引擎对象"""
         return self.__getattr__(name)
-        
+    
+    #----------------------------------------------------------------------
+    def exit(self):
+        self.eventEvent.stop()
+        if self.client:
+            self.client.stop()  


### PR DESCRIPTION
建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

example/serverclient/client.py
关掉Qt会调用MainEngine的exit()函数，但是由于客户端MainEngineProxy没有实现这个函数，所以client会远程调用server的exit()导致出错

## 相关的Issue号（如有）
Issue 750
Close #