### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/beta/api/coincheck/__init__.py
+++ b/beta/api/coincheck/__init__.py
@@ -1,3 +1,4 @@
 # encoding: UTF-8
 
-from vncoincheck import TradeApi, DataApi
+from __future__ import absolute_import
+from .vncoincheck import TradeApi, DataApi

--- a/beta/api/coincheck/test.py
+++ b/beta/api/coincheck/test.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
-from vncoincheck import *
+from __future__ import absolute_import
+from .vncoincheck import *
 
 def testTrade():
     """测试交易"""

--- a/beta/api/coincheck/test2.py
+++ b/beta/api/coincheck/test2.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
+from __future__ import print_function
 from coincheck import order,market,account
 
 ok = order.Order(access_key="你的accessKey", secret_key="你的secretKey")
-print ok.buy_btc_jpy(amount=0.01,rate=200)
+print(ok.buy_btc_jpy(amount=0.01,rate=200))

--- a/beta/api/coincheck/test3.py
+++ b/beta/api/coincheck/test3.py
@@ -1,6 +1,8 @@
 # encoding: utf-8
 
-from vncoincheck import *
+from __future__ import print_function
+from __future__ import absolute_import
+from .vncoincheck import *
 
 import socket
 import json
@@ -10,7 +12,7 @@ from websocket import create_connection
 ws = None
 def open():
     global ws
-    print "open"
+    print("open")
     ws.send( json.dumps({"type": "subscribe", "channel": "btc_jpy-trades"}))
 
 def testWebsocket():
@@ -20,7 +22,7 @@ def testWebsocket():
         ws = create_connection("wss://ws-api.coincheck.com/", on_open=open)
         if ws.connected:
             
-            print ws.recv()
+            print(ws.recv())
 
     sleep(5)
 

--- a/beta/api/coincheck/test4.py
+++ b/beta/api/coincheck/test4.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
-from vncoincheck import *
+from __future__ import absolute_import
+from .vncoincheck import *
 
 def test():
 

--- a/beta/api/coincheck/vncoincheck.py
+++ b/beta/api/coincheck/vncoincheck.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import print_function
 import urllib
 import hashlib
 
@@ -108,7 +109,7 @@ class TradeApi(object):
         if r != None and r.status_code == 200:
             data = r.json()
             if data['success'] == 0:
-                print "error in coincheck %s" % method
+                print("error in coincheck %s" % method)
                 return data
             else:
                 return data
@@ -116,7 +117,7 @@ class TradeApi(object):
             try:
                 data = json.loads(r.text)
                 return data
-            except Exception,ex:
+            except Exception as ex:
                 return None    
 
     #----------------------------------------------------------------------
@@ -138,12 +139,12 @@ class TradeApi(object):
                 # 请求成功
                 if data != None :
                     if self.DEBUG:
-                        print callback.__name__
+                        print(callback.__name__)
                     callback(data, req, reqID)
 
                 self.reqQueue.pop(0)
                 sleep(0.1)
-            except Exception,ex:
+            except Exception as ex:
                 pass    
 
     #----------------------------------------------------------------------
@@ -205,11 +206,11 @@ class TradeApi(object):
         return self.sendRequest( self.API_balance , FUNCTIONCODE_GET_BALANCE_COINCHECK , self.onGet_balance , None)
 
     def buy_btc_jpy(self , **kwargs):
-        print "buy_btc_jpy"
+        print("buy_btc_jpy")
         return self.sendRequest( self.API_trade , FUNCTIONCODE_BUY_ORDER_COINCHECK , self.onBuy_btc , kwargs = kwargs, optional = None)
 
     def sell_btc_jpy(self, **kwargs):
-        print "sell_btc_jpy"
+        print("sell_btc_jpy")
         return self.sendRequest( self.API_trade , FUNCTIONCODE_SELL_ORDER_COINCHECK , self.onSell_btc , kwargs = kwargs, optional = None)
 
     def list_orders(self):
@@ -225,19 +226,19 @@ class TradeApi(object):
     ## 回调函数
     ####################################################
     def onGet_info(self, data, req, reqID):
-        print data
+        print(data)
     def onGet_balance(self, data, req, reqID):
-        print data
+        print(data)
     def onBuy_btc(self, data, req, reqID):
-        print data
+        print(data)
     def onSell_btc(self, data, req, reqID):
-        print data
+        print(data)
     def onList_order(self, data, req, reqID):
-        print data
+        print(data)
     def onCancel_orders(self, data, req, reqID):
-        print data
+        print(data)
     def onHistory_orders(self, data, req, reqID):
-        print data
+        print(data)
 
 class DataApiSocket(object):
     """基于websocket的API对象"""
@@ -257,24 +258,24 @@ class DataApiSocket(object):
     #----------------------------------------------------------------------
     def onMessage(self, ws, evt):
         """信息推送""" 
-        print 'onMessage'
-        print evt
+        print('onMessage')
+        print(evt)
         
     #----------------------------------------------------------------------
     def onError(self, ws, evt):
         """错误推送"""
-        print 'onError'
-        print evt
+        print('onError')
+        print(evt)
         
     #----------------------------------------------------------------------
     def onClose(self, ws):
         """接口断开"""
-        print 'onClose'
+        print('onClose')
         
     #----------------------------------------------------------------------
     def onOpen(self, ws):
         """接口打开"""
-        print "onOpen"
+        print("onOpen")
         self.sendOrderbookRequest()
         self.sendTradesRequest()
 
@@ -415,10 +416,10 @@ class DataApi(object):
                     if r.status_code == 200:
                         data = r.json()
                         if self.DEBUG:
-                            print callback.__name__
+                            print(callback.__name__)
                         callback(data)
-                except Exception, e:
-                    print e
+                except Exception as e:
+                    print(e)
             sleep(self.taskInterval)
 
     #----------------------------------------------------------------------
@@ -445,16 +446,16 @@ class DataApi(object):
     #----------------------------------------------------------------------
     def onTick(self, data):
         """实时成交推送"""
-        print data
+        print(data)
     #----------------------------------------------------------------------
     def onTrades(self, data):
         """实时成交推送"""
-        print data
+        print(data)
 
     #----------------------------------------------------------------------
     def onOrderbooks(self, data):
         """实时成交推送"""
-        print data
+        print(data)
 
 if __name__ == '__main__':
     pass

--- a/beta/api/korbit/__init__.py
+++ b/beta/api/korbit/__init__.py
@@ -1,3 +1,4 @@
 # encoding: UTF-8
 
-from vnkorbit import Korbit_TradeApi, Korbit_DataApi , KORBIT_ALL_SYMBOL_PAIR , KORBIT_ALL_SYMBOLS
+from __future__ import absolute_import
+from .vnkorbit import Korbit_TradeApi, Korbit_DataApi , KORBIT_ALL_SYMBOL_PAIR , KORBIT_ALL_SYMBOLS

--- a/beta/api/korbit/korbit-python-master/korbit/private_api.py
+++ b/beta/api/korbit/korbit-python-master/korbit/private_api.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import absolute_import
 import time
-from public_api import PublicAPI
+from .public_api import PublicAPI
 
 
 class PrivateAPI(PublicAPI):
@@ -105,7 +107,7 @@ class PrivateAPI(PublicAPI):
             'offset': offset,
             'limit': limit
         }
-        print "user/orders" , self.headers , params
+        print("user/orders" , self.headers , params)
         return self.request_get("user/orders", headers=self.headers, params=params)
 
     def view_transfers(self, offset=0, limit=10, currency="btc"):

--- a/beta/api/korbit/korbit-python-master/korbit/public_api.py
+++ b/beta/api/korbit/korbit-python-master/korbit/public_api.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import requests
 import json
 import logging
@@ -53,9 +54,9 @@ class PublicAPI:
         return self.request_get("constants")
 
     def request_get(self, path, headers=None, params=None):
-        print urljoin(self.host, path)
+        print(urljoin(self.host, path))
         response = requests.get(urljoin(self.host, path), headers=headers, params=params, timeout=self.__timeout)
-        print response
+        print(response)
         try:
             return response.json()
         except json.decoder.JSONDecodeError as e:
@@ -63,9 +64,9 @@ class PublicAPI:
             return response.text
 
     def request_post(self, path, headers=None, data=None):
-        print urljoin(self.host, path) , headers , data 
+        print(urljoin(self.host, path) , headers , data) 
         response = requests.post(urljoin(self.host, path), headers=headers, data=data, timeout=self.__timeout)
-        print response
+        print(response)
         try:
             return response.json()
         except json.decoder.JSONDecodeError as e:

--- a/beta/api/korbit/korbit-python-master/korbit/test.py
+++ b/beta/api/korbit/korbit-python-master/korbit/test.py
@@ -1,10 +1,12 @@
 # encoding: utf-8
 
-from private_api import *
+from __future__ import print_function
+from __future__ import absolute_import
+from .private_api import *
 
 api = PrivateAPI('FssV9Jw0aZVCOYbu9YlqVNc2Rhgmh1QpruNgSVhvVmFP1iw1aPfc3APbfz0ZM', 'lSMc1TT2AZYX5pyEm01SFqx7PgMjNB18eXWpi8DQKHf0rcYhLiaiRVzJwaVZR')
 
-print api.create_token_directly('xiaoshuang8921@naver.com', 'Wxiaoshuang8921')
+print(api.create_token_directly('xiaoshuang8921@naver.com', 'Wxiaoshuang8921'))
 
 # print api.view_exchange_orders( 0 , 10 , "btc_krw")
 #api.limit_bid_order(coin_amount = 0.01 , price = 1000 , currency_pair="btc_krw")

--- a/beta/api/korbit/test.py
+++ b/beta/api/korbit/test.py
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
-from vnkorbit import Korbit_TradeApi , Korbit_DataApi
+from __future__ import absolute_import
+from .vnkorbit import Korbit_TradeApi , Korbit_DataApi
 
 apiKey = 'FssV9Jw0aZVCOYbu9YlqVNc2Rhgmh1QpruNgSVhvVmFP1iw1aPfc3APbfz0ZM'
 secretKey = 'lSMc1TT2AZYX5pyEm01SFqx7PgMjNB18eXWpi8DQKHf0rcYhLiaiRVzJwaVZR'

--- a/beta/api/korbit/vnkorbit.py
+++ b/beta/api/korbit/vnkorbit.py
@@ -1,9 +1,11 @@
 # encoding: utf-8
 
+from __future__ import print_function
 import urllib
 import hashlib
 
 import json
+import logging
 import requests
 import hmac
 import time
@@ -62,7 +64,7 @@ class Korbit_TradeApi(object):
         try:
             return response.json()
         except json.decoder.JSONDecodeError as e:
-            print "exception: {}, response_text: {}".format(e, response.text)
+            print("exception: {}, response_text: {}".format(e, response.text))
             return response.text
 
     '''
@@ -169,10 +171,10 @@ class Korbit_TradeApi(object):
         else:
             try:
                 data = json.loads(r.text)
-                print "Error in r , " , data
+                print("Error in r , " , data)
                 return data
-            except Exception,ex:
-                print ex
+            except Exception as ex:
+                print(ex)
                 return None   
 
     #----------------------------------------------------------------------
@@ -193,13 +195,13 @@ class Korbit_TradeApi(object):
                     # 请求成功
                     if data != None :
                         if self.DEBUG:
-                            print callback.__name__
+                            print(callback.__name__)
                         callback(data, req, reqID)
                     
                     sleep(0.1)
 
-            except Exception,ex:
-                print ex
+            except Exception as ex:
+                print(ex)
                 
     #----------------------------------------------------------------------
     def sendRequest(self, url , method, callback, kwargs = None,optional=None):
@@ -276,19 +278,19 @@ class Korbit_TradeApi(object):
     ## 回调函数
     ####################################################
     def on_buy_currency(self, data , req, reqID):
-        print data
+        print(data)
     #----------------------------------------------------------------------
     def on_sell_currency(self, data , req, reqID):
-        print data
+        print(data)
     #----------------------------------------------------------------------
     def on_list_exchange_orders(self, data , req, reqID):
-        print data
+        print(data)
     #----------------------------------------------------------------------
     def onCancelOrders(self, data , req, reqID):
-        print data
+        print(data)
     #----------------------------------------------------------------------
     def onBalances(self, data , req, reqID):
-        print data
+        print(data)
 
 class Korbit_DataApi(object):
 
@@ -333,10 +335,10 @@ class Korbit_DataApi(object):
                         data = r.json()
                         data["symbol"] = symbol
                         if self.DEBUG:
-                            print callback.__name__
+                            print(callback.__name__)
                         callback(data)
-                except Exception, e:
-                    print "Korbit_DataApi" , e
+                except Exception as e:
+                    print("Korbit_DataApi" , e)
             sleep(self.taskInterval)
 
     #----------------------------------------------------------------------
@@ -364,14 +366,14 @@ class Korbit_DataApi(object):
     #----------------------------------------------------------------------
     def onTick(self, data):
         """实时成交推送"""
-        print data
+        print(data)
     #----------------------------------------------------------------------
     def onTrades(self, data):
         """实时成交推送"""
-        print data
+        print(data)
 
     #----------------------------------------------------------------------
     def onOrderbooks(self, data):
         """实时成交推送"""
-        print data
+        print(data)
 

--- a/beta/api/okex/__init__.py
+++ b/beta/api/okex/__init__.py
@@ -1,3 +1,4 @@
 # encoding: UTF-8
 
-from vnokex import OkexSpotApi, OkexFuturesApi, CONTRACT_SYMBOL, SPOT_CURRENCY
+from __future__ import absolute_import
+from .vnokex import OkexSpotApi, OkexFuturesApi, CONTRACT_SYMBOL, SPOT_CURRENCY

--- a/beta/api/okex/test.py
+++ b/beta/api/okex/test.py
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
-from vnokex import *
+from __future__ import absolute_import
+from .vnokex import *
 
 # 在OkCoin网站申请这两个Key，分别对应用户名和密码
 apiKey = '你的accessKey'

--- a/beta/api/okex/vnokex.py
+++ b/beta/api/okex/vnokex.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import hashlib
 import zlib
 import json
@@ -129,23 +130,23 @@ class OkexApi(object):
     #----------------------------------------------------------------------
     def onMessage(self, ws, evt):
         """信息推送""" 
-        print evt
+        print(evt)
         
     #----------------------------------------------------------------------
     def onError(self, ws, evt):
         """错误推送"""
-        print 'onError'
-        print evt
+        print('onError')
+        print(evt)
         
     #----------------------------------------------------------------------
     def onClose(self, ws):
         """接口断开"""
-        print 'onClose'
+        print('onClose')
         
     #----------------------------------------------------------------------
     def onOpen(self, ws):
         """接口打开"""
-        print 'onOpen'
+        print('onOpen')
         
     #----------------------------------------------------------------------
     def generateSign(self, params):

--- a/beta/api/zaif/__init__.py
+++ b/beta/api/zaif/__init__.py
@@ -1,3 +1,4 @@
 # encoding: UTF-8
 
-from vnzaif import TradeApi, DataApi
+from __future__ import absolute_import
+from .vnzaif import TradeApi, DataApi

--- a/beta/api/zaif/test.py
+++ b/beta/api/zaif/test.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
-from vnzaif import *
+from __future__ import absolute_import
+from .vnzaif import *
 
 def testTrade():
     """测试交易"""

--- a/beta/api/zaif/vnzaif.py
+++ b/beta/api/zaif/vnzaif.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import print_function
 import urllib
 import hashlib
 
@@ -175,11 +176,11 @@ class TradeApi(object):
             try:
                 data = r.json()
                 if data['success'] == 0:
-                    print "error in vnzaif %s" % method
+                    print("error in vnzaif %s" % method)
                     return data
                 else:
                     return data
-            except Exception,ex:
+            except Exception as ex:
                 return None
         else:
             return None    
@@ -218,7 +219,7 @@ class TradeApi(object):
                 # 请求成功
                 else:
                     if self.DEBUG:
-                        print callback.__name__
+                        print(callback.__name__)
                     callback(data, req, reqID)
                 
             except Empty:
@@ -344,29 +345,29 @@ class TradeApi(object):
         print data
     '''
     def onTrade(self, data, req, reqID):
-        print data
+        print(data)
         
     def onCancelOrder(self, data, req, reqID):
-        print data
+        print(data)
 
     def onWithdraw(self, data, req, reqID):
-        print data
+        print(data)
 
     def onDepositHistory(self, data, req, reqID):
-        print data
+        print(data)
 
     def onWithdrawHistory(self, data, req, reqID):
-        print data
+        print(data)
 
     def onTradeHistory(self, data, req, reqID):
-        print data
+        print(data)
 
     def onActiveOrders(self, data, req, reqID):
-        print data
+        print(data)
 
     def onGet_info2(self, data, req, reqID):
         """用户信息"""
-        print data
+        print(data)
 
 
 
@@ -435,13 +436,13 @@ class DataApi(object):
                     if r.status_code == 200:
                         data = r.json()
                         if self.DEBUG:
-                            print callback.__name__
+                            print(callback.__name__)
 
                         data = {"return_symbol": (url.split('/'))[-1].split('_')[0] , "data":data}
                         #data["return_symbol"] = 
                         callback(data)
-                except Exception, e:
-                    print e
+                except Exception as e:
+                    print(e)
                     
             sleep(self.taskInterval)
 
@@ -483,18 +484,18 @@ class DataApi(object):
     #----------------------------------------------------------------------
     def onTick(self, data):
         """实时成交推送"""
-        print data
+        print(data)
 
     #----------------------------------------------------------------------
     def onLast(self, data):
         """实时深度推送"""
-        print data        
+        print(data)        
     #----------------------------------------------------------------------
     def onTrades(self, data):
         """实时深度推送"""
-        print data        
+        print(data)        
     #----------------------------------------------------------------------
     def onDepth(self, data):
         """实时深度推送"""
-        print data        
+        print(data)        
 

--- a/beta/api/zb/__init__.py
+++ b/beta/api/zb/__init__.py
@@ -1,3 +1,4 @@
 # encoding: UTF-8
 
-from vnzb import ZB_Sub_Spot_Api , zb_all_symbol_pairs , zb_all_symbols , zb_all_real_pair
+from __future__ import absolute_import
+from .vnzb import ZB_Sub_Spot_Api , zb_all_symbol_pairs , zb_all_symbols , zb_all_real_pair

--- a/beta/api/zb/test.py
+++ b/beta/api/zb/test.py
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
-from vnzb import *
+from __future__ import absolute_import
+from .vnzb import *
 
 # 在OkCoin网站申请这两个Key，分别对应用户名和密码
 apiKey = '你的apiKey'

--- a/beta/gateway/coincheckGateway/__init__.py
+++ b/beta/gateway/coincheckGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from coincheckGateway import CoincheckGateway, CoincheckTradeApi , CoincheckSocketDataApi
+from .coincheckGateway import CoincheckGateway, CoincheckTradeApi , CoincheckSocketDataApi
 
 gatewayClass = CoincheckGateway
 gatewayName = 'COINCHECK'

--- a/beta/gateway/coincheckGateway/coincheckGateway.py
+++ b/beta/gateway/coincheckGateway/coincheckGateway.py
@@ -3,6 +3,7 @@
 '''
 vn.coincheck的gateway接入
 '''
+from __future__ import print_function
 import os
 import json
 from datetime import datetime
@@ -146,7 +147,7 @@ class CoincheckGateway(VtGateway):
 
     #----------------------------------------------------------------------
     def onListOrder(self, data):
-        print data
+        print(data)
     
     #----------------------------------------------------------------------
     def setQryEnabled(self, qryEnabled):
@@ -181,7 +182,7 @@ class CoincheckTradeApi(vncoincheck.TradeApi):
     #----------------------------------------------------------------------
     
     def onError(self, method ,data):
-        print method , data 
+        print(method , data) 
     #
     '''
     "return" :
@@ -191,7 +192,7 @@ ty_status': u'identity_verified', u'id': 1007549}
     '''
     def onGet_info(self, data, req, reqID):
         """用户信息"""
-        print data
+        print(data)
     '''
     {u'zec': u'0', u'rep_debt': u'0.0', u'xem': u'0', u'lsk': u'0', u'rep_lend_in_use': u'0.0', u'ltc_de
 bt': u'0.0', u'xmr_reserved': u'0.0', u'cny': u'0', u'btc_reserved': u'0.0', u'dao_reserved': u'0.0'
@@ -215,8 +216,8 @@ u'dash': u'0', u'cny_debt': u'0.0', u'xrp_lend_in_use': u'0.0', u'xem_reserved':
     '''
     def onGet_balance(self, data, req, reqID):
         if data["success"] == 0:
-            print "Error in onGet_balance"
-            print data
+            print("Error in onGet_balance")
+            print(data)
         else:
             account = VtAccountData()
             account.gatewayName = self.gatewayName
@@ -308,8 +309,8 @@ u'id': 324141928}
         # print "onBuy_btc"
         # print data
         if data["success"] == 0:
-            print "Error in onBuy_btc"
-            print data
+            print("Error in onBuy_btc")
+            print(data)
         else:
             localID = self.reqLocalDict[reqID]
             systemID = data['id']
@@ -335,7 +336,7 @@ u'id': 324141928}
         # print data
         """卖出回调"""
         if data["success"] == 0:
-            print "Error in onSell_btc"
+            print("Error in onSell_btc")
         else:
             localID = self.reqLocalDict[reqID]
             systemID = data['id']
@@ -513,7 +514,7 @@ pending_market_buy_amount': None, u'rate': u'100.0', u'pair': u'btc_jpy', u'stop
             self.gateway.onOrder(order)
 
     def onHistory_orders(self, data, req, reqID):
-        print data
+        print(data)
 
     def cancel(self, req):
         localID = req.orderID
@@ -594,7 +595,7 @@ class CoincheckSocketDataApi(vncoincheck.DataApiSocket):
                 tick.bidPrice3, tick.bidVolume3 = bids[2]
                 tick.bidPrice4, tick.bidVolume4 = bids[3]
                 tick.bidPrice5, tick.bidVolume5 = bids[4]
-            except Exception,ex:
+            except Exception as ex:
                 pass
 
             try:
@@ -603,7 +604,7 @@ class CoincheckSocketDataApi(vncoincheck.DataApiSocket):
                 tick.askPrice3, tick.askVolume3 = asks[2]
                 tick.askPrice4, tick.askVolume4 = asks[3]
                 tick.askPrice5, tick.askVolume5 = asks[4]
-            except Exception,ex:
+            except Exception as ex:
                 pass
 
             now = datetime.now()
@@ -716,7 +717,7 @@ class CoincheckDataApi(vncoincheck.DataApi):
     #----------------------------------------------------------------------
     def onTrades(self, data):
         """实时成交推送"""
-        print data
+        print(data)
 
     #----------------------------------------------------------------------
     def onOrderbooks(self, data):

--- a/beta/gateway/korbitGateway/__init__.py
+++ b/beta/gateway/korbitGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from korbitGateway import korbitGateway
+from .korbitGateway import korbitGateway
 
 gatewayClass = korbitGateway
 gatewayName = 'KORBIT'

--- a/beta/gateway/korbitGateway/korbitGateway.py
+++ b/beta/gateway/korbitGateway/korbitGateway.py
@@ -3,6 +3,7 @@
 '''
 vn.coincheck的gateway接入
 '''
+from __future__ import print_function
 import os
 import json
 from datetime import datetime
@@ -255,13 +256,13 @@ class KorbitTradeApi(vnkorbit.Korbit_TradeApi):
 
     #--------------------------------------------------------------------
     def onError(self, method ,data):
-        print method , data 
+        print(method , data) 
 
     #--------------------------------------------------------------------
     def on_buy_currency(self, data , req, reqID):
         if data["status"] != "success":
-            print "Error in on_buy_currency"
-            print data
+            print("Error in on_buy_currency")
+            print(data)
         else:
             localID = self.reqLocalDict[reqID]
             systemID = str(data['orderId'])
@@ -286,7 +287,7 @@ class KorbitTradeApi(vnkorbit.Korbit_TradeApi):
     def on_sell_currency(self, data , req, reqID):
         """卖出回调"""
         if data["status"] != "success":
-            print "Error in on_sell_currency"
+            print("Error in on_sell_currency")
         else:
             localID = self.reqLocalDict[reqID]
             systemID = str(data['orderId'])
@@ -306,7 +307,7 @@ class KorbitTradeApi(vnkorbit.Korbit_TradeApi):
             self.tradedVolumeDict[localID] = 0.0
             self.gateway.onOrder(order)
 
-            print "what"
+            print("what")
 
     #--------------------------------------------------------------------
     def on_list_exchange_orders(self, data , req, reqID):

--- a/beta/gateway/okexGateway/__init__.py
+++ b/beta/gateway/okexGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from okexGateway import okexGateway
+from .okexGateway import okexGateway
 
 gatewayClass = okexGateway
 gatewayName = 'OKEX'

--- a/beta/gateway/okexGateway/okexGateway.py
+++ b/beta/gateway/okexGateway/okexGateway.py
@@ -6,6 +6,7 @@ vnpy.api.okex的gateway接入
 注意：
 1. 目前仅支持USD现货交易
 '''
+from __future__ import print_function
 
 import os
 import json
@@ -232,7 +233,7 @@ class SpotApi(OkexSpotApi):
         data = self.readData(evt)[0]
         try:
             channel = data['channel']
-        except Exception,ex:
+        except Exception as ex:
             channel = None
         if channel == None:
             return
@@ -310,7 +311,7 @@ class SpotApi(OkexSpotApi):
 
     #----------------------------------------------------------------------
     def spotAllOrders(self):
-        print spotAllOrders
+        print(spotAllOrders)
         for symbol in registerSymbolPairArray:
             if symbol in okex_all_symbol_pairs:
                 self.spotOrderInfo(symbol, '-1')
@@ -453,8 +454,8 @@ class SpotApi(OkexSpotApi):
             # print "ticker", tick.date, tick.time
             # newtick = copy(tick)
             # self.gateway.onTick(newtick)
-        except Exception,ex:
-            print "Error in onTicker ", channel
+        except Exception as ex:
+            print("Error in onTicker ", channel)
     
     #----------------------------------------------------------------------
     def onDepth(self, data):
@@ -464,7 +465,7 @@ class SpotApi(OkexSpotApi):
         try:
             channel = data['channel']
             symbol = self.channelSymbolMap[channel]
-        except Exception,ex:
+        except Exception as ex:
             symbol = None
 
         if symbol == None:
@@ -789,7 +790,7 @@ nel': u'ok_sub_spot_etc_usdt_order'}
     def onSpotOrderInfo(self, data):
         """委托信息查询回调"""
         if "error_code" in data.keys():
-            print data
+            print(data)
             return 
         rawData = data['data']
         for d in rawData['orders']:
@@ -839,7 +840,7 @@ nel': u'ok_sub_spot_etc_usdt_order'}
     def onSpotOrder(self, data):
         rawData = data['data']
         if 'error_code' in rawData.keys():
-            print data
+            print(data)
             return
 
         orderId = str(rawData['order_id'])

--- a/beta/gateway/zbGateway/__init__.py
+++ b/beta/gateway/zbGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from zbGateway import zbGateway
+from .zbGateway import zbGateway
 
 gatewayClass = zbGateway
 gatewayName = 'ZB'

--- a/beta/gateway/zbGateway/zbGateway.py
+++ b/beta/gateway/zbGateway/zbGateway.py
@@ -3,6 +3,7 @@
 '''
 vn.zb的gateway接入
 '''
+from __future__ import print_function
 import os
 import json
 from datetime import datetime
@@ -224,7 +225,7 @@ class ZB_API_Spot(ZB_Sub_Spot_Api):
         data = self.readData(evt)
         try:
             channel = data['channel']
-        except Exception,ex:
+        except Exception as ex:
             channel = None
         if channel == None:
             return
@@ -379,8 +380,8 @@ class ZB_API_Spot(ZB_Sub_Spot_Api):
             # print "ticker", tick.date , tick.time
             # newtick = copy(tick)
             # self.gateway.onTick(newtick)
-        except Exception,ex:
-            print "Error in onTicker " , channel
+        except Exception as ex:
+            print("Error in onTicker " , channel)
 
     #----------------------------------------------------------------------
     def onDepth(self, data):
@@ -388,7 +389,7 @@ class ZB_API_Spot(ZB_Sub_Spot_Api):
         try:
             channel = data['channel']
             symbol = self.channelSymbolMap[channel]
-        except Exception,ex:
+        except Exception as ex:
             symbol = None
 
         if symbol == None:
@@ -605,7 +606,7 @@ class ZB_API_Spot(ZB_Sub_Spot_Api):
         # 现在的处理方式是， 先缓存这里的信息，等到出现了 localID，再来处理这一段
         localNo = self.orderIdDict.get(orderId , None)
         if localNo == None:
-            print "Error , localNo is none !" + str(localNo)
+            print("Error , localNo is none !" + str(localNo))
             return 
 
         # 委托信息
@@ -812,8 +813,8 @@ class ZB_API_Spot(ZB_Sub_Spot_Api):
             rawData = json.loads(rawData)
             coins = rawData["coins"]
 
-        except Exception,ex:
-            print ex
+        except Exception as ex:
+            print(ex)
 
         for coin in coins:
             symbol = coin["cnName"].lower()

--- a/beta/spreadtrading/stBase.py
+++ b/beta/spreadtrading/stBase.py
@@ -184,8 +184,8 @@ class StSpread(object):
         askok = True
         
         for k in self.code.co_names :
-            bidok = bidok and legbidglobal.has_key(k)
-            askok = askok and legaskglobal.has_key(k)
+            bidok = bidok and k in legbidglobal
+            askok = askok and k in legaskglobal
         
         if bidok and askok :
             self.bidPrice = eval(self.code,legbidglobal)

--- a/examples/CtaBacktesting/runOptimization.py
+++ b/examples/CtaBacktesting/runOptimization.py
@@ -5,6 +5,7 @@
 """
 
 from __future__ import division
+from __future__ import print_function
 
 
 from vnpy.trader.app.ctaStrategy.ctaBacktesting import BacktestingEngine, MINUTE_DB_NAME, OptimizationSetting
@@ -49,4 +50,4 @@ if __name__ == '__main__':
     # 多进程优化，耗时：89秒
     engine.runParallelOptimization(AtrRsiStrategy, setting)
     
-    print u'耗时：%s' %(time.time()-start)
+    print(u'耗时：%s' %(time.time()-start))

--- a/examples/CtaTrading/runCtaTrading.py
+++ b/examples/CtaTrading/runCtaTrading.py
@@ -1,5 +1,11 @@
 # encoding: UTF-8
 
+from __future__ import print_function
+
+try:
+    reload         # Python 2
+except NameError:  # Python 3
+    from importlib import reload
 import sys
 reload(sys)
 sys.setdefaultencoding('utf8')
@@ -24,50 +30,50 @@ def processErrorEvent(event):
     错误信息在每次登陆后，会将当日所有已产生的均推送一遍，所以不适合写入日志
     """
     error = event.dict_['data']
-    print u'错误代码：%s，错误信息：%s' %(error.errorID, error.errorMsg)
-    
+    print(u'错误代码：%s，错误信息：%s' %(error.errorID, error.errorMsg))
+
 #----------------------------------------------------------------------
 def runChildProcess():
     """子进程运行函数"""
-    print '-'*20
-    
+    print('-'*20)
+
     # 创建日志引擎
     le = LogEngine()
     le.setLogLevel(le.LEVEL_INFO)
     le.addConsoleHandler()
     le.addFileHandler()
-    
+
     le.info(u'启动CTA策略运行子进程')
-    
+
     ee = EventEngine2()
     le.info(u'事件引擎创建成功')
-    
+
     me = MainEngine(ee)
     me.addGateway(ctpGateway)
     me.addApp(ctaStrategy)
     le.info(u'主引擎创建成功')
-    
+
     ee.register(EVENT_LOG, le.processLogEvent)
     ee.register(EVENT_CTA_LOG, le.processLogEvent)
     ee.register(EVENT_ERROR, processErrorEvent)
     le.info(u'注册日志事件监听')
-    
+
     me.connect('CTP')
     le.info(u'连接CTP接口')
-    
+
     sleep(10)    # 等待CTP接口初始化
-    
+
     cta = me.getApp(ctaStrategy.appName)
-    
+
     cta.loadSetting()
     le.info(u'CTA策略载入成功')
-    
+
     cta.initAll()
     le.info(u'CTA策略初始化成功')
-    
+
     cta.startAll()
     le.info(u'CTA策略启动成功')
-    
+
     while True:
         sleep(1)
 
@@ -78,34 +84,34 @@ def runParentProcess():
     le = LogEngine()
     le.setLogLevel(le.LEVEL_INFO)
     le.addConsoleHandler()
-    
+
     le.info(u'启动CTA策略守护父进程')
-    
+
     DAY_START = time(8, 45)         # 日盘启动和停止时间
     DAY_END = time(15, 30)
-    
+
     NIGHT_START = time(20, 45)      # 夜盘启动和停止时间
     NIGHT_END = time(2, 45)
-    
+
     p = None        # 子进程句柄
-    
+
     while True:
         currentTime = datetime.now().time()
         recording = False
-        
+
         # 判断当前处于的时间段
         if ((currentTime >= DAY_START and currentTime <= DAY_END) or
             (currentTime >= NIGHT_START) or
             (currentTime <= NIGHT_END)):
             recording = True
-        
+
         # 记录时间则需要启动子进程
         if recording and p is None:
             le.info(u'启动子进程')
             p = multiprocessing.Process(target=runChildProcess)
             p.start()
             le.info(u'子进程启动成功')
-            
+
         # 非记录时间则退出子进程
         if not recording and p is not None:
             le.info(u'关闭子进程')
@@ -113,12 +119,12 @@ def runParentProcess():
             p.join()
             p = None
             le.info(u'子进程关闭成功')
-            
+
         sleep(5)
 
 
 if __name__ == '__main__':
     runChildProcess()
-    
+
     # 尽管同样实现了无人值守，但强烈建议每天启动时人工检查，为自己的PNL负责
     #runParentProcess()

--- a/examples/DataRecording/runDataCleaning.py
+++ b/examples/DataRecording/runDataCleaning.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import json
 from datetime import datetime, timedelta, time
 
@@ -22,7 +23,7 @@ NIGHT_END = time(2, 30)
 #----------------------------------------------------------------------
 def cleanData(dbName, collectionName, start):
     """清洗数据"""
-    print u'\n清洗数据库：%s, 集合：%s, 起始日：%s' %(dbName, collectionName, start)
+    print(u'\n清洗数据库：%s, 集合：%s, 起始日：%s' %(dbName, collectionName, start))
     
     mc = MongoClient('localhost', 27017)    # 创建MongoClient
     cl = mc[dbName][collectionName]         # 获取数据集合
@@ -47,17 +48,17 @@ def cleanData(dbName, collectionName, start):
         
         # 如果需要清洗
         if cleanRequired:
-            print u'删除无效数据，时间戳：%s' %data['datetime']
+            print(u'删除无效数据，时间戳：%s' %data['datetime'])
             cl.delete_one(data)
     
-    print u'清洗完成，数据库：%s, 集合：%s' %(dbName, collectionName)
+    print(u'清洗完成，数据库：%s, 集合：%s' %(dbName, collectionName))
     
 
 
 #----------------------------------------------------------------------
 def runDataCleaning():
     """运行数据清洗"""
-    print u'开始数据清洗工作'
+    print(u'开始数据清洗工作')
     
     # 加载配置
     setting = {}
@@ -77,7 +78,7 @@ def runDataCleaning():
         symbol = l[0]
         cleanData(MINUTE_DB_NAME, symbol, start)
     
-    print u'数据清洗工作完成'
+    print(u'数据清洗工作完成')
     
 
 if __name__ == '__main__':

--- a/examples/DataRecording/runDataRecording.py
+++ b/examples/DataRecording/runDataRecording.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import multiprocessing
 from time import sleep
 from datetime import datetime, time
@@ -18,12 +19,12 @@ def processErrorEvent(event):
     错误信息在每次登陆后，会将当日所有已产生的均推送一遍，所以不适合写入日志
     """
     error = event.dict_['data']
-    print u'错误代码：%s，错误信息：%s' %(error.errorID, error.errorMsg)
+    print(u'错误代码：%s，错误信息：%s' %(error.errorID, error.errorMsg))
 
 #----------------------------------------------------------------------
 def runChildProcess():
     """子进程运行函数"""
-    print '-'*20
+    print('-'*20)
 
     # 创建日志引擎
     le = LogEngine()

--- a/examples/FutuDataService/dataService.py
+++ b/examples/FutuDataService/dataService.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import sys
 import json
 from datetime import datetime, timedelta
@@ -56,7 +57,7 @@ def downMinuteBarBySymbol(symbol):
     
     code, data = quote.get_history_kline(symbol, start=startDate, ktype='K_1M')
     if code:
-        print u'合约%s数据下载失败：%s' %(symbol, data)
+        print(u'合约%s数据下载失败：%s' %(symbol, data))
         return
         
     data = data.sort_index()
@@ -70,24 +71,24 @@ def downMinuteBarBySymbol(symbol):
     end = time()
     cost = (end - start) * 1000
 
-    print u'合约%s数据下载完成%s - %s，耗时%s毫秒' %(symbol, data.iloc[0]['time_key'], 
-                                                  data.iloc[-1]['time_key'], cost)
+    print(u'合约%s数据下载完成%s - %s，耗时%s毫秒' %(symbol, data.iloc[0]['time_key'], 
+                                                  data.iloc[-1]['time_key'], cost))
 
     
 #----------------------------------------------------------------------
 def downloadAllMinuteBar():
     """下载所有配置中的合约的分钟线数据"""
-    print '-' * 50
-    print u'开始下载合约分钟线数据'
-    print '-' * 50
+    print('-' * 50)
+    print(u'开始下载合约分钟线数据')
+    print('-' * 50)
     
     # 添加下载任务
     for symbol in SYMBOLS:
         downMinuteBarBySymbol(str(symbol))
     
-    print '-' * 50
-    print u'合约分钟线数据下载完成'
-    print '-' * 50
+    print('-' * 50)
+    print(u'合约分钟线数据下载完成')
+    print('-' * 50)
     
 
 

--- a/examples/FutuDataService/runService.py
+++ b/examples/FutuDataService/runService.py
@@ -3,6 +3,7 @@
 """
 定时服务，可无人值守运行，实现每日自动下载更新历史行情数据到数据库中。
 """
+from __future__ import print_function
 
 import time
 import datetime
@@ -27,6 +28,6 @@ if __name__ == '__main__':
             # 更新任务完成的日期
             taskCompletedDate = t.date()
         else:
-            print u'当前时间%s，任务定时%s' %(t, taskTime)
+            print(u'当前时间%s，任务定时%s' %(t, taskTime))
     
         time.sleep(60)

--- a/examples/JaqsService/run.py
+++ b/examples/JaqsService/run.py
@@ -1,6 +1,10 @@
 # encoding: UTF-8
 
 # 重载sys模块，设置默认字符串编码方式为utf8
+try:
+    reload         # Python 2
+except NameError:  # Python 3
+    from importlib import reload
 import sys
 reload(sys)
 sys.setdefaultencoding('utf8')
@@ -28,24 +32,24 @@ def main():
     le.setLogLevel(le.LEVEL_INFO)
     le.addConsoleHandler()
     le.addFileHandler()
-    
+
     le.info(u'启动JAQS服务进程')
-    
+
     ee = EventEngine()
     le.info(u'事件引擎创建成功')
-    
+
     me = MainEngine(ee)
     me.addGateway(ctpGateway)
     me.addApp(jaqsService)
     le.info(u'主引擎创建成功')
-    
+
     ee.register(EVENT_LOG, le.processLogEvent)
     ee.register(EVENT_JS_LOG, le.processLogEvent)
-    le.info(u'注册日志事件监听')    
-    
+    le.info(u'注册日志事件监听')
+
     me.connect('CTP')
-    le.info(u'连接CTP接口')    
-    
+    le.info(u'连接CTP接口')
+
     while True:
         sleep(1)
 

--- a/examples/JaqsService/runUI.py
+++ b/examples/JaqsService/runUI.py
@@ -1,6 +1,10 @@
 # encoding: UTF-8
 
 # 重载sys模块，设置默认字符串编码方式为utf8
+try:
+    reload         # Python 2
+except NameError:  # Python 3
+    from importlib import reload
 import sys
 reload(sys)
 sys.setdefaultencoding('utf8')
@@ -26,23 +30,23 @@ def main():
     """主程序入口"""
     # 创建Qt应用对象
     qApp = createQApp()
-    
+
     # 创建事件引擎
     ee = EventEngine()
-    
+
     # 创建主引擎
     me = MainEngine(ee)
-    
+
     # 添加交易接口
     me.addGateway(ctpGateway)
-    
+
     # 添加上层应用
     me.addApp(jaqsService)
-    
+
     # 创建主窗口
     mw = MainWindow(me, ee)
     mw.showMaximized()
-    
+
     # 在主线程中启动Qt事件循环
     sys.exit(qApp.exec_())
 

--- a/examples/OptionMaster/run.py
+++ b/examples/OptionMaster/run.py
@@ -1,6 +1,10 @@
 # encoding: UTF-8
 
 # 重载sys模块，设置默认字符串编码方式为utf8
+try:
+    reload         # Python 2
+except NameError:  # Python 3
+    from importlib import reload
 import sys
 reload(sys)
 sys.setdefaultencoding('utf8')
@@ -29,26 +33,26 @@ def main():
     """主程序入口"""
     # 创建Qt应用对象
     qApp = createQApp()
-    
+
     # 创建事件引擎
     ee = EventEngine()
-    
+
     # 创建主引擎
     me = MainEngine(ee)
-    
+
     # 添加交易接口
     me.addGateway(secGateway)
     me.addGateway(ctpGateway)
     me.addGateway(ctpsecGateway)
-        
+
     # 添加上层应用
     me.addApp(riskManager)
     me.addApp(optionMaster)
-    
+
     # 创建主窗口
     mw = MainWindow(me, ee)
     mw.showMaximized()
-    
+
     # 在主线程中启动Qt事件循环
     sys.exit(qApp.exec_())
 

--- a/examples/QuantosDataService/dataService.py
+++ b/examples/QuantosDataService/dataService.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import sys
 import json
 from datetime import datetime, timedelta
@@ -123,15 +124,15 @@ def downMinuteBarBySymbol(api, vtSymbol, startDate, endDate=''):
     e = time()
     cost = (e - start) * 1000
 
-    print u'合约%s数据下载完成%s - %s，耗时%s毫秒' %(vtSymbol, startDate, end.strftime('%Y%m%d'), cost)
+    print(u'合约%s数据下载完成%s - %s，耗时%s毫秒' %(vtSymbol, startDate, end.strftime('%Y%m%d'), cost))
 
     
 #----------------------------------------------------------------------
 def downloadAllMinuteBar(api, days=10):
     """下载所有配置中的合约的分钟线数据"""
-    print '-' * 50
-    print u'开始下载合约分钟线数据'
-    print '-' * 50
+    print('-' * 50)
+    print(u'开始下载合约分钟线数据')
+    print('-' * 50)
     
     startDt = datetime.today() - days * timedelta(1)
     startDate = startDt.strftime('%Y%m%d')
@@ -140,7 +141,7 @@ def downloadAllMinuteBar(api, days=10):
     for symbol in SYMBOLS:
         downMinuteBarBySymbol(api, str(symbol), startDate)
     
-    print '-' * 50
-    print u'合约分钟线数据下载完成'
-    print '-' * 50
+    print('-' * 50)
+    print(u'合约分钟线数据下载完成')
+    print('-' * 50)
     

--- a/examples/QuantosDataService/downloadData.py
+++ b/examples/QuantosDataService/downloadData.py
@@ -3,6 +3,7 @@
 """
 立即下载数据到数据库中，用于手动执行更新操作。
 """
+from __future__ import print_function
 
 import json
 
@@ -16,7 +17,7 @@ if __name__ == '__main__':
     info, msg = api.login(USERNAME, TOKEN)
     
     if not info:
-        print u'数据服务器登录失败，原因：%s' %msg    
+        print(u'数据服务器登录失败，原因：%s' %msg)    
 
     # 下载数据
     downloadAllMinuteBar(api, 100)

--- a/examples/QuantosDataService/runService.py
+++ b/examples/QuantosDataService/runService.py
@@ -3,6 +3,7 @@
 """
 定时服务，可无人值守运行，实现每日自动下载更新历史行情数据到数据库中。
 """
+from __future__ import print_function
 
 import datetime as ddt
 
@@ -26,7 +27,7 @@ if __name__ == '__main__':
             info, msg = api.login(USERNAME, TOKEN)
             
             if not info:
-                print u'数据服务器登录失败，原因：%s' %msg    
+                print(u'数据服务器登录失败，原因：%s' %msg)    
         
             # 下载数据
             downloadAllMinuteBar(api)            
@@ -34,6 +35,6 @@ if __name__ == '__main__':
             # 更新任务完成的日期
             taskCompletedDate = t.date()
         else:
-            print u'当前时间%s，任务定时%s' %(t, taskTime)
+            print(u'当前时间%s，任务定时%s' %(t, taskTime))
     
         sleep(60)

--- a/examples/ServerClient/client.py
+++ b/examples/ServerClient/client.py
@@ -1,6 +1,10 @@
 # encoding: UTF-8
 
 # 重载sys模块，设置默认字符串编码方式为utf8
+try:
+    reload         # Python 2
+except NameError:  # Python 3
+    from importlib import reload
 import sys
 reload(sys)
 sys.setdefaultencoding('utf8')
@@ -20,20 +24,20 @@ def main():
     """主程序入口"""
     # 创建Qt应用对象
     qApp = createQApp()
-    
+
     # 创建事件引擎
     ee = EventEngine()
-    
+
     # 创建主引擎
     reqAddress = 'tcp://localhost:2014'
-    subAddress = 'tcp://localhost:0602'    
+    subAddress = 'tcp://localhost:0602'
     me = MainEngineProxy(ee)
     me.init(reqAddress, subAddress)
-    
+
     # 创建主窗口
     mw = MainWindow(me, ee)
     mw.showMaximized()
-    
+
     # 在主线程中启动Qt事件循环
     sys.exit(qApp.exec_())
 

--- a/examples/ServerClient/server.py
+++ b/examples/ServerClient/server.py
@@ -1,6 +1,10 @@
 # encoding: UTF-8
 
 # 重载sys模块，设置默认字符串编码方式为utf8
+try:
+    reload         # Python 2
+except NameError:  # Python 3
+    from importlib import reload
 import sys
 reload(sys)
 sys.setdefaultencoding('utf8')
@@ -20,30 +24,30 @@ from vnpy.trader.app import ctaStrategy, rpcService
 
 #----------------------------------------------------------------------
 def main():
-    """主程序入口"""    
+    """主程序入口"""
     le = LogEngine()
     le.setLogLevel(le.LEVEL_INFO)
     le.addConsoleHandler()
     le.addFileHandler()
 
     le.info(u'服务器进程启动')
-    
+
     # 创建事件引擎
     ee = EventEngine2()
     le.info(u'事件引擎创建成功')
-    
+
     # 创建主引擎
     me = MainEngine(ee)
-    
+
     # 添加交易接口
     me.addGateway(ctpGateway)
-    
+
     # 添加上层应用
     me.addApp(ctaStrategy)
     me.addApp(rpcService)
-    
+
     le.info(u'主引擎创建成功')
-    
+
     # 阻塞运行
     le.info(u'服务器启动成功')
     while 1:

--- a/examples/ShcifcoDataService/dataService.py
+++ b/examples/ShcifcoDataService/dataService.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import json
 import time
 import datetime
@@ -57,7 +58,7 @@ def downMinuteBarBySymbol(symbol, num):
     
     l = api.getHisBar(symbol, num, period=PERIOD_1MIN)
     if not l:
-        print u'%s数据下载失败' %symbol
+        print(u'%s数据下载失败' %symbol)
         return
     
     for d in l:
@@ -69,23 +70,23 @@ def downMinuteBarBySymbol(symbol, num):
     end = time.time()
     cost = (end - start) * 1000
 
-    print u'合约%s数据下载完成%s - %s，耗时%s毫秒' %(symbol, generateVtBar(l[0]).datetime,
-                                                  generateVtBar(l[-1]).datetime, cost)
+    print(u'合约%s数据下载完成%s - %s，耗时%s毫秒' %(symbol, generateVtBar(l[0]).datetime,
+                                                  generateVtBar(l[-1]).datetime, cost))
 
 #----------------------------------------------------------------------
 def downloadAllMinuteBar(num):
     """下载所有配置中的合约的分钟线数据"""
-    print '-' * 50
-    print u'开始下载合约分钟线数据'
-    print '-' * 50
+    print('-' * 50)
+    print(u'开始下载合约分钟线数据')
+    print('-' * 50)
     
     for symbol in SYMBOLS:
         downMinuteBarBySymbol(symbol, num)
         time.sleep(1)
 
-    print '-' * 50
-    print u'合约分钟线数据下载完成'
-    print '-' * 50
+    print('-' * 50)
+    print(u'合约分钟线数据下载完成')
+    print('-' * 50)
 
 
     

--- a/examples/ShcifcoDataService/runService.py
+++ b/examples/ShcifcoDataService/runService.py
@@ -3,6 +3,7 @@
 """
 定时服务，可无人值守运行，实现每日自动下载更新历史行情数据到数据库中。
 """
+from __future__ import print_function
 
 from dataService import *
 
@@ -25,6 +26,6 @@ if __name__ == '__main__':
             # 更新任务完成的日期
             taskCompletedDate = t.date()
         else:
-            print u'当前时间%s，任务定时%s' %(t, taskTime)
+            print(u'当前时间%s，任务定时%s' %(t, taskTime))
     
         time.sleep(60)

--- a/examples/TqDataService/dataService.py
+++ b/examples/TqDataService/dataService.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import sys
 import json
 from datetime import datetime
@@ -68,7 +69,7 @@ def onChart(symbol, seconds):
     
     start = datetime.fromtimestamp(l[0]['datetime']/1000000000)
     end = datetime.fromtimestamp(l[-1]['datetime']/1000000000)
-    print u'合约%s下载完成%s - %s' %(symbol, start, end)
+    print(u'合约%s下载完成%s - %s' %(symbol, start, end))
     
     # 移除已经完成的任务
     if symbol in taskList:
@@ -82,9 +83,9 @@ def downMinuteBarBySymbol(symbol, num):
 #----------------------------------------------------------------------
 def downloadAllMinuteBar(num):
     """下载所有配置中的合约的分钟线数据"""
-    print '-' * 50
-    print u'开始下载合约分钟线数据'
-    print '-' * 50
+    print('-' * 50)
+    print(u'开始下载合约分钟线数据')
+    print('-' * 50)
     
     # 添加下载任务
     taskList.extend(SYMBOLS)
@@ -97,9 +98,9 @@ def downloadAllMinuteBar(num):
 
         # 如果任务列表为空，则说明数据已经全部下载完成
         if not taskList:
-            print '-' * 50
-            print u'合约分钟线数据下载完成'
-            print '-' * 50
+            print('-' * 50)
+            print(u'合约分钟线数据下载完成')
+            print('-' * 50)
             return       
     
 

--- a/examples/TqDataService/runService.py
+++ b/examples/TqDataService/runService.py
@@ -3,6 +3,7 @@
 """
 定时服务，可无人值守运行，实现每日自动下载更新历史行情数据到数据库中。
 """
+from __future__ import print_function
 
 import time
 import datetime
@@ -28,6 +29,6 @@ if __name__ == '__main__':
             # 更新任务完成的日期
             taskCompletedDate = t.date()
         else:
-            print u'当前时间%s，任务定时%s' %(t, taskTime)
+            print(u'当前时间%s，任务定时%s' %(t, taskTime))
     
         time.sleep(60)

--- a/examples/TushareDataService/dataService.py
+++ b/examples/TushareDataService/dataService.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import sys
 import json
 from datetime import datetime
@@ -72,23 +73,23 @@ def downMinuteBarBySymbol(symbol):
     end = time()
     cost = (end - start) * 1000
 
-    print u'合约%s数据下载完成%s - %s，耗时%s毫秒' %(symbol, df.index[0], df.index[-1], cost)
+    print(u'合约%s数据下载完成%s - %s，耗时%s毫秒' %(symbol, df.index[0], df.index[-1], cost))
 
     
 #----------------------------------------------------------------------
 def downloadAllMinuteBar():
     """下载所有配置中的合约的分钟线数据"""
-    print '-' * 50
-    print u'开始下载合约分钟线数据'
-    print '-' * 50
+    print('-' * 50)
+    print(u'开始下载合约分钟线数据')
+    print('-' * 50)
     
     # 添加下载任务
     for symbol in SYMBOLS:
         downMinuteBarBySymbol(str(symbol))
     
-    print '-' * 50
-    print u'合约分钟线数据下载完成'
-    print '-' * 50
+    print('-' * 50)
+    print(u'合约分钟线数据下载完成')
+    print('-' * 50)
     
 
 

--- a/examples/TushareDataService/runService.py
+++ b/examples/TushareDataService/runService.py
@@ -3,6 +3,7 @@
 """
 定时服务，可无人值守运行，实现每日自动下载更新历史行情数据到数据库中。
 """
+from __future__ import print_function
 
 import time
 import datetime
@@ -27,6 +28,6 @@ if __name__ == '__main__':
             # 更新任务完成的日期
             taskCompletedDate = t.date()
         else:
-            print u'当前时间%s，任务定时%s' %(t, taskTime)
+            print(u'当前时间%s，任务定时%s' %(t, taskTime))
     
         time.sleep(60)

--- a/examples/VnTrader/run.py
+++ b/examples/VnTrader/run.py
@@ -1,6 +1,10 @@
 # encoding: UTF-8
 
 # 重载sys模块，设置默认字符串编码方式为utf8
+try:
+    reload         # Python 2
+except NameError:  # Python 3
+    from importlib import reload
 import sys
 reload(sys)
 sys.setdefaultencoding('utf8')
@@ -16,11 +20,11 @@ from vnpy.trader.uiQt import createQApp
 from vnpy.trader.uiMainWindow import MainWindow
 
 # 加载底层接口
-from vnpy.trader.gateway import (ctpGateway, oandaGateway, 
+from vnpy.trader.gateway import (ctpGateway, oandaGateway,
                                  ibGateway)
 
 if system == 'Windows':
-    from vnpy.trader.gateway import (femasGateway, xspeedGateway, 
+    from vnpy.trader.gateway import (femasGateway, xspeedGateway,
                                      futuGateway, secGateway)
 
 # 加载上层应用
@@ -32,36 +36,36 @@ def main():
     """主程序入口"""
     # 创建Qt应用对象
     qApp = createQApp()
-    
+
     # 创建事件引擎
     ee = EventEngine()
-    
+
     # 创建主引擎
     me = MainEngine(ee)
-    
+
     # 添加交易接口
     me.addGateway(ctpGateway)
     me.addGateway(oandaGateway)
     me.addGateway(ibGateway)
-    
+
     if system == 'Windows':
         me.addGateway(femasGateway)
         me.addGateway(xspeedGateway)
         me.addGateway(secGateway)
         me.addGateway(futuGateway)
-        
+
     if system == 'Linux':
         me.addGateway(xtpGateway)
-        
+
     # 添加上层应用
     me.addApp(riskManager)
     me.addApp(ctaStrategy)
     me.addApp(spreadTrading)
-    
+
     # 创建主窗口
     mw = MainWindow(me, ee)
     mw.showMaximized()
-    
+
     # 在主线程中启动Qt事件循环
     sys.exit(qApp.exec_())
 

--- a/examples/VnTrader/run_simple.py
+++ b/examples/VnTrader/run_simple.py
@@ -1,8 +1,11 @@
 # encoding: UTF-8
 
 # 重载sys模块，设置默认字符串编码方式为utf8
+try:
+    reload         # Python 2
+except NameError:  # Python 3
+    from importlib import reload
 import sys
-
 reload(sys)
 sys.setdefaultencoding('utf8')
 

--- a/examples/WebTrader/run.py
+++ b/examples/WebTrader/run.py
@@ -1,6 +1,12 @@
 # encoding: UTF-8
 
 # 修改编码
+from __future__ import print_function
+
+try:
+    reload         # Python 2
+except NameError:  # Python 3
+    from importlib import reload
 import sys
 reload(sys)
 sys.setdefaultencoding('utf8')
@@ -15,7 +21,7 @@ from vnpy.trader.app.rpcService.rsClient import MainEngineProxy
 from vnpy.trader.app.ctaStrategy.ctaBase import EVENT_CTA_LOG, EVENT_CTA_STRATEGY
 
 reqAddress = 'tcp://localhost:6688'
-subAddress = 'tcp://localhost:8866'    
+subAddress = 'tcp://localhost:8866'
 
 ee = EventEngine2()
 me = MainEngineProxy(ee)
@@ -25,10 +31,10 @@ me.init(reqAddress, subAddress)
 def printLog(event):
     """打印日志"""
     log = event.dict_['data']
-    print log.logTime, log.logContent
-    
+    print(log.logTime, log.logContent)
+
 ee.register(EVENT_LOG, printLog)
-    
+
 
 # 载入Web密码
 import json
@@ -59,7 +65,7 @@ socketio = SocketIO(app)
 ########################################################################
 class Token(Resource):
     """登录验证"""
-    
+
     #----------------------------------------------------------------------
     def __init__(self):
         """初始化"""
@@ -67,14 +73,14 @@ class Token(Resource):
         self.parser.add_argument('username')
         self.parser.add_argument('password')
         super(Token, self).__init__()
-    
+
     #----------------------------------------------------------------------
     def get(self):
         """查询"""
         args = self.parser.parse_args()
         username = args['username']
         password = args['password']
-        
+
         if username == USERNAME and password == PASSWORD:
             return {'result_code':'success','data':TOKEN}
         else:
@@ -84,39 +90,39 @@ class Token(Resource):
 ########################################################################
 class Gateway(Resource):
     """接口"""
-    
+
     #----------------------------------------------------------------------
     def __init__(self):
         """初始化"""
         self.parser = reqparse.RequestParser()
         self.parser.add_argument('gatewayName')
         self.parser.add_argument('token')
-        
+
         super(Gateway, self).__init__()
-    
+
     #----------------------------------------------------------------------
     def get(self):
         """查询"""
         args = self.parser.parse_args()
         token = args['token']
-        print token
-        print TOKEN
+        print(token)
+        print(TOKEN)
         if token != TOKEN:
-            print 'token error'
+            print('token error')
             return {'result_code':'error','message':'token error'}
-        
+
         l = me.getAllGatewayDetails()
         return {'result_code':'success','data':l}
-    
+
     #----------------------------------------------------------------------
     def post(self):
         """连接"""
         args = self.parser.parse_args()
         token = args['token']
         if token != TOKEN:
-            print 'token error'
+            print('token error')
             return {'result_code':'error','message':'token error'}
-                
+
         gatewayName = args['gatewayName']
         me.connect(gatewayName)
         return {'result_code':'success','data':''}
@@ -129,9 +135,9 @@ class Order(Resource):
     #----------------------------------------------------------------------
     def __init__(self):
         """初始化"""
-        self.getParser = reqparse.RequestParser()    
+        self.getParser = reqparse.RequestParser()
         self.getParser.add_argument('token')
-        
+
         self.postParser = reqparse.RequestParser()
         self.postParser.add_argument('vtSymbol')
         self.postParser.add_argument('price')
@@ -140,13 +146,13 @@ class Order(Resource):
         self.postParser.add_argument('direction')
         self.postParser.add_argument('offset')
         self.postParser.add_argument('token')
-        
+
         self.deleteParser = reqparse.RequestParser()
-        self.deleteParser.add_argument('vtOrderID')        
+        self.deleteParser.add_argument('vtOrderID')
         self.deleteParser.add_argument('token')
-        
+
         super(Order, self).__init__()
-    
+
     #----------------------------------------------------------------------
     def get(self):
         """查询"""
@@ -154,11 +160,11 @@ class Order(Resource):
         token = args['token']
         if token != TOKEN:
             return {'result_code':'error','message':'token error'}
-        
+
         data = me.getAllOrders()
         l = [o.__dict__ for o in data]
         return {'result_code':'success','data':l}
-    
+
     #----------------------------------------------------------------------
     def post(self):
         """发单"""
@@ -166,22 +172,22 @@ class Order(Resource):
         token = args['token']
         if token != TOKEN:
             return {'result_code':'error','message':'token error'}
-        print args
-        vtSymbol = args['vtSymbol']        
-        price = args['price']        
-        volume = args['volume']        
-        priceType = args['priceType']        
-        direction = args['direction']        
-        offset = args['offset']      
-        
+        print(args)
+        vtSymbol = args['vtSymbol']
+        price = args['price']
+        volume = args['volume']
+        priceType = args['priceType']
+        direction = args['direction']
+        offset = args['offset']
+
         contract = me.getContract(vtSymbol)
         if not contract:
             return {'result_code':'error','message':'contract error'}
-        
+
         priceType_map = {'PRICETYPE_LIMITPRICE' : u'限价','PRICETYPE_MARKETPRICE' : u'市价','PRICETYPE_FAK' : u'FAK','PRICETYPE_FOK' : u'FOK'}
         direction_map = {'DIRECTION_LONG' : u'多','DIRECTION_SHORT' : u'空'}
         offset_map    = {'OFFSET_OPEN' : u'开仓',  'OFFSET_CLOSE' : u'平仓','OFFSET_CLOSETODAY' : u'平今','OFFSET_CLOSEYESTERDAY' : u'平昨'}
-        
+
         req = VtOrderReq()
         req.symbol    = contract.symbol
         req.exchange  = contract.exchange
@@ -192,7 +198,7 @@ class Order(Resource):
         req.offset    = offset_map[ offset ]
         vtOrderID     = me.sendOrder(req, contract.gatewayName)
         return {'result_code':'success','data':vtOrderID}
-    
+
     #----------------------------------------------------------------------
     def delete(self):
         """撤单"""
@@ -200,25 +206,25 @@ class Order(Resource):
         token = args['token']
         if token != TOKEN:
             return {'result_code':'error','message':'token error'}
-        
+
         vtOrderID = args['vtOrderID']
-        
+
         # 撤单某一委托
         if vtOrderID:
             order = me.getOrder(vtOrderID)
             if not order:
                 return {'result_code':'error','message':'vtOrderID error'}
-            
+
             self.cancel(order)
         # 全撤
         else:
             l = me.getAllWorkingOrders()
-            
+
             for order in l:
                 self.cancel(order)
-            
+
         return {'result_code':'success','data':""}
-    
+
     #----------------------------------------------------------------------
     def cancel(self, order):
         """撤单"""
@@ -228,20 +234,20 @@ class Order(Resource):
         req.symbol = order.symbol
         req.frontID = order.frontID
         req.sessionID = order.sessionID
-        me.cancelOrder(req, order.gatewayName)                
+        me.cancelOrder(req, order.gatewayName)
 
 
 ########################################################################
 class Trade(Resource):
     """成交"""
-    
+
     #----------------------------------------------------------------------
     def __init__(self):
         """初始化"""
         self.parser = reqparse.RequestParser()
         self.parser.add_argument('token')
-        
-        super(Trade, self).__init__()    
+
+        super(Trade, self).__init__()
 
     #----------------------------------------------------------------------
     def get(self):
@@ -250,23 +256,23 @@ class Trade(Resource):
         token = args['token']
         if token != TOKEN:
             return {'result_code':'error','message':'token error'}
-        
+
         data = me.getAllTrades()
         l = [o.__dict__ for o in data]
         return {'result_code':'success','data':l}
-    
+
 
 ########################################################################
 class Account(Resource):
     """账户"""
-    
+
     #----------------------------------------------------------------------
     def __init__(self):
         """初始化"""
         self.parser = reqparse.RequestParser()
         self.parser.add_argument('token')
-        
-        super(Account, self).__init__()    
+
+        super(Account, self).__init__()
 
     #----------------------------------------------------------------------
     def get(self):
@@ -275,24 +281,24 @@ class Account(Resource):
         token = args['token']
         if token != TOKEN:
             return {'result_code':'error','message':'token error'}
-        
+
         data = me.getAllAccounts()
         l = [o.__dict__ for o in data]
-        return {'result_code':'success','data':l}        
+        return {'result_code':'success','data':l}
 
 
 ########################################################################
 class Position(Resource):
     """持仓"""
-    
+
     #----------------------------------------------------------------------
     def __init__(self):
         """初始化"""
         self.parser = reqparse.RequestParser()
         self.parser.add_argument('token')
-        
-        super(Position, self).__init__()    
-    
+
+        super(Position, self).__init__()
+
     #----------------------------------------------------------------------
     def get(self):
         """查询"""
@@ -300,9 +306,9 @@ class Position(Resource):
         token = args['token']
         if token != TOKEN:
             return {'result_code':'error','message':'token error'}
-        
+
         data = me.getAllPositions()
-        print 'position',data
+        print('position',data)
         l = [o.__dict__ for o in data]
         return {'result_code':'success','data':l}
 
@@ -316,9 +322,9 @@ class Contract(Resource):
         """初始化"""
         self.parser = reqparse.RequestParser()
         self.parser.add_argument('token')
-        
-        super(Contract, self).__init__()    
-    
+
+        super(Contract, self).__init__()
+
 
     #----------------------------------------------------------------------
     def get(self):
@@ -327,24 +333,24 @@ class Contract(Resource):
         token = args['token']
         if token != TOKEN:
             return {'result_code':'error','message':'token error'}
-        
+
         data = me.getAllContracts()
-        print 'Contract',data
+        print('Contract',data)
         l = [o.__dict__ for o in data]
-        return {'result_code':'success','data':l}        
+        return {'result_code':'success','data':l}
 
 
 ########################################################################
 class Log(Resource):
     """日志"""
-    
+
     #----------------------------------------------------------------------
     def __init__(self):
         """初始化"""
         self.parser = reqparse.RequestParser()
         self.parser.add_argument('token')
-        
-        super(Log, self).__init__()    
+
+        super(Log, self).__init__()
 
     #----------------------------------------------------------------------
     def get(self):
@@ -353,23 +359,23 @@ class Log(Resource):
         token = args['token']
         if token != TOKEN:
             return {'result_code':'error','message':'token error'}
-        
+
         data = me.getLog()
         l = [o.__dict__ for o in data]
-        return {'result_code':'success','data':l}   
+        return {'result_code':'success','data':l}
 
 
 ########################################################################
 class Error(Resource):
     """错误"""
-    
+
     #----------------------------------------------------------------------
     def __init__(self):
         """初始化"""
         self.parser = reqparse.RequestParser()
         self.parser.add_argument('token')
-        
-        super(Error, self).__init__()    
+
+        super(Error, self).__init__()
 
     #----------------------------------------------------------------------
     def get(self):
@@ -378,7 +384,7 @@ class Error(Resource):
         token = args['token']
         if token != TOKEN:
             return {'result_code':'error','message':'token error'}
-        
+
         data = me.getError()
         l = [o.__dict__ for o in data]
         return {'result_code':'success','data':l}
@@ -387,14 +393,14 @@ class Error(Resource):
 ########################################################################
 class Tick(Resource):
     """行情"""
-    
+
     #----------------------------------------------------------------------
     def __init__(self):
         """初始化"""
         self.parser = reqparse.RequestParser()
         self.parser.add_argument('vtSymbol')
         self.parser.add_argument('token')
-        super(Tick, self).__init__()    
+        super(Tick, self).__init__()
 
     #----------------------------------------------------------------------
     def post(self):
@@ -414,22 +420,22 @@ class Tick(Resource):
         req.symbol = contract.symbol
         req.exchange = contract.exchange
         req.vtSymbol = contract.vtSymbol
-        
+
         me.subscribe(req, contract.gatewayName)
         return {'result_code':'success','data':''}
-    
+
 
 ########################################################################
 class CtaStrategyInit(Resource):
     """初始化策略"""
-    
+
     #----------------------------------------------------------------------
     def __init__(self):
         """初始化"""
         self.parser = reqparse.RequestParser()
         self.parser.add_argument('name')
         self.parser.add_argument('token')
-        super(CtaStrategyInit, self).__init__()    
+        super(CtaStrategyInit, self).__init__()
 
     #----------------------------------------------------------------------
     def post(self):
@@ -438,9 +444,9 @@ class CtaStrategyInit(Resource):
         token = args['token']
         if token != TOKEN:
             return {'result_code':'error','message':'token error'}
-        
+
         name = args['name']
-        
+
         engine = me.getApp('CtaStrategy')
         if not name:
             engine.initAll()
@@ -452,14 +458,14 @@ class CtaStrategyInit(Resource):
 ########################################################################
 class CtaStrategyStart(Resource):
     """启动策略"""
-    
+
     #----------------------------------------------------------------------
     def __init__(self):
         """初始化"""
         self.parser = reqparse.RequestParser()
         self.parser.add_argument('name')
         self.parser.add_argument('token')
-        super(CtaStrategyStart, self).__init__()    
+        super(CtaStrategyStart, self).__init__()
 
     #----------------------------------------------------------------------
     def post(self):
@@ -468,9 +474,9 @@ class CtaStrategyStart(Resource):
         token = args['token']
         if token != TOKEN:
             return {'result_code':'error','message':'token error'}
-        
+
         name = args['name']
-        
+
         engine = me.getApp('CtaStrategy')
         if not name:
             engine.startAll()
@@ -482,14 +488,14 @@ class CtaStrategyStart(Resource):
 ########################################################################
 class CtaStrategyStop(Resource):
     """停止策略"""
-    
+
     #----------------------------------------------------------------------
     def __init__(self):
         """初始化"""
         self.parser = reqparse.RequestParser()
         self.parser.add_argument('name')
         self.parser.add_argument('token')
-        super(CtaStrategyStop, self).__init__()    
+        super(CtaStrategyStop, self).__init__()
 
     #----------------------------------------------------------------------
     def post(self):
@@ -498,9 +504,9 @@ class CtaStrategyStop(Resource):
         token = args['token']
         if token != TOKEN:
             return {'result_code':'error','message':'token error'}
-        
+
         name = args['name']
-        
+
         engine = me.getApp('CtaStrategy')
         if not name:
             engine.stopAll()
@@ -511,22 +517,22 @@ class CtaStrategyStop(Resource):
 ########################################################################
 class CtaStrategyName(Resource):
     """»ñÈ¡²ßÂÔÃû"""
-    
+
     #----------------------------------------------------------------------
     def __init__(self):
         """³õÊ¼»¯"""
         self.parser = reqparse.RequestParser()
         self.parser.add_argument('token')
-        super(CtaStrategyName, self).__init__()        
-    
+        super(CtaStrategyName, self).__init__()
+
     #----------------------------------------------------------------------
     def get(self):
-        """»ñÈ¡²ßÂÔÃû""" 
+        """»ñÈ¡²ßÂÔÃû"""
         args = self.parser.parse_args()
         token = args['token']
         if token != TOKEN:
             return {'result_code':'error','message':'token error'}
-        
+
         engine = me.getApp('CtaStrategy')
         l = engine.getStrategyNames()
         return {'result_code':'success','data':l}
@@ -534,22 +540,22 @@ class CtaStrategyName(Resource):
 ########################################################################
 class CtaStrategyLoad(Resource):
     """加载策略"""
-    
+
     #----------------------------------------------------------------------
     def __init__(self):
         """初始化"""
         self.parser = reqparse.RequestParser()
         self.parser.add_argument('token')
-        super(CtaStrategyLoad, self).__init__()        
-    
+        super(CtaStrategyLoad, self).__init__()
+
     #----------------------------------------------------------------------
     def post(self):
-        """订阅""" 
+        """订阅"""
         args = self.parser.parse_args()
         token = args['token']
         if token != TOKEN:
             return {'result_code':'error','message':'token error'}
-        
+
         engine = me.getApp('CtaStrategy')
         engine.loadSetting()
         l = engine.getStrategyNames()
@@ -559,14 +565,14 @@ class CtaStrategyLoad(Resource):
 ########################################################################
 class CtaStrategyParam(Resource):
     """查询策略参数"""
-    
+
     #----------------------------------------------------------------------
     def __init__(self):
         """初始化"""
         self.parser = reqparse.RequestParser()
         self.parser.add_argument('name')
         self.parser.add_argument('token')
-        super(CtaStrategyParam, self).__init__()    
+        super(CtaStrategyParam, self).__init__()
 
     #----------------------------------------------------------------------
     def get(self):
@@ -575,9 +581,9 @@ class CtaStrategyParam(Resource):
         token = args['token']
         if token != TOKEN:
             return {'result_code':'error','message':'token error'}
-        
+
         name = args['name']
-        
+
         engine = me.getApp('CtaStrategy')
         l = engine.getStrategyParam(name)
         return {'result_code':'success','data':l}
@@ -586,14 +592,14 @@ class CtaStrategyParam(Resource):
 ########################################################################
 class CtaStrategyVar(Resource):
     """查询策略变量"""
-    
+
     #----------------------------------------------------------------------
     def __init__(self):
         """初始化"""
         self.parser = reqparse.RequestParser()
         self.parser.add_argument('name')
         self.parser.add_argument('token')
-        super(CtaStrategyVar, self).__init__()    
+        super(CtaStrategyVar, self).__init__()
 
     #----------------------------------------------------------------------
     def get(self):
@@ -602,14 +608,14 @@ class CtaStrategyVar(Resource):
         token = args['token']
         if token != TOKEN:
             return {'result_code':'error','message':'token error'}
-        
+
         name = args['name']
-        
+
         engine = me.getApp('CtaStrategy')
         l = engine.getStrategyVar(name)
         return {'result_code':'success','data':l}
 
-      
+
 ########################################################################
 @app.route('/')
 def index_html():
@@ -665,7 +671,7 @@ ee.register(EVENT_LOG, handleEvent)
 ee.register(EVENT_ERROR, handleEvent)
 ee.register(EVENT_CTA_LOG, handleEvent)
 ee.register(EVENT_CTA_STRATEGY, handleEvent)
-    
+
 
 if __name__ == '__main__':
     socketio.run(app,debug=True,host='0.0.0.0',port=5000)

--- a/examples/WebTrader/server.py
+++ b/examples/WebTrader/server.py
@@ -1,6 +1,10 @@
 # encoding: UTF-8
 
 # 重载sys模块，设置默认字符串编码方式为utf8
+try:
+    reload         # Python 2
+except NameError:  # Python 3
+    from importlib import reload
 import sys
 reload(sys)
 sys.setdefaultencoding('utf8')
@@ -21,39 +25,39 @@ from vnpy.trader.app import ctaStrategy, rpcService
 
 #----------------------------------------------------------------------
 def main():
-    """主程序入口"""    
+    """主程序入口"""
     le = LogEngine()
     le.setLogLevel(le.LEVEL_INFO)
     le.addConsoleHandler()
     le.addFileHandler()
 
     le.info(u'服务器进程启动')
-    
+
     # 创建事件引擎
     ee = EventEngine2()
     le.info(u'事件引擎创建成功')
-    
+
     # 创建主引擎
     me = MainEngine(ee)
-    
+
     # 安全退出机制
     def shutdown(signal, frame):
         le.info(u'安全关闭进程')
         me.exit()
         sys.exit()
-    
+
     for sig in [signal.SIGINT, signal.SIGTERM]:
         signal.signal(sig, shutdown)
-    
+
     # 添加交易接口
     me.addGateway(ctpGateway)
-    
+
     # 添加上层应用
     me.addApp(ctaStrategy)
     me.addApp(rpcService)
-    
+
     le.info(u'主引擎创建成功')
-    
+
     # 阻塞运行
     le.info(u'服务器启动成功')
     while 1:

--- a/vnpy/api/cshshlp/__init__.py
+++ b/vnpy/api/cshshlp/__init__.py
@@ -1,3 +1,4 @@
 # encoding: UTF-8
 
-from vncshshlp import CsHsHlp
+from __future__ import absolute_import
+from .vncshshlp import CsHsHlp

--- a/vnpy/api/cshshlp/test/cstest.py
+++ b/vnpy/api/cshshlp/test/cstest.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import sys
 from time import sleep
 
@@ -14,21 +15,21 @@ branch_no = ''
 def print_list(l):
     """"""
     for d in l:
-        print d
+        print(d)
 
 #----------------------------------------------------------------------
 def print_dict(d):
     """按照键值打印一个字典"""
     for key,value in d.items():
-        print key + ':' + str(value)
+        print(key + ':' + str(value))
         
         
 #----------------------------------------------------------------------
 def simple_log(func):
     """简单装饰器用于输出函数名"""
     def wrapper(*args, **kw):
-        print '-' * 20
-        print str(func.__name__)
+        print('-' * 20)
+        print(str(func.__name__))
         return func(*args, **kw)
     return wrapper
 
@@ -59,18 +60,18 @@ class TestHlp(CsHsHlp):
     @simple_log
     def onMsg(self, type_, data, reqNo, errorNo, errorInfo):
         """"""
-        print 'type:', type_
+        print('type:', type_)
         # print_list(data)
-        print 'reqNo:', reqNo
-        print 'errorNo:', errorNo
-        print 'errorInfo:', errorInfo
+        print('reqNo:', reqNo)
+        print('errorNo:', errorNo)
+        print('errorInfo:', errorInfo)
         '''
         for i in data[0].keys():
             print "key=%s,value=%s"%(i,data[0][i])
         '''
         
         for dd in data:
-            print dd        
+            print(dd)        
         
         self.data = data
 
@@ -101,23 +102,23 @@ class TestHlp(CsHsHlp):
         '''
         i = self.loadConfig("Hsconfig.ini")
         if i:
-            print u'加载配置失败：', i
+            print(u'加载配置失败：', i)
             return i            
-        print u'加载配置成功'
+        print(u'加载配置成功')
         
         # 初始化
         i = self.init()
         if i:
-            print u'初始化失败：', i
+            print(u'初始化失败：', i)
             return i
-        print u'初始化成功'
+        print(u'初始化成功')
 
         # 连接服务器
         i = self.connectServer()
         if i:
-            print u'服务器连接失败：', i
+            print(u'服务器连接失败：', i)
             return i
-        print u'服务器连接成功'
+        print(u'服务器连接成功')
 
         return int(0)
 
@@ -135,10 +136,10 @@ def test():
     # 初始化端口
     i = api.init_api()
     if i:
-        print u'初始化端口失败，请检查clog文件', i
+        print(u'初始化端口失败，请检查clog文件', i)
         return
     # 登录
-    print u'尝试登录'
+    print(u'尝试登录')
     i = api.beginParam()
     api.setValue("identity_type", "2")
     api.setValue("password_type", "2")
@@ -150,7 +151,7 @@ def test():
     api.setValue('option_fund_account', account['id'])
     api.setValue('op_station', '<yangxs><vnpy><test>')
     i = api.bizCallAndCommit(331100)
-    print u'尝试登录返回', i
+    print(u'尝试登录返回', i)
     sleep(3)
     #---------------------------------------------------------
     # 配置self的变量
@@ -170,34 +171,34 @@ def test():
         api.request_num = '500'
         api.op_station = '<yangxs><vnpy><test>'
     else:
-        print 'error in set the value'
+        print('error in set the value')
 
     
     #------------------------------------------
     # 订阅  620001  成交回报  33011
     # 订阅  620001  委托回写  33012
     # api.setNessaryParam()
-    print u'订阅 33011'
+    print(u'订阅 33011')
     api.beginParam()
     acc_info = '~' .join([api.branch_no, api.fund_account])
     api.setValue('issue_type', "33011")
     api.setValue('acc_info', acc_info)
     i = api.subscribeData(620001)
-    print i
+    print(i)
     sleep(1)
 
 
-    print u'订阅 33012'
+    print(u'订阅 33012')
     api.beginParam()
     acc_info = '~' .join([api.branch_no, api.fund_account])
     api.setValue('issue_type', "33012")
     api.setValue('acc_info', acc_info)
     i = api.subscribeData(620001)
-    print i
+    print(i)
     sleep(1)
 
     
-    print u'配置参数，进行下单'
+    print(u'配置参数，进行下单')
     # 配置
     api.setNessaryParam()
     # 下单参数 338011
@@ -211,22 +212,22 @@ def test():
     api.setValue('entrust_prop', '0')
     api.setValue('covered_flag', '')
     i = api.bizCallAndCommit(338011)
-    print u'尝试下单返回', i
+    print(u'尝试下单返回', i)
     sleep(3)
     
     
-    print u'查询持仓'
+    print(u'查询持仓')
      # 查询持仓
     # api.beginParam()
     api.setNessaryParam()
     i = api.bizCallAndCommit(338023)
     sleep(3)
-    print u'查询持仓返回',i
+    print(u'查询持仓返回',i)
     if(len(api.data)):
         for dd in api.data:
-            print "-----------------------"
+            print("-----------------------")
             for i in dd.keys():
-                print "key=%s,value=%s"%(i,api.data[0][i])
+                print("key=%s,value=%s"%(i,api.data[0][i]))
 
     # --------------------------------------------------------------------------   
     # 测试撤单 338012,先下单，间隔后撤单
@@ -241,7 +242,7 @@ def test():
     api.setValue('entrust_prop', '0')
     api.setValue('covered_flag', '')
     i = api.bizCallAndCommit(338011)
-    print u'尝试下单返回', i
+    print(u'尝试下单返回', i)
     sleep(3)
     # print api.data
 
@@ -251,16 +252,16 @@ def test():
             e_no = tt['entrust_no']
             api.order[e_no] = tt
         
-    print api.order
+    print(api.order)
     api.setNessaryParam()
     api.setValue('exchange_type','1')
     for kk in api.order.keys():
         api.setValue('entrust_no', kk)
         i = api.bizCallAndCommit(338012)
-        print u'尝试撤单', kk
+        print(u'尝试撤单', kk)
         sleep(1)
         #pop or del
-    print api.data
+    print(api.data)
 
     
     #-----------------------------------
@@ -271,15 +272,15 @@ def test():
 
         api.setValue('locate_entrust_no', kk)
         i = api.bizCallAndCommit(338020)
-        print u'查询指定订单', kk
+        print(u'查询指定订单', kk)
         sleep(1)
-    print api.data
+    print(api.data)
     
     api.setNessaryParam()
     api.setValue('query_kind', '1')
     i = api.bizCallAndCommit(338020)
     sleep(1)
-    print api.data
+    print(api.data)
     
 
     

--- a/vnpy/api/ctp/__init__.py
+++ b/vnpy/api/ctp/__init__.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
-from vnctpmd import MdApi
-from vnctptd import TdApi
-from ctp_data_type import defineDict
+from __future__ import absolute_import
+from .vnctpmd import MdApi
+from .vnctptd import TdApi
+from .ctp_data_type import defineDict

--- a/vnpy/api/ctp/py3/pyscript/generate_data_type.py
+++ b/vnpy/api/ctp/py3/pyscript/generate_data_type.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 # C++和python类型的映射字典
@@ -92,9 +93,9 @@ def main():
         fcpp.close()
         fpy.close()
 
-        print u'data_type.py生成过程完成'
+        print(u'data_type.py生成过程完成')
     except:
-        print u'data_type.py生成过程出错'
+        print(u'data_type.py生成过程出错')
 
 
 if __name__ == '__main__':

--- a/vnpy/api/ctp/py3/pyscript/generate_td_functions.py
+++ b/vnpy/api/ctp/py3/pyscript/generate_td_functions.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 from ctp_struct import structDict
@@ -257,7 +258,7 @@ def createFunction(fcName, fcArgsTypeList, fcArgsValueList):
         ffunction.write(line)
 
         if type_ == 'CThostFtdcInputOrderField':
-            print(key, value)
+            print((key, value))
             print(line)
 
     ffunction.write('\tint i = this->api->' + fcName + '(&myreq, nRequestID);\n')

--- a/vnpy/api/ctp/pyscript/generate_data_type.py
+++ b/vnpy/api/ctp/pyscript/generate_data_type.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 # C++和python类型的映射字典
@@ -92,9 +93,9 @@ def main():
         fcpp.close()
         fpy.close()
 
-        print u'data_type.py生成过程完成'
+        print(u'data_type.py生成过程完成')
     except:
-        print u'data_type.py生成过程出错'
+        print(u'data_type.py生成过程出错')
 
 
 if __name__ == '__main__':

--- a/vnpy/api/ctp/pyscript/generate_td_functions.py
+++ b/vnpy/api/ctp/pyscript/generate_td_functions.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 from string import join
@@ -250,8 +251,8 @@ def createFunction(fcName, fcArgsTypeList, fcArgsValueList):
         ffunction.write(line)
 
         if type_ == 'CThostFtdcInputOrderField':
-            print key, value
-            print line
+            print(key, value)
+            print(line)
 
     ffunction.write('\tint i = this->api->' + fcName + '(&myreq, nRequestID);\n')
     ffunction.write('\treturn i;\n')

--- a/vnpy/api/ctp/vnctpmd/test/mdtest.py
+++ b/vnpy/api/ctp/vnctpmd/test/mdtest.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import sys
 from time import sleep
 
@@ -12,15 +13,15 @@ from vnctpmd import *
 def print_dict(d):
     """按照键值打印一个字典"""
     for key,value in d.items():
-        print key + ':' + str(value)
+        print(key + ':' + str(value))
         
         
 #----------------------------------------------------------------------
 def simple_log(func):
     """简单装饰器用于输出函数名"""
     def wrapper(*args, **kw):
-        print ""
-        print str(func.__name__)
+        print("")
+        print(str(func.__name__))
         return func(*args, **kw)
     return wrapper
 
@@ -44,13 +45,13 @@ class TestMdApi(MdApi):
     @simple_log    
     def onFrontDisconnected(self, n):
         """服务器断开"""
-        print n
+        print(n)
         
     #----------------------------------------------------------------------
     @simple_log    
     def onHeartBeatWarning(self, n):
         """心跳报警"""
-        print n
+        print(n)
     
     #----------------------------------------------------------------------
     @simple_log    

--- a/vnpy/api/ctp/vnctptd/test/tdtest.py
+++ b/vnpy/api/ctp/vnctptd/test/tdtest.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import sys
 from time import sleep
 
@@ -11,15 +12,15 @@ from vnctptd import *
 def print_dict(d):
     """按照键值打印一个字典"""
     for key,value in d.items():
-        print key + ':' + str(value)
+        print(key + ':' + str(value))
         
         
 #----------------------------------------------------------------------
 def simple_log(func):
     """简单装饰器用于输出函数名"""
     def wrapper(*args, **kw):
-        print ""
-        print str(func.__name__)
+        print("")
+        print(str(func.__name__))
         return func(*args, **kw)
     return wrapper
 
@@ -43,13 +44,13 @@ class TestTdApi(TdApi):
     @simple_log    
     def onFrontDisconnected(self, n):
         """服务器断开"""
-        print n
+        print(n)
         
     #----------------------------------------------------------------------
     @simple_log    
     def onHeartBeatWarning(self, n):
         """心跳报警"""
-        print n
+        print(n)
     
     #----------------------------------------------------------------------
     @simple_log    
@@ -95,8 +96,8 @@ class TestTdApi(TdApi):
         """查询合约回报"""
         print_dict(data)
         print_dict(error)
-        print n
-        print last
+        print(n)
+        print(last)
         
         
 #----------------------------------------------------------------------

--- a/vnpy/api/femas/__init__.py
+++ b/vnpy/api/femas/__init__.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
-from vnfemasmd import MdApi
-from vnfemastd import TdApi
-from femas_data_type import defineDict
+from __future__ import absolute_import
+from .vnfemasmd import MdApi
+from .vnfemastd import TdApi
+from .femas_data_type import defineDict

--- a/vnpy/api/femas/pyscript/generate_data_type.py
+++ b/vnpy/api/femas/pyscript/generate_data_type.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 # C++和python类型的映射字典
@@ -88,9 +89,9 @@ def main():
         fcpp.close()
         fpy.close()
 
-        print u'data_type.py生成过程完成'
+        print(u'data_type.py生成过程完成')
     except:
-        print u'data_type.py生成过程出错'
+        print(u'data_type.py生成过程出错')
 
 
 if __name__ == '__main__':

--- a/vnpy/api/femas/vnfemasmd/test/mdtest.py
+++ b/vnpy/api/femas/vnfemasmd/test/mdtest.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import sys
 from time import sleep
 
@@ -12,15 +13,15 @@ from vnfemasmd import *
 def print_dict(d):
     """按照键值打印一个字典"""
     for key,value in d.items():
-        print key + ':' + str(value)
+        print(key + ':' + str(value))
         
         
 #----------------------------------------------------------------------
 def simple_log(func):
     """简单装饰器用于输出函数名"""
     def wrapper(*args, **kw):
-        print ""
-        print str(func.__name__)
+        print("")
+        print(str(func.__name__))
         return func(*args, **kw)
     return wrapper
 
@@ -44,13 +45,13 @@ class TestMdApi(MdApi):
     @simple_log    
     def onFrontDisconnected(self, n):
         """服务器断开"""
-        print n
+        print(n)
         
     #----------------------------------------------------------------------
     @simple_log    
     def onHeartBeatWarning(self, n):
         """心跳报警"""
-        print n
+        print(n)
     
     #----------------------------------------------------------------------
     @simple_log    

--- a/vnpy/api/femas/vnfemastd/test/tdtest.py
+++ b/vnpy/api/femas/vnfemastd/test/tdtest.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import sys
 from time import sleep
 
@@ -11,15 +12,15 @@ from vnfemastd import *
 def print_dict(d):
     """按照键值打印一个字典"""
     for key,value in d.items():
-        print key + ':' + str(value)
+        print(key + ':' + str(value))
         
         
 #----------------------------------------------------------------------
 def simple_log(func):
     """简单装饰器用于输出函数名"""
     def wrapper(*args, **kw):
-        print ""
-        print str(func.__name__)
+        print("")
+        print(str(func.__name__))
         return func(*args, **kw)
     return wrapper
 
@@ -43,13 +44,13 @@ class TestTdApi(TdApi):
     @simple_log    
     def onFrontDisconnected(self, n):
         """服务器断开"""
-        print n
+        print(n)
         
     #----------------------------------------------------------------------
     @simple_log    
     def onHeartBeatWarning(self, n):
         """心跳报警"""
-        print n
+        print(n)
     
     #----------------------------------------------------------------------
     @simple_log    
@@ -95,8 +96,8 @@ class TestTdApi(TdApi):
         """查询合约回报"""
         print_dict(data)
         print_dict(error)
-        print n
-        print last
+        print(n)
+        print(last)
         
         
 #----------------------------------------------------------------------

--- a/vnpy/api/fxcm/__init__.py
+++ b/vnpy/api/fxcm/__init__.py
@@ -1,3 +1,4 @@
 # encoding: UTF-8
 
-from vnfxcm import FxcmApi
+from __future__ import absolute_import
+from .vnfxcm import FxcmApi

--- a/vnpy/api/fxcm/test.py
+++ b/vnpy/api/fxcm/test.py
@@ -1,8 +1,10 @@
 # encoding: UTF-8
 
+from __future__ import print_function
+from __future__ import absolute_import
 from time import sleep
 
-from vnfxcm import FxcmApi
+from .vnfxcm import FxcmApi
 
 url = 'https://api-demo.fxcm.com:443'
 port = 443    
@@ -10,10 +12,10 @@ token = '48055b5d9afac0a300143ac067ce04cd2430a434'
 proxy = 'https://localhost:1080'
 
 api = FxcmApi()
-print 'api created'
+print('api created')
 
 api.connect(url, port, token, proxy)
-print api.bearer
+print(api.bearer)
 
 sleep(20)
 #api.getInstruments()

--- a/vnpy/api/fxcm/vnfxcm.py
+++ b/vnpy/api/fxcm/vnfxcm.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import json
 import requests
 from socketIO_client import SocketIO
@@ -334,32 +335,32 @@ class FxcmApi(object):
     #----------------------------------------------------------------------
     def onConnect(self):
         """连接回调"""
-        print 'onConnect'
+        print('onConnect')
         
     #----------------------------------------------------------------------
     def onDisconnect(self):
         """断开回调"""
-        print 'onClose'
+        print('onClose')
         
     #----------------------------------------------------------------------
     def onError(self, error, reqid):
         """错误回调"""
-        print 'onError', error
+        print('onError', error)
     
     #----------------------------------------------------------------------
     def onGetInstruments(self, data, reqid):
         """查询合约代码回调"""
-        print data, reqid
+        print(data, reqid)
         
     #----------------------------------------------------------------------
     def onGetModel(self, data, reqid):
         """查询表回调"""
-        print '*' * 30
-        print data
+        print('*' * 30)
+        print(data)
         for d in data['offers']:
             #if str(d['currency']) == 'EUR/USD':
             #    print d
-            print d['currency']#, d['visible']
+            print(d['currency'])#, d['visible']
         #print len(data['summary'])
         #print data
         
@@ -367,47 +368,47 @@ class FxcmApi(object):
     #----------------------------------------------------------------------
     def onSubscribe(self, data, reqid):	
         """订阅行情回调"""
-        print data, reqid    
+        print(data, reqid)    
     
     #----------------------------------------------------------------------
     def onUnsubscribe(self, data, reqid):
         """退订行情回调"""
-        print data, reqid 
+        print(data, reqid) 
         
     #----------------------------------------------------------------------
     def onSubscribeModel(self, data, reqid):
         """订阅表回调"""
-        print data, reqid    
+        print(data, reqid)    
     
     #----------------------------------------------------------------------
     def onUnsubscribeModel(self, data, reqid):
         """退订表回调"""
-        print data, reqid   
+        print(data, reqid)   
         
     #----------------------------------------------------------------------
     def onUpdateSubscriptions(self, data, reqid):
         """订阅报价表回调"""
-        print data, reqid
+        print(data, reqid)
         
     #----------------------------------------------------------------------
     def onOpenTrade(self, data, reqid):
         """开仓回调"""
-        print data, reqid
+        print(data, reqid)
         
     #----------------------------------------------------------------------
     def onCloseTrade(self, data, reqid):
         """平仓回调"""
-        print data, reqid 
+        print(data, reqid) 
         
     #----------------------------------------------------------------------
     def onChangeOrder(self, data, reqid):
         """改单回调"""
-        print data, reqid       
+        print(data, reqid)       
 
     #----------------------------------------------------------------------
     def onDeleteOrder(self, data, reqid):
         """撤单回调"""
-        print data, reqid    
+        print(data, reqid)    
     
     #----------------------------------------------------------------------
     def processPriceUpdate(self, msg):
@@ -418,19 +419,19 @@ class FxcmApi(object):
     #----------------------------------------------------------------------
     def processModelUpdate(self, msg):
         """表推送"""
-        print msg
+        print(msg)
         data = json.loads(msg)
         self.onModelUpdate(data)
     
     #----------------------------------------------------------------------
     def onPriceUpdate(self, data):
         """行情推送"""
-        print data
+        print(data)
         
     #----------------------------------------------------------------------
     def onModelUpdate(self, data):
         """表推送"""
-        print data
+        print(data)
         #print '*' * 30
         #fsubscribeModel
         #print len(data), data.get('isTotal', None), data

--- a/vnpy/api/ib/__init__.py
+++ b/vnpy/api/ib/__init__.py
@@ -1,3 +1,4 @@
 # encoding: UTF-8
 
-from vnib import *
+from __future__ import absolute_import
+from .vnib import *

--- a/vnpy/api/ib/test/test.py
+++ b/vnpy/api/ib/test/test.py
@@ -1,324 +1,328 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import sys
 
 from time import sleep
 
 from vnib import IbApi
 
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
+
 
 ########################################################################
 class TestApi(IbApi):
-    print sys._getframe().f_code.co_name
+    print(sys._getframe().f_code.co_name)
 
     #----------------------------------------------------------------------
     def __init__(self):
         """Constructor"""
         super(TestApi, self).__init__()
-        
+
     #----------------------------------------------------------------------
     def nextValidId(self, orderId):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def currentTime(self, time):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def connectAck(self):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def error(self, id_, errorCode, errorString):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def accountSummary(self, reqId, account, tag, value, curency):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def accountSummaryEnd(self, reqId):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def tickPrice(self, tickerId, field, price, canAutoExecute):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def tickSize(self, tickerId, field, size):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def tickOptionComputation(self, tickerId, tickType, impliedVol, delta, optPrice, pvDividend, gamma, vega, theta, undPrice):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def tickGeneric(self, tickerId, tickType, value):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def tickString(self, tickerId, tickType, value):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def tickEFP(self, tickerId, tickType, basisPoints, formattedBasisPoints, totalDividends, holdDays, futureLastTradeDate, dividendImpact, dividendsToLastTradeDate):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def orderStatus(self, orderId, status, filled, remaining, avgFillPrice, permId, parentId, lastFillPrice, clientId, whyHeld):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def openOrder(self, orderId, contract, order, orderState):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def openOrderEnd(self):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def winError(self, str_, lastError):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def connectionClosed(self):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def updateAccountValue(self, key, val, currency, accountName):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def updatePortfolio(self, contract, position, marketPrice, marketValue, averageCost, unrealizedPNL, realizedPNL, accountName):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def updateAccountTime(self, timeStamp):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def accountDownloadEnd(self, accountName):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def contractDetails(self, reqId, contractDetails):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def bondContractDetails(self, reqId, contractDetails):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def contractDetailsEnd(self, reqId):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def execDetails(self, reqId, contract, execution):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def execDetailsEnd(self, reqId):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def updateMktDepth(self, id_, position, operation, side, price, size):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def updateMktDepthL2(self, id_, position, marketMaker, operation, side, price, size):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def updateNewsBulletin(self, msgId, msgType, newsMessage, originExch):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def managedAccounts(self, accountsList):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def receiveFA(self, pFaDataType, cxml):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def historicalData(self, reqId, date, open_, high, low, close, volume, barCount, WAP, hasGaps):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def scannerParameters(self, xml):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def scannerData(self, reqId, rank, contractDetails, distance, benchmark, projection, legsStr):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def scannerDataEnd(self, reqId):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def realtimeBar(self, reqId, time, open_, high, low, close, volume, wap, count):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def fundamentalData(self, reqId, data):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def deltaNeutralValidation(self, reqId, underComp):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def tickSnapshotEnd(self, reqId):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def marketDataType(self, reqId, marketDataType):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def commissionReport(self, commissionReport):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def position(self, account, contract, position, avgCost):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def positionEnd(self):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def verifyMessageAPI(self, apiData):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def verifyCompleted(self, isSuccessful, errorText):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def displayGroupList(self, reqId, groups):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def displayGroupUpdated(self, reqId, contractInfo):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def verifyAndAuthMessageAPI(self, apiData, xyzChallange):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def verifyAndAuthCompleted(self, isSuccessful, errorText):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def positionMulti(self, reqId, account, modelCode, contract, pos, avgCost):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
-    def positionMultiEnd(self, reqId):	
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+    def positionMultiEnd(self, reqId):
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def accountUpdateMulti(self, reqId, account, modelCode, key, value, currency):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
-    def accountUpdateMultiEnd(self, reqId):	
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+    def accountUpdateMultiEnd(self, reqId):
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def securityDefinitionOptionalParameter(self, reqId, exchange, underlyingConId, tradingClass, multiplier, expirations, strikes):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def securityDefinitionOptionalParameterEnd(self, reqId):
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def softDollarTiers(self, reqId, tiers):
-        print sys._getframe().f_code.co_name
-        print locals()
-        
-        
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
+
 
 if __name__ == '__main__':
     api = TestApi()
-    
+
     n = api.eConnect('127.0.0.1', 7497, 123, False)
-    print n
-    
+    print(n)
+
     #t = api.TwsConnectionTime()
     #print t
-    
+
     #
     sleep(1)
-    print 'req time'
+    print('req time')
     api.reqCurrentTime()
-    
+
     #
     sleep(1)
     api.reqAccountSummary(9001, "All", "AccountType")
-    
+
     #print 'disconnect'
     #api.eDisconnect()
-    
+
     raw_input()
-    
-    

--- a/vnpy/api/ksgold/__init__.py
+++ b/vnpy/api/ksgold/__init__.py
@@ -1,4 +1,5 @@
 # encoding: UTF-8
 
-from vnksgoldtd import TdApi
-from ksgold_data_type import defineDict
+from __future__ import absolute_import
+from .vnksgoldtd import TdApi
+from .ksgold_data_type import defineDict

--- a/vnpy/api/ksgold/pyscript/generate_data_type.py
+++ b/vnpy/api/ksgold/pyscript/generate_data_type.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 # C++和python类型的映射字典
@@ -48,7 +49,7 @@ def process_typedef(line):
     else:
         keyword = content[-1]
         keyword = keyword.replace(';\n', '')
-        print content, keyword
+        print(content, keyword)
 
     if '[' in keyword:
         i = keyword.index('[')
@@ -91,15 +92,15 @@ def main():
             py_line = process_line(line)
             if py_line:
                 fpy.write(py_line.decode('gbk').encode('utf-8'))
-                print n 
+                print(n) 
 
         fcpp.close()
         fpy.close()
 
-        print u'data_type.py生成过程完成'
-    except Exception, e:
-        print u'data_type.py生成过程出错'
-        print e
+        print(u'data_type.py生成过程完成')
+    except Exception as e:
+        print(u'data_type.py生成过程出错')
+        print(e)
 
 
 if __name__ == '__main__':

--- a/vnpy/api/ksgold/pyscript/generate_struct.py
+++ b/vnpy/api/ksgold/pyscript/generate_struct.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 from ksgold_data_type import *
@@ -47,7 +48,7 @@ def main():
                 n = line.index('//')
                 line = line[:n]
 
-            print no, ':', line
+            print(no, ':', line)
 
             content = line.split('\t')
 

--- a/vnpy/api/ksotp/__init__.py
+++ b/vnpy/api/ksotp/__init__.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
-from vnksotpmd import MdApi
-from vnksotptd import TdApi
-from ksotp_data_type import defineDict
+from __future__ import absolute_import
+from .vnksotpmd import MdApi
+from .vnksotptd import TdApi
+from .ksotp_data_type import defineDict

--- a/vnpy/api/ksotp/pyscript/generate_data_type.py
+++ b/vnpy/api/ksotp/pyscript/generate_data_type.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 # C++和python类型的映射字典
@@ -88,9 +89,9 @@ def main():
         fcpp.close()
         fpy.close()
 
-        print u'data_type.py生成过程完成'
+        print(u'data_type.py生成过程完成')
     except:
-        print u'data_type.py生成过程出错'
+        print(u'data_type.py生成过程出错')
 
 
 if __name__ == '__main__':

--- a/vnpy/api/ksotp/pyscript/generate_struct.py
+++ b/vnpy/api/ksotp/pyscript/generate_struct.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 from ksotp_data_type import *
@@ -15,7 +16,7 @@ def main():
     fpy.write('\n')
 
     for n, line in enumerate(fcpp):
-        print n
+        print(n)
         # 结构体申明注释
         if '///' in line and '\t' not in line:
             py_line = '#' + line[3:]
@@ -38,8 +39,8 @@ def main():
             try:
                 type_ = typedefDict[typedef]
             except KeyError:
-                print content
-                print typedef
+                print(content)
+                print(typedef)
 
             variable = content[2].replace(';\n', "")
             py_line = '%s["%s"] = "%s"\n' % (name, variable, type_)

--- a/vnpy/api/ksotp/vnksotpmd/test/mdtest.py
+++ b/vnpy/api/ksotp/vnksotpmd/test/mdtest.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import sys
 from time import sleep
 
@@ -12,15 +13,15 @@ from vnksotpmd import *
 def print_dict(d):
     """按照键值打印一个字典"""
     for key,value in d.items():
-        print key + ':' + str(value)
+        print(key + ':' + str(value))
         
         
 #----------------------------------------------------------------------
 def simple_log(func):
     """简单装饰器用于输出函数名"""
     def wrapper(*args, **kw):
-        print ""
-        print str(func.__name__)
+        print("")
+        print(str(func.__name__))
         return func(*args, **kw)
     return wrapper
 
@@ -44,7 +45,7 @@ class TestMdApi(MdApi):
     @simple_log    
     def onFrontDisconnected(self, n):
         """服务器断开"""
-        print n
+        print(n)
         
     #----------------------------------------------------------------------
     @simple_log    

--- a/vnpy/api/ksotp/vnksotptd/test/tdtest.py
+++ b/vnpy/api/ksotp/vnksotptd/test/tdtest.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import sys
 from time import sleep
 
@@ -11,15 +12,15 @@ from vnksotptd import *
 def print_dict(d):
     """按照键值打印一个字典"""
     for key,value in d.items():
-        print key + ':' + str(value)
+        print(key + ':' + str(value))
         
         
 #----------------------------------------------------------------------
 def simple_log(func):
     """简单装饰器用于输出函数名"""
     def wrapper(*args, **kw):
-        print ""
-        print str(func.__name__)
+        print("")
+        print(str(func.__name__))
         return func(*args, **kw)
     return wrapper
 
@@ -43,7 +44,7 @@ class TestTdApi(TdApi):
     @simple_log    
     def onFrontDisconnected(self, n):
         """服务器断开"""
-        print n
+        print(n)
 
     #----------------------------------------------------------------------
     @simple_log    
@@ -89,8 +90,8 @@ class TestTdApi(TdApi):
         """查询合约回报"""
         print_dict(data)
         print_dict(error)
-        print n
-        print last
+        print(n)
+        print(last)
         
         
 #----------------------------------------------------------------------

--- a/vnpy/api/lbank/__init__.py
+++ b/vnpy/api/lbank/__init__.py
@@ -1,3 +1,4 @@
 # encoding: UTF-8
 
-from vnlbank import LbankApi
+from __future__ import absolute_import
+from .vnlbank import LbankApi

--- a/vnpy/api/lbank/test.py
+++ b/vnpy/api/lbank/test.py
@@ -1,19 +1,24 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 from time import time, sleep
 
-from vnlbank import LbankApi
+from .vnlbank import LbankApi
 
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
 
 if __name__ == '__main__':
     apiKey = ''
     secretKey = ''
-    
+
     # 创建API对象并初始化
     api = LbankApi()
     api.DEBUG = True
     api.init(apiKey, secretKey, 2)
-    
+
     # 查询行情
     api.getTicker('btc_cny')
 
@@ -44,4 +49,4 @@ if __name__ == '__main__':
     #api.getOrdersInfoHistory('btc_cny', '0', '1', '100')
 
     # 阻塞
-    raw_input()    
+    raw_input()

--- a/vnpy/api/lbank/vnlbank.py
+++ b/vnpy/api/lbank/vnlbank.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import print_function
 import urllib
 import hashlib
 
@@ -120,7 +121,7 @@ class LbankApi(object):
                 # 请求成功
                 else:
                     if self.DEBUG:
-                        print callback.__name__                        
+                        print(callback.__name__)                        
                     callback(data, req, reqID)
 
                 # 流控等待
@@ -149,7 +150,7 @@ class LbankApi(object):
     #----------------------------------------------------------------------
     def onError(self, error, req, reqID):
         """错误推送"""
-        print error, req, reqID
+        print(error, req, reqID)
 
     ###############################################
     # 行情接口
@@ -203,22 +204,22 @@ class LbankApi(object):
     #----------------------------------------------------------------------
     def onGetTicker(self, data, req, reqID):
         """查询行情回调"""
-        print data, reqID
+        print(data, reqID)
 
     # ----------------------------------------------------------------------
     def onGetDepth(self, data, req, reqID):
         """查询深度回调"""
-        print data, reqID
+        print(data, reqID)
 
     # ----------------------------------------------------------------------
     def onGetTrades(self, data, req, reqID):
         """查询历史成交"""
-        print data, reqID
+        print(data, reqID)
 
     # ----------------------------------------------------------------------
     def onGetKline(self, data, req, reqID):
         """查询Ｋ线回报"""
-        print data, reqID
+        print(data, reqID)
 
     ###############################################
     # 交易接口
@@ -283,25 +284,25 @@ class LbankApi(object):
     # ----------------------------------------------------------------------
     def onGetUserInfo(self, data, req, reqID):
         """查询账户信息"""
-        print data, reqID
+        print(data, reqID)
 
     # ----------------------------------------------------------------------
     def onCreateOrder(self, data, req, reqID):
         """委托回报"""
-        print data, reqID
+        print(data, reqID)
 
     # ----------------------------------------------------------------------
     def onCancelOrder(self, data, req, reqID):
         """撤单回报"""
-        print data, reqID
+        print(data, reqID)
 
     # ----------------------------------------------------------------------
     def onGetOrdersInfo(self, data, req, reqID):
         """查询委托回报"""
-        print data, reqID
+        print(data, reqID)
 
     # ----------------------------------------------------------------------
     def onGetOrdersInfoHistory(self, data, req, reqID):
         """撤单回报"""
-        print data, reqID
+        print(data, reqID)
 

--- a/vnpy/api/lts/__init__.py
+++ b/vnpy/api/lts/__init__.py
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
-from vnltsmd import MdApi
-from vnltstd import TdApi
-from vnltsqry import QryApi
-from lts_data_type import defineDict
+from __future__ import absolute_import
+from .vnltsmd import MdApi
+from .vnltstd import TdApi
+from .vnltsqry import QryApi
+from .lts_data_type import defineDict

--- a/vnpy/api/lts/pyscript/generate_data_type.py
+++ b/vnpy/api/lts/pyscript/generate_data_type.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 # C++和python类型的映射字典
@@ -88,9 +89,9 @@ def main():
         fcpp.close()
         fpy.close()
 
-        print u'data_type.py生成过程完成'
+        print(u'data_type.py生成过程完成')
     except:
-        print u'data_type.py生成过程出错'
+        print(u'data_type.py生成过程出错')
 
 
 if __name__ == '__main__':

--- a/vnpy/api/lts/pyscript/l2/generate_data_type.py
+++ b/vnpy/api/lts/pyscript/l2/generate_data_type.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 # C++和python类型的映射字典
@@ -88,9 +89,9 @@ def main():
         fcpp.close()
         fpy.close()
 
-        print u'data_type.py生成过程完成'
+        print(u'data_type.py生成过程完成')
     except:
-        print u'data_type.py生成过程出错'
+        print(u'data_type.py生成过程出错')
 
 
 if __name__ == '__main__':

--- a/vnpy/api/lts/vnltsmd/test/mdtest.py
+++ b/vnpy/api/lts/vnltsmd/test/mdtest.py
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
 # 内置模块
+from __future__ import print_function
 import sys
 from time import sleep
 
@@ -11,15 +12,15 @@ from vnltsmd import *
 def print_dict(d):
     """按照键值打印一个字典"""
     for key,value in d.items():
-        print key + ':' + str(value)
+        print(key + ':' + str(value))
         
         
 #----------------------------------------------------------------------
 def simple_log(func):
     """简单装饰器用于输出函数名"""
     def wrapper(*args, **kw):
-        print ""
-        print str(func.__name__)
+        print("")
+        print(str(func.__name__))
         return func(*args, **kw)
     return wrapper
 
@@ -43,13 +44,13 @@ class TestMdApi(MdApi):
     @simple_log    
     def onFrontDisconnected(self, n):
         """服务器断开"""
-        print n
+        print(n)
         
     #----------------------------------------------------------------------
     @simple_log    
     def onHeartBeatWarning(self, n):
         """心跳报警"""
-        print n
+        print(n)
     
     #----------------------------------------------------------------------
     @simple_log    
@@ -124,7 +125,7 @@ def main():
     
     #获取交易日，测试通过
     day = api.getTradingDay()
-    print 'Trading Day is:' + str(day)
+    print('Trading Day is:' + str(day))
     sleep(0.5)
     
     # 订阅合约，测试通过

--- a/vnpy/api/lts/vnltsqry/test/qrytest.py
+++ b/vnpy/api/lts/vnltsqry/test/qrytest.py
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
 # 内置模块
+from __future__ import print_function
 import sys
 from time import sleep
 
@@ -12,15 +13,15 @@ from lts_data_type import defineDict
 def print_dict(d):
     """按照键值打印一个字典"""
     for key,value in d.items():
-        print key + ':' + str(value)
+        print(key + ':' + str(value))
         
         
 #----------------------------------------------------------------------
 def simple_log(func):
     """简单装饰器用于输出函数名"""
     def wrapper(*args, **kw):
-        print ""
-        print str(func.__name__)
+        print("")
+        print(str(func.__name__))
         return func(*args, **kw)
     return wrapper
 
@@ -44,13 +45,13 @@ class TestQryApi(QryApi):
     @simple_log    
     def onFrontDisconnected(self, n):
         """服务器断开"""
-        print n
+        print(n)
         
     #----------------------------------------------------------------------
     @simple_log    
     def onHeartBeatWarning(self, n):
         """心跳报警"""
-        print n
+        print(n)
         
     #----------------------------------------------------------------------
     @simple_log    

--- a/vnpy/api/lts/vnltstd/test/tdtest.py
+++ b/vnpy/api/lts/vnltstd/test/tdtest.py
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
 # 内置模块
+from __future__ import print_function
 import sys
 from time import sleep
 
@@ -12,15 +13,15 @@ from lts_data_type import defineDict
 def print_dict(d):
     """按照键值打印一个字典"""
     for key,value in d.items():
-        print key + ':' + str(value)
+        print(key + ':' + str(value))
         
         
 #----------------------------------------------------------------------
 def simple_log(func):
     """简单装饰器用于输出函数名"""
     def wrapper(*args, **kw):
-        print ""
-        print str(func.__name__)
+        print("")
+        print(str(func.__name__))
         return func(*args, **kw)
     return wrapper
 
@@ -44,13 +45,13 @@ class TestTdApi(TdApi):
     @simple_log    
     def onFrontDisconnected(self, n):
         """服务器断开"""
-        print n
+        print(n)
         
     #----------------------------------------------------------------------
     @simple_log    
     def onHeartBeatWarning(self, n):
         """心跳报警"""
-        print n
+        print(n)
         
     #----------------------------------------------------------------------
     @simple_log    

--- a/vnpy/api/oanda/__init__.py
+++ b/vnpy/api/oanda/__init__.py
@@ -1,3 +1,4 @@
 # encoding: UTF-8
 
-from vnoanda import OandaApi
+from __future__ import absolute_import
+from .vnoanda import OandaApi

--- a/vnpy/api/oanda/test.py
+++ b/vnpy/api/oanda/test.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
-from vnoanda import OandaApi
+from __future__ import absolute_import
+from .vnoanda import OandaApi
 
     
 if __name__ == '__main__':

--- a/vnpy/api/oanda/vnoanda.py
+++ b/vnpy/api/oanda/vnoanda.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import print_function
 import json
 import requests
 from Queue import Queue, Empty
@@ -208,7 +209,7 @@ class OandaApi(object):
         
         try:
             r = self.session.send(pre, stream=stream)
-        except Exception, e:
+        except Exception as e:
             error = e
 
         return r, error
@@ -228,9 +229,9 @@ class OandaApi(object):
                     try:
                         data = r.json()
                         if self.DEBUG:
-                            print callback.__name__                        
+                            print(callback.__name__)                        
                         callback(data, reqID)    
-                    except Exception, e:                  
+                    except Exception as e:                  
                         self.onError(str(e), reqID)                      
                 else:                
                     self.onError(error, reqID)
@@ -260,7 +261,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onError(self, error, reqID):
         """错误信息回调"""
-        print error, reqID
+        print(error, reqID)
             
     #----------------------------------------------------------------------
     def getInstruments(self, params):
@@ -270,7 +271,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onGetInstruments(self, data, reqID):
         """回调函数"""
-        print data, reqID
+        print(data, reqID)
         
     #----------------------------------------------------------------------
     def getPrices(self, params):
@@ -280,7 +281,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onGetPrices(self, data, reqID):
         """回调函数"""
-        print data, reqID
+        print(data, reqID)
         
     #----------------------------------------------------------------------
     def getPriceHisory(self, params):
@@ -290,7 +291,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onGetPriceHistory(self, data, reqID):
         """回调函数"""
-        print data, reqID    
+        print(data, reqID)    
         
     #----------------------------------------------------------------------
     def getAccounts(self):
@@ -300,7 +301,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onGetAccounts(self, data, reqID):
         """回调函数"""
-        print data, reqID   
+        print(data, reqID)   
         
     #----------------------------------------------------------------------
     def getAccountInfo(self):
@@ -310,7 +311,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onGetAccountInfo(self, data, reqID):
         """回调函数"""
-        print data, reqID   
+        print(data, reqID)   
         
     #----------------------------------------------------------------------
     def getOrders(self, params):
@@ -320,7 +321,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onGetOrders(self, data, reqID):
         """回调函数"""
-        print data, reqID     
+        print(data, reqID)     
 
     #----------------------------------------------------------------------
     def sendOrder(self, params):
@@ -330,7 +331,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onSendOrder(self, data, reqID):
         """回调函数"""
-        print data, reqID         
+        print(data, reqID)         
     
     #----------------------------------------------------------------------
     def getOrderInfo(self, optional):
@@ -340,7 +341,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onGetOrderInfo(self, data, reqID):
         """回调函数"""
-        print data, reqID     
+        print(data, reqID)     
         
     #----------------------------------------------------------------------
     def modifyOrder(self, params, optional):
@@ -350,7 +351,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onModifyOrder(self, data, reqID):
         """回调函数"""
-        print data, reqID      
+        print(data, reqID)      
     
     #----------------------------------------------------------------------
     def cancelOrder(self, optional):
@@ -360,7 +361,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onCancelOrder(self, data, reqID):
         """回调函数"""
-        print data, reqID     
+        print(data, reqID)     
     
     #----------------------------------------------------------------------
     def getTrades(self, params):
@@ -370,7 +371,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onGetTrades(self, data, reqID):
         """回调函数"""
-        print data, reqID     
+        print(data, reqID)     
     
     #----------------------------------------------------------------------
     def getTradeInfo(self, optional):
@@ -380,7 +381,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onGetTradeInfo(self, data, reqID):
         """回调函数"""
-        print data, reqID     
+        print(data, reqID)     
         
     #----------------------------------------------------------------------
     def modifyTrade(self, params, optional):
@@ -390,7 +391,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onModifyTrade(self, data, reqID):
         """回调函数"""
-        print data, reqID      
+        print(data, reqID)      
     
     #----------------------------------------------------------------------
     def closeTrade(self, optional):
@@ -400,7 +401,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onCloseTrade(self, data, reqID):
         """回调函数"""
-        print data, reqID         
+        print(data, reqID)         
 
     #----------------------------------------------------------------------
     def getPositions(self):
@@ -410,7 +411,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onGetPositions(self, data, reqID):
         """回调函数"""
-        print data, reqID  
+        print(data, reqID)  
         
     #----------------------------------------------------------------------
     def getPositionInfo(self, optional):
@@ -420,7 +421,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onGetPositionInfo(self, data, reqID):
         """回调函数"""
-        print data, reqID         
+        print(data, reqID)         
 
     #----------------------------------------------------------------------
     def closePosition(self, optional):
@@ -430,7 +431,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onClosePosition(self, data, reqID):
         """回调函数"""
-        print data, reqID      
+        print(data, reqID)      
     
     
     #----------------------------------------------------------------------
@@ -441,7 +442,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onGetTransactions(self, data, reqID):
         """回调函数"""
-        print data, reqID  
+        print(data, reqID)  
         
     #----------------------------------------------------------------------
     def getTransactionInfo(self, optional):
@@ -451,7 +452,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onGetTransactionInfo(self, data, reqID):
         """回调函数"""
-        print data, reqID   
+        print(data, reqID)   
         
     #----------------------------------------------------------------------
     def getAccountHistory(self):
@@ -461,7 +462,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onGetAccountHistory(self, data, reqID):
         """回调函数"""
-        print data, reqID      
+        print(data, reqID)      
     
     #----------------------------------------------------------------------
     def getCalendar(self, params):
@@ -471,7 +472,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onGetCalendar(self, data, reqID):
         """回调函数"""
-        print data, reqID       
+        print(data, reqID)       
         
     #----------------------------------------------------------------------
     def getPositionRatios(self, params):
@@ -481,7 +482,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onGetPositionRatios(self, data, reqID):
         """回调函数"""
-        print data, reqID  
+        print(data, reqID)  
         
     #----------------------------------------------------------------------
     def getSpreads(self, params):
@@ -491,7 +492,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onGetSpreads(self, data, reqID):
         """回调函数"""
-        print data, reqID       
+        print(data, reqID)       
         
     #----------------------------------------------------------------------
     def getCommitments(self, params):
@@ -501,7 +502,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onGetCommitments(self, data, reqID):
         """回调函数"""
-        print data, reqID       
+        print(data, reqID)       
     
     #----------------------------------------------------------------------
     def getOrderbook(self, params):
@@ -511,7 +512,7 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onGetOrderbook(self, data, reqID):
         """回调函数"""
-        print data, reqID       
+        print(data, reqID)       
         
     #----------------------------------------------------------------------
     def getAutochartist(self, params):
@@ -521,17 +522,17 @@ class OandaApi(object):
     #----------------------------------------------------------------------
     def onGetAutochartist(self, data, reqID):
         """回调函数"""
-        print data, reqID   
+        print(data, reqID)   
         
     #----------------------------------------------------------------------
     def onPrice(self, data):
         """行情推送"""
-        print data
+        print(data)
         
     #----------------------------------------------------------------------
     def onEvent(self, data):
         """事件推送（成交等）"""
-        print data
+        print(data)
         
     #----------------------------------------------------------------------
     def processStreamPrices(self):
@@ -546,7 +547,7 @@ class OandaApi(object):
             try:
                 data = r.json()
                 symbols = [d['instrument'] for d in data['instruments']]   
-            except Exception, e:
+            except Exception as e:
                 self.onError(e, -1)
                 return
         else:
@@ -570,10 +571,10 @@ class OandaApi(object):
                         msg = json.loads(line)
                         
                         if self.DEBUG:
-                            print self.onPrice.__name__
+                            print(self.onPrice.__name__)
                             
                         self.onPrice(msg)
-                    except Exception, e:
+                    except Exception as e:
                         self.onError(e, -1)
                 
                 if not self.active:
@@ -597,10 +598,10 @@ class OandaApi(object):
                         msg = json.loads(line)
                         
                         if self.DEBUG:
-                            print self.onEvent.__name__
+                            print(self.onEvent.__name__)
                             
                         self.onEvent(msg)
-                    except Exception, e:
+                    except Exception as e:
                         self.onError(e, -1)
                 
                 if not self.active:

--- a/vnpy/api/qdp/__init__.py
+++ b/vnpy/api/qdp/__init__.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
-from vnqdpmd import MdApi
-from vnqdptd import TdApi
-from qdp_data_type import defineDict
+from __future__ import absolute_import
+from .vnqdpmd import MdApi
+from .vnqdptd import TdApi
+from .qdp_data_type import defineDict

--- a/vnpy/api/qdp/pyscript/generate_data_type.py
+++ b/vnpy/api/qdp/pyscript/generate_data_type.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 # C++和python类型的映射字典
@@ -92,9 +93,9 @@ def main():
         fcpp.close()
         fpy.close()
 
-        print u'data_type.py生成过程完成'
+        print(u'data_type.py生成过程完成')
     except:
-        print u'data_type.py生成过程出错'
+        print(u'data_type.py生成过程出错')
 
 
 if __name__ == '__main__':

--- a/vnpy/api/qdp/pyscript/generate_td_functions.py
+++ b/vnpy/api/qdp/pyscript/generate_td_functions.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 from string import join
@@ -250,8 +251,8 @@ def createFunction(fcName, fcArgsTypeList, fcArgsValueList):
         ffunction.write(line)
 
         if type_ == 'CQdpFtdcInputOrderField':
-            print key, value
-            print line
+            print(key, value)
+            print(line)
 
     ffunction.write('\tint i = this->api->' + fcName + '(&myreq, nRequestID);\n')
     ffunction.write('\treturn i;\n')

--- a/vnpy/api/sec/__init__.py
+++ b/vnpy/api/sec/__init__.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
-from vnsecmd import MdApi
-from vnsectd import TdApi
-import sec_data_type as DATA_TYPE
+from __future__ import absolute_import
+from .vnsecmd import MdApi
+from .vnsectd import TdApi
+from . import sec_data_type as DATA_TYPE

--- a/vnpy/api/sec/pyscript/generate_data_type.py
+++ b/vnpy/api/sec/pyscript/generate_data_type.py
@@ -2,6 +2,7 @@
 
 
 # C++和Python类型映射
+from __future__ import print_function
 type_map = {
     'int': 'int',
     'long': 'long', 
@@ -97,7 +98,7 @@ def main(cpp_filename, py_filename):
     cpp_f.close()
     py_f.close()
         
-    print u'data_type处理完成'
+    print(u'data_type处理完成')
     
 
 if __name__ == '__main__':

--- a/vnpy/api/sec/pyscript/generate_md_functions.py
+++ b/vnpy/api/sec/pyscript/generate_md_functions.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 from generate_data_type import pre_process
 
 import sec_struct
@@ -69,7 +70,7 @@ def process_function(cpp_line):
         args_type_list.append(l[0])
         args_name_list.append(l[1])    
 
-    print args_type_list
+    print(args_type_list)
     if args_type_list and args_type_list[0] in STRUCT_DICT:
         create_function(fc_name, args_type_list, args_name_list)
     
@@ -298,4 +299,4 @@ header_process_f.close()
 header_on_f.close()
 header_function_f.close()
 
-print API_NAME + u'处理完成'
+print(API_NAME + u'处理完成')

--- a/vnpy/api/sec/pyscript/generate_struct.py
+++ b/vnpy/api/sec/pyscript/generate_struct.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 from generate_data_type import pre_process
 
 import sec_data_type
@@ -62,7 +63,7 @@ def main(cpp_filename, py_filename):
     cpp_f.close()
     py_f.close()
         
-    print u'struct处理完成'
+    print(u'struct处理完成')
     
 
 if __name__ == '__main__':

--- a/vnpy/api/sec/pyscript/generate_td_functions.py
+++ b/vnpy/api/sec/pyscript/generate_td_functions.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 from generate_data_type import pre_process
 
 import sec_struct
@@ -69,7 +70,7 @@ def process_function(cpp_line):
         args_type_list.append(l[0])
         args_name_list.append(l[1])    
 
-    print args_type_list
+    print(args_type_list)
     if args_type_list and args_type_list[0] in STRUCT_DICT:
         create_function(fc_name, args_type_list, args_name_list)
     
@@ -298,4 +299,4 @@ header_process_f.close()
 header_on_f.close()
 header_function_f.close()
 
-print API_NAME + u'处理完成'
+print(API_NAME + u'处理完成')

--- a/vnpy/api/sec/test/md_test.py
+++ b/vnpy/api/sec/test/md_test.py
@@ -1,16 +1,21 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import sys
 
 from vnsecmd import MdApi
 
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
 
 #----------------------------------------------------------------------
 def print_dict(d):
     """输出字典"""
     for k, v in d.items():
-        print '%s:%s' %(k, v)
-    
+        print('%s:%s' %(k, v))
+
 
 ########################################################################
 class TestMdApi(MdApi):
@@ -20,134 +25,134 @@ class TestMdApi(MdApi):
     def __init__(self):
         """Constructor"""
         super(TestMdApi, self).__init__()
-    
+
     #----------------------------------------------------------------------
     def onFrontConnected(self):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onFrontDisconnected(self, reason):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRtnNotice(self, data):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspError(self, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-        print dict(error)
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+        print(dict(error))
+
     #----------------------------------------------------------------------
     def onRspStockUserLogin(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockUserLogout(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPUserLogin(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
+        print(sys._getframe().f_code.co_name)
+        print(locals())
         print_dict(data)
         print_dict(error)
-    
+
     #----------------------------------------------------------------------
     def onRspSOPUserLogout(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLUserLogin(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLUserLogout(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockSubMarketData(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockUnSubMarketData(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPSubMarketData(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPUnSubMarketData(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onStockMarketData(self, data):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onSOPMarketData(self, data):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockAvailableQuot(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSopAvailableQuot(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspUserMDPasswordUpdate(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
+        print(sys._getframe().f_code.co_name)
+        print(locals())
 
 
 if __name__ == '__main__':
     SERVER_ADDRESS = 'tcp://203.86.95.187:10915'
     ACCOUNT = '110100001088'
     PASSWORD = '123456'
-    
+
     api = TestMdApi()
     api.createDFITCMdApi('')
     api.init('tcp://203.86.95.187:10915')
-    
+
     # 登录
     req_id = 1
     req = {
@@ -155,7 +160,7 @@ if __name__ == '__main__':
         'password': PASSWORD,
         'requestID': req_id
     }
-    
+
     api.reqSOPUserLogin(req)
-    
+
     raw_input()

--- a/vnpy/api/sec/test/td_test.py
+++ b/vnpy/api/sec/test/td_test.py
@@ -1,16 +1,21 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import sys
 
 from vnsectd import TdApi
 
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
 
 #----------------------------------------------------------------------
 def print_dict(d):
     """输出字典"""
     for k, v in d.items():
-        print '%s:%s' %(k, v)
-    
+        print('%s:%s' %(k, v))
+
 
 ########################################################################
 class TestTdApi(TdApi):
@@ -20,560 +25,560 @@ class TestTdApi(TdApi):
     def __init__(self):
         """Constructor"""
         super(TestTdApi, self).__init__()
-    
+
     #----------------------------------------------------------------------
     def onFrontConnected(self, ):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onFrontDisconnected(self, reason):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRtnNotice(self, data):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspError(self, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockUserLogin(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockUserLogout(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockUserPasswordUpdate(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockEntrustOrder(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockWithdrawOrder(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockQryEntrustOrder(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockQryRealTimeTrade(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockQrySerialTrade(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockQryPosition(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockQryCapitalAccountInfo(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockQryAccountInfo(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockQryShareholderInfo(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockTransferFunds(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockEntrustBatchOrder(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockWithdrawBatchOrder(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockCalcAbleEntrustQty(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockCalcAblePurchaseETFQty(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockQryFreezeFundsDetail(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockQryFreezeStockDetail(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockQryTransferStockDetail(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockQryTransferFundsDetail(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockQryStockInfo(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockQryStockStaticInfo(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspStockQryTradeTime(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onStockEntrustOrderRtn(self, data):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onStockTradeRtn(self, data):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onStockWithdrawOrderRtn(self, data):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPUserLogin(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
+        print(sys._getframe().f_code.co_name)
+        print(locals())
         print_dict(data)
         print_dict(error)
-    
+
     #----------------------------------------------------------------------
     def onRspSOPUserLogout(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPUserPasswordUpdate(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPEntrustOrder(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPGroupSplit(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPQryGroupPosition(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPLockOUnLockStock(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPWithdrawOrder(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPQryEntrustOrder(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPQrySerialTrade(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPQryPosition(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPQryCollateralPosition(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPQryCapitalAccountInfo(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPQryAccountInfo(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPQryShareholderInfo(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPCalcAbleEntrustQty(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPQryAbleLockStock(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPQryContactInfo(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPExectueOrder(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPQryExecAssiInfo(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPQryTradeTime(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPQryExchangeInfo(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPQryCommission(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPQryDeposit(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspSOPQryContractObjectInfo(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onSOPEntrustOrderRtn(self, data):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onSOPTradeRtn(self, data):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onSOPWithdrawOrderRtn(self, data):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLUserLogin(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLUserLogout(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLQryAbleFinInfo(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLQryAbleSloInfo(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLTransferCollateral(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLDirectRepayment(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLRepayStockTransfer(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLEntrustCrdtOrder(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLEntrustOrder(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLCalcAbleEntrustCrdtQty(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLQryCrdtFunds(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLQryCrdtContract(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLQryCrdtConChangeInfo(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLTransferFunds(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLQryAccountInfo(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLQryCapitalAccountInfo(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLQryShareholderInfo(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLQryPosition(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLQryEntrustOrder(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLQrySerialTrade(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLQryRealTimeTrade(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLQryFreezeFundsDetail(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLQryFreezeStockDetail(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLQryTransferFundsDetail(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLWithdrawOrder(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLQrySystemTime(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLQryTransferredContract(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLDesirableFundsOut(self, data, error):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLQryGuaranteedContract(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onRspFASLQryUnderlyingContract(self, data, error, flag):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onFASLEntrustOrderRtn(self, data):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onFASLTradeRtn(self, data):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
-    
+        print(sys._getframe().f_code.co_name)
+        print(locals())
+
     #----------------------------------------------------------------------
     def onFASLWithdrawOrderRtn(self, data):
         """"""
-        print sys._getframe().f_code.co_name
-        print locals()
+        print(sys._getframe().f_code.co_name)
+        print(locals())
 
 
 
@@ -581,11 +586,11 @@ if __name__ == '__main__':
     SERVER_ADDRESS = 'tcp://203.86.95.187:10910'
     ACCOUNT = '110100001088'
     PASSWORD = '123456'
-    
+
     api = TestTdApi()
     api.createDFITCSECTraderApi('')
     api.init(SERVER_ADDRESS)
-    
+
     # 登录
     req_id = 1
     req = {
@@ -593,7 +598,7 @@ if __name__ == '__main__':
         'password': PASSWORD,
         'requestID': req_id
     }
-    
+
     api.reqSOPUserLogin(req)
-    
+
     raw_input()

--- a/vnpy/api/sgit/__init__.py
+++ b/vnpy/api/sgit/__init__.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
-from vnsgitmd import MdApi
-from vnsgittd import TdApi
-from sgit_data_type import defineDict
+from __future__ import absolute_import
+from .vnsgitmd import MdApi
+from .vnsgittd import TdApi
+from .sgit_data_type import defineDict

--- a/vnpy/api/shzd/__init__.py
+++ b/vnpy/api/shzd/__init__.py
@@ -1,3 +1,4 @@
 # encoding: UTF-8
 
-from vnshzd import ShzdApi
+from __future__ import absolute_import
+from .vnshzd import ShzdApi

--- a/vnpy/api/shzd/test/test.py
+++ b/vnpy/api/shzd/test/test.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 from time import sleep
 
 from vnshzd import *
@@ -10,7 +11,7 @@ def printDict(d):
     l = d.keys()
     l.sort()
     for key in l:
-        print '%s:%s' %(key, d[key])
+        print('%s:%s' %(key, d[key]))
 
 
 ########################################################################
@@ -26,19 +27,19 @@ class TestApi(ShzdApi):
     #----------------------------------------------------------------------
     def onReceiveErrorInfo(self, errcode, errmsg):
         """"""
-        print '-' * 50
-        print 'errorcode %s, error msg %s' %(errcode, errmsg)
+        print('-' * 50)
+        print('errorcode %s, error msg %s' %(errcode, errmsg))
     
     #----------------------------------------------------------------------
     def onReceiveMarketInfo(self, data):
         """"""
-        print '-' * 50
+        print('-' * 50)
         printDict(data)
     
     #----------------------------------------------------------------------
     def onReceiveTradeInfo(self, data):
         """"""
-        print '-' * 50
+        print('-' * 50)
         printDict(data)
         
 if __name__ == '__main__':
@@ -49,8 +50,8 @@ if __name__ == '__main__':
     api.initShZdServer()
     
     # 注册前置机地址
-    print api.registerFront('222.73.119.230', 7003)
-    print api.registerMarket('222.73.119.230', 9003)
+    print(api.registerFront('222.73.119.230', 7003))
+    print(api.registerMarket('222.73.119.230', 9003))
     
     # 登录
     sleep(1)
@@ -68,7 +69,7 @@ if __name__ == '__main__':
     data['201'] = '+'
     #data['307'] = "CME,6J1609"
     data['307'] = 'ICE,WBS1611'
-    print data
+    print(data)
     api.shzdSendInfoToMarket(data)
     
     # # 查询合约

--- a/vnpy/api/xspeed/__init__.py
+++ b/vnpy/api/xspeed/__init__.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
-from vnxspeedmd import MdApi
-from vnxspeedtd import TdApi
-from xspeed_data_type import defineDict
+from __future__ import absolute_import
+from .vnxspeedmd import MdApi
+from .vnxspeedtd import TdApi
+from .xspeed_data_type import defineDict

--- a/vnpy/api/xspeed/pyscript/generate_data_type.py
+++ b/vnpy/api/xspeed/pyscript/generate_data_type.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 # C++和python类型的映射字典
@@ -48,7 +49,7 @@ def process_typedef(line):
     else:
         keyword = content[-1]
         keyword = keyword.replace(';\n', '')
-        print content, keyword
+        print(content, keyword)
 
     if '[' in keyword:
         i = keyword.index('[')
@@ -97,15 +98,15 @@ def main():
             py_line = process_line(line)
             if py_line:
                 fpy.write(py_line.decode('gbk').encode('utf-8'))
-                print n 
+                print(n) 
 
         fcpp.close()
         fpy.close()
 
-        print u'data_type.py生成过程完成'
-    except Exception, e:
-        print u'data_type.py生成过程出错'
-        print e
+        print(u'data_type.py生成过程完成')
+    except Exception as e:
+        print(u'data_type.py生成过程出错')
+        print(e)
 
 
 if __name__ == '__main__':

--- a/vnpy/api/xspeed/pyscript/generate_md_functions.py
+++ b/vnpy/api/xspeed/pyscript/generate_md_functions.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 from string import join
@@ -224,7 +225,7 @@ def processFunction(line):
             fcArgsTypeList.append(content[1])           # 参数类型列表
             fcArgsValueList.append(content[3])          # 参数数据列表
 
-    print fcArgsTypeList
+    print(fcArgsTypeList)
     if len(fcArgsTypeList)>0 and fcArgsTypeList[0] in structDict:
         createFunction(fcName, fcArgsTypeList, fcArgsValueList)
         
@@ -286,10 +287,10 @@ define_count = 1
 
 for line in fcpp:
     if "    virtual void On" in line:
-        print 'callback'
+        print('callback')
         processCallBack(line)
     elif "    virtual int" in line:
-        print 'function'
+        print('function')
         processFunction(line)
 
 fcpp.close()

--- a/vnpy/api/xspeed/pyscript/generate_struct.py
+++ b/vnpy/api/xspeed/pyscript/generate_struct.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 from xspeed_data_type import *
@@ -47,10 +48,10 @@ def main():
                 n = line.index('//')
                 line = line[:n]
 
-            print no, ':', line
+            print(no, ':', line)
 
             content = line.split('\t')
-            print content
+            print(content)
 
             typedef = content[1]
             type_ = typedefDict[typedef]

--- a/vnpy/api/xspeed/pyscript/generate_td_functions.py
+++ b/vnpy/api/xspeed/pyscript/generate_td_functions.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 from string import join
@@ -33,7 +34,7 @@ def processCallBack(line):
                 cbArgsTypeList.append(content[0])           # 参数类型列表
                 cbArgsValueList.append(content[1])          # 参数数据列表
             else:
-                print content
+                print(content)
                 cbArgsTypeList.append(content[1])           # 参数类型列表
                 cbArgsValueList.append(content[2]+content[3])          # 参数数据列表
 
@@ -230,8 +231,8 @@ def processFunction(line):
             fcArgsTypeList.append(content[1])           # 参数类型列表
             fcArgsValueList.append(content[3])          # 参数数据列表
 
-    print line
-    print fcArgsTypeList
+    print(line)
+    print(fcArgsTypeList)
     if len(fcArgsTypeList)>0 and fcArgsTypeList[0] in structDict:
         createFunction(fcName, fcArgsTypeList, fcArgsValueList)
         
@@ -263,7 +264,7 @@ def createFunction(fcName, fcArgsTypeList, fcArgsValueList):
         elif value == 'short':
             line = '\tgetShort(req, "' + key + '", &myreq.' + key + ');\n'
         elif value == 'float':
-            print line
+            print(line)
             line = '\tgetDouble(req, "' + key + '", &myreq.' + key + ');\n'
         ffunction.write(line)
 
@@ -294,10 +295,10 @@ define_count = 1
 
 for line in fcpp:
     if "    virtual void On" in line:
-        print 'callback'
+        print('callback')
         processCallBack(line)
     elif "    virtual int" in line:
-        print 'function'
+        print('function')
         processFunction(line)
 
 fcpp.close()

--- a/vnpy/api/xspeed/pyscript/old/generate_data_type.py
+++ b/vnpy/api/xspeed/pyscript/old/generate_data_type.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 # C++和python类型的映射字典
@@ -48,7 +49,7 @@ def process_typedef(line):
     else:
         keyword = content[-1]
         keyword = keyword.replace(';\n', '')
-        print content, keyword
+        print(content, keyword)
 
     if '[' in keyword:
         i = keyword.index('[')
@@ -91,15 +92,15 @@ def main():
             py_line = process_line(line)
             if py_line:
                 fpy.write(py_line.decode('gbk').encode('utf-8'))
-                print n 
+                print(n) 
 
         fcpp.close()
         fpy.close()
 
-        print u'data_type.py生成过程完成'
-    except Exception, e:
-        print u'data_type.py生成过程出错'
-        print e
+        print(u'data_type.py生成过程完成')
+    except Exception as e:
+        print(u'data_type.py生成过程出错')
+        print(e)
 
 
 if __name__ == '__main__':

--- a/vnpy/api/xspeed/pyscript/old/generate_struct.py
+++ b/vnpy/api/xspeed/pyscript/old/generate_struct.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 from ksgold_data_type import *
@@ -47,7 +48,7 @@ def main():
                 n = line.index('//')
                 line = line[:n]
 
-            print no, ':', line
+            print(no, ':', line)
 
             content = line.split('\t')
 

--- a/vnpy/api/xspeed/test/xspeedmdtest.py
+++ b/vnpy/api/xspeed/test/xspeedmdtest.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import sys
 from time import sleep
 import datetime
@@ -13,7 +14,7 @@ from vnxspeedmd import *
 def print_dict(d):
     """按照键值打印一个字典"""
     for key,value in d.items():
-        print key + ':' + str(value)
+        print(key + ':' + str(value))
 
 
 def parseDateTime(date,time,milli):
@@ -32,8 +33,8 @@ def parseDateTime(date,time,milli):
 def simple_log(func):
     """简单装饰器用于输出函数名"""
     def wrapper(*args, **kw):
-        print ""
-        print str(func.__name__)
+        print("")
+        print(str(func.__name__))
         return func(*args, **kw)
     return wrapper
 
@@ -57,7 +58,7 @@ class TestMdApi(MdApi):
     @simple_log
     def onFrontDisconnected(self, n):
         """服务器断开"""
-        print n
+        print(n)
 
     #----------------------------------------------------------------------
     @simple_log

--- a/vnpy/api/xspeed/test/xspeedtdtest.py
+++ b/vnpy/api/xspeed/test/xspeedtdtest.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import sys
 from time import sleep
 
@@ -12,15 +13,15 @@ from vnxspeedtd import *
 def print_dict(d):
     """按照键值打印一个字典"""
     for key,value in d.items():
-        print key + ':' + str(value)
+        print(key + ':' + str(value))
 
 
 #----------------------------------------------------------------------
 def simple_log(func):
     """简单装饰器用于输出函数名"""
     def wrapper(*args, **kw):
-        print ""
-        print str(func.__name__)
+        print("")
+        print(str(func.__name__))
         return func(*args, **kw)
     return wrapper
 
@@ -43,7 +44,7 @@ class TestTdApi(TdApi):
     @simple_log
     def onFrontDisconnected(self, n):
         """服务器断开"""
-        print n
+        print(n)
 
     #----------------------------------------------------------------------
     @simple_log
@@ -82,7 +83,7 @@ class TestTdApi(TdApi):
         """查询持仓"""
         print_dict(data)
         print_dict(error)
-        print last
+        print(last)
 
     #----------------------------------------------------------------------
     @simple_log
@@ -90,7 +91,7 @@ class TestTdApi(TdApi):
         """查询持仓"""
         print_dict(data)
         print_dict(error)
-        print last
+        print(last)
 
     #----------------------------------------------------------------------
     @simple_log
@@ -105,7 +106,7 @@ class TestTdApi(TdApi):
         """查询持仓"""
         print_dict(data)
         print_dict(error)
-        print last
+        print(last)
 
     #----------------------------------------------------------------------
     @simple_log
@@ -113,7 +114,7 @@ class TestTdApi(TdApi):
         """查询持仓"""
         print_dict(data)
         print_dict(error)
-        print last
+        print(last)
 
     #----------------------------------------------------------------------
     @simple_log
@@ -145,7 +146,7 @@ class TestTdApi(TdApi):
         """查询持仓"""
         print_dict(data)
         print_dict(error)
-        print last
+        print(last)
 
     #----------------------------------------------------------------------
     @simple_log
@@ -153,7 +154,7 @@ class TestTdApi(TdApi):
         """查询持仓"""
         print_dict(data)
         print_dict(error)
-        print last
+        print(last)
 
     #----------------------------------------------------------------------
     @simple_log
@@ -161,7 +162,7 @@ class TestTdApi(TdApi):
         """查询持仓"""
         print_dict(data)
         print_dict(error)
-        print last
+        print(last)
 
     #----------------------------------------------------------------------
     @simple_log
@@ -188,7 +189,7 @@ class TestTdApi(TdApi):
         """查询持仓"""
         print_dict(data)
         print_dict(error)
-        print last
+        print(last)
 
     #----------------------------------------------------------------------
     @simple_log
@@ -203,7 +204,7 @@ class TestTdApi(TdApi):
         """查询持仓"""
         print_dict(data)
         print_dict(error)
-        print last
+        print(last)
 
     #----------------------------------------------------------------------
     @simple_log
@@ -217,7 +218,7 @@ class TestTdApi(TdApi):
         """查询持仓"""
         print_dict(data)
         print_dict(error)
-        print last
+        print(last)
 
     #----------------------------------------------------------------------
     @simple_log
@@ -225,7 +226,7 @@ class TestTdApi(TdApi):
         """查询持仓"""
         print_dict(data)
         print_dict(error)
-        print last
+        print(last)
 
     #----------------------------------------------------------------------
     @simple_log
@@ -233,7 +234,7 @@ class TestTdApi(TdApi):
         """查询持仓"""
         print_dict(data)
         print_dict(error)
-        print last
+        print(last)
 
 
 #----------------------------------------------------------------------

--- a/vnpy/api/xtp/__init__.py
+++ b/vnpy/api/xtp/__init__.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
-from vnxtpquote import QuoteApi
-from vnxtptrader import TraderApi
-from xtp_data_type import *
+from __future__ import absolute_import
+from .vnxtpquote import QuoteApi
+from .vnxtptrader import TraderApi
+from .xtp_data_type import *

--- a/vnpy/api/xtp/pyscript/generate_data_type.py
+++ b/vnpy/api/xtp/pyscript/generate_data_type.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = u'用Python的交易员'
 
 # C++和python类型的映射字典
@@ -128,7 +129,7 @@ def main():
     fcpp.close()
     fpy.close()
 
-    print u'data_type.py生成过程完成'
+    print(u'data_type.py生成过程完成')
 
 
 if __name__ == '__main__':

--- a/vnpy/api/xtp/pyscript/generate_md_functions.py
+++ b/vnpy/api/xtp/pyscript/generate_md_functions.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 from string import join
@@ -331,4 +332,4 @@ fheaderon.close()
 fheaderfunction.close()
 fwrap.close()
 
-print 'md functions done'
+print('md functions done')

--- a/vnpy/api/xtp/pyscript/generate_struct_oms.py
+++ b/vnpy/api/xtp/pyscript/generate_struct_oms.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 from xtp_data_type import *
@@ -27,7 +28,7 @@ def main():
     fpy.write('\n')
 
     for row, line in enumerate(fcpp):
-        print row
+        print(row)
         # 结构体申明注释
         if '///' in line and '\t' not in line:
             py_line = '#' + line[3:]
@@ -38,7 +39,7 @@ def main():
 
         # 结构体申明
         elif 'struct ' in line:
-            print line
+            print(line)
             content = line.split(' ')
             name = content[1].replace('\n','')
             name = name.replace('\r', '')

--- a/vnpy/api/xtp/pyscript/generate_struct_quote.py
+++ b/vnpy/api/xtp/pyscript/generate_struct_quote.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 from xtp_data_type import *
@@ -38,7 +39,7 @@ def main():
 
     lcpp = replaceTabs(fcpp)
     for n, line in enumerate(lcpp):
-        print n
+        print(n)
         # 结构体申明注释
         if '///' in line and '\t' not in line:
             py_line = '#' + line[3:]

--- a/vnpy/api/xtp/pyscript/generate_td_functions.py
+++ b/vnpy/api/xtp/pyscript/generate_td_functions.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 __author__ = 'CHENXY'
 
 from string import join
@@ -194,7 +195,7 @@ def createProcess(cbName, cbArgsTypeList, cbArgsValueList):
     fprocess.write("    PyLock lock;\n")
 
     onArgsList = []
-    print cbName, cbArgsTypeList
+    print(cbName, cbArgsTypeList)
     
     for i, type_ in enumerate(cbArgsTypeList):
         if 'XTPRI' in type_:
@@ -258,7 +259,7 @@ def processFunction(line):
     fcArgs = fcArgs.replace(')', '')
 
     fcArgsList = fcArgs.split(', ')                 # 将每个参数转化为列表
-    print fcArgsList
+    print(fcArgsList)
     fcArgsTypeList = []
     fcArgsValueList = []
 
@@ -352,4 +353,4 @@ fheaderon.close()
 fheaderfunction.close()
 fwrap.close()
 
-print 'td functions done'
+print('td functions done')

--- a/vnpy/api/xtp/test/quotetest.py
+++ b/vnpy/api/xtp/test/quotetest.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import os
 from time import sleep
 
@@ -8,11 +9,11 @@ from vnxtpquote import *
 #----------------------------------------------------------------------
 def printDict(d):
     """"""
-    print '-' * 50
+    print('-' * 50)
     l = d.keys()
     l.sort()
     for k in l:
-        print k, d[k]
+        print(k, d[k])
     
     
 
@@ -28,32 +29,32 @@ class TestApi(QuoteApi):
     #----------------------------------------------------------------------
     def onDisconnected(self, reason):
         """"""
-        print 'disconnect', reason
+        print('disconnect', reason)
         
     #----------------------------------------------------------------------
     def onError(self, data):
         """"""
-        print 'error'
+        print('error')
         printDict(data)
         
     #----------------------------------------------------------------------
     def onSubMarketData(self, data, error, last):
         """"""
-        print 'sub market data'
+        print('sub market data')
         printDict(data)
         printDict(error)
         
     #----------------------------------------------------------------------
     def onUnSubMarketData(self, data, error, last):
         """"""
-        print 'unsub market data'
+        print('unsub market data')
         printDict(data)
         printDict(error)
         
     #----------------------------------------------------------------------
     def onMarketData(self, data):
         """"""
-        print 'new market data'
+        print('new market data')
         printDict(data)
         
     #----------------------------------------------------------------------
@@ -75,7 +76,7 @@ if __name__ == '__main__':
     
     # 登录
     n = api.login(ip, port, user, password, 1)
-    print 'login result', n    
+    print('login result', n)    
     
     # 订阅行情
     api.subscribeMarketData('000001', 2)

--- a/vnpy/api/xtp/test/tradertest.py
+++ b/vnpy/api/xtp/test/tradertest.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import os
 from time import sleep
 
@@ -8,11 +9,11 @@ from vnxtptrader import *
 #----------------------------------------------------------------------
 def printDict(d):
     """"""
-    print '-' * 50
+    print('-' * 50)
     l = d.keys()
     l.sort()
     for k in l:
-        print k, d[k]
+        print(k, d[k])
     
     
 
@@ -28,79 +29,79 @@ class TestApi(TraderApi):
     #----------------------------------------------------------------------
     def onDisconnected(self, reason):
         """"""
-        print '-' * 30
-        print 'onDisconnected'
-        print reason
+        print('-' * 30)
+        print('onDisconnected')
+        print(reason)
         
     #----------------------------------------------------------------------
     def onError(self, data):
         """"""
-        print '-' * 30
-        print 'onError'
+        print('-' * 30)
+        print('onError')
         printDict(data)
         
     #----------------------------------------------------------------------
     def onOrderEvent(self, data, error):
         """"""
-        print '-' * 30
-        print 'onOrderEvent'
+        print('-' * 30)
+        print('onOrderEvent')
         printDict(data)
         printDict(error)
         
     #----------------------------------------------------------------------
     def onTradeEvent(self, data):
         """"""
-        print '-' * 30
-        print 'onTradeEvent'
+        print('-' * 30)
+        print('onTradeEvent')
         printDict(data)
         
     #----------------------------------------------------------------------
     def onCancelOrderError(self, data, error):
         """"""
-        print '-' * 30
-        print 'onCancelOrderError'
+        print('-' * 30)
+        print('onCancelOrderError')
         printDict(data)
         printDict(error)
         
     #----------------------------------------------------------------------
     def onQueryOrder(self, data, error, reqid, last):
         """"""
-        print '-' * 30
-        print 'onQueryOrder'
+        print('-' * 30)
+        print('onQueryOrder')
         printDict(data)
         printDict(error) 
-        print reqid
-        print last
+        print(reqid)
+        print(last)
         
     #----------------------------------------------------------------------
     def onQueryTrade(self, data, error, reqid, last):
         """"""
-        print '-' * 30
-        print 'onQueryTrade'
+        print('-' * 30)
+        print('onQueryTrade')
         printDict(data)
         printDict(error)
-        print reqid
-        print last        
+        print(reqid)
+        print(last)        
         
     #----------------------------------------------------------------------
     def onQueryPosition(self, data, error, reqid, last):
         """"""
-        print '-' * 30
-        print 'onQueryPosition'
+        print('-' * 30)
+        print('onQueryPosition')
         printDict(data)
         printDict(error)
-        print reqid
-        print last        
+        print(reqid)
+        print(last)        
         
     #----------------------------------------------------------------------
     def onQueryAsset(self, data, error, reqid, last):
         """"""
-        print '-' * 30
-        print 'onQueryAsset'
+        print('-' * 30)
+        print('onQueryAsset')
         printDict(data)
         printDict(error)
-        print reqid
-        print last        
+        print(reqid)
+        print(last)        
 
 
 
@@ -121,12 +122,12 @@ if __name__ == '__main__':
     
     # 登录
     session = api.login(ip, port, user, password, 1)
-    print 'login result', session
+    print('login result', session)
 
     # 调用同步函数查询一些信息
-    print 'trading day is:', api.getTradingDay()
-    print 'api version is:', api.getApiVersion()
-    print 'last error is:', api.getApiLastError()
+    print('trading day is:', api.getTradingDay())
+    print('api version is:', api.getApiVersion())
+    print('last error is:', api.getApiLastError())
     
     # 查询资产
     sleep(2)
@@ -166,7 +167,7 @@ if __name__ == '__main__':
     
     # 登出
     sleep(5)
-    print 'logout:', api.logout(session)
+    print('logout:', api.logout(session))
     
     # 阻塞
     raw_input()

--- a/vnpy/data/datayes/__init__.py
+++ b/vnpy/data/datayes/__init__.py
@@ -1,1 +1,2 @@
-from vndatayes import DatayesApi
+from __future__ import absolute_import
+from .vndatayes import DatayesApi

--- a/vnpy/data/datayes/vndatayes.py
+++ b/vnpy/data/datayes/vndatayes.py
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
 '''一个简单的通联数据客户端，主要使用requests开发，比通联官网的python例子更为简洁。'''
+from __future__ import print_function
 
 import os
 import requests
@@ -34,7 +35,7 @@ class DatayesApi(object):
         r = requests.get(url=url, headers=self.header, params=params)
         
         if r.status_code != HTTP_OK:
-            print u'http请求失败，状态代码%s' %r.status_code
+            print(u'http请求失败，状态代码%s' %r.status_code)
             return None
         else:
             result = r.json()
@@ -42,9 +43,9 @@ class DatayesApi(object):
                 return result['data']
             else:
                 if 'retMsg' in result:
-                    print u'查询失败，返回信息%s' %result['retMsg']
+                    print(u'查询失败，返回信息%s' %result['retMsg'])
                 elif 'message' in result:
-                    print u'查询失败，返回信息%s' %result['message']
+                    print(u'查询失败，返回信息%s' %result['message'])
                 return None
                     
                     

--- a/vnpy/data/shcifco/test.py
+++ b/vnpy/data/shcifco/test.py
@@ -1,6 +1,8 @@
 # encoding: UTF-8
 
-from vnshcifco import ShcifcoApi, PERIOD_1MIN
+from __future__ import print_function
+from __future__ import absolute_import
+from .vnshcifco import ShcifcoApi, PERIOD_1MIN
 
 
 if __name__ == "__main__":
@@ -13,15 +15,15 @@ if __name__ == "__main__":
     api = ShcifcoApi(ip, port, token)
     
     # 获取最新tick
-    print api.getLastTick(symbol)
+    print(api.getLastTick(symbol))
     
     # 获取最新价格
-    print api.getLastPrice(symbol)
+    print(api.getLastPrice(symbol))
     
     # 获取最新分钟线
-    print api.getLastBar(symbol)
+    print(api.getLastBar(symbol))
     
     # 获取历史分钟线
-    print api.getHisBar(symbol, 500, period=PERIOD_1MIN)
+    print(api.getHisBar(symbol, 500, period=PERIOD_1MIN))
     
     

--- a/vnpy/data/shcifco/vnshcifco.py
+++ b/vnpy/data/shcifco/vnshcifco.py
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
 
+from __future__ import print_function
 import requests
 
 HTTP_OK = 200
@@ -34,7 +35,7 @@ class ShcifcoApi(object):
         r = requests.get(url=url, params=params)
         
         if r.status_code != HTTP_OK:
-            print u'http请求失败，状态代码%s' %r.status_code
+            print(u'http请求失败，状态代码%s' %r.status_code)
             return None
         else:
             return r.text

--- a/vnpy/data/tq/test.py
+++ b/vnpy/data/tq/test.py
@@ -1,9 +1,15 @@
 # encoding: UTF-8
 
+from __future__ import print_function
+from __future__ import absolute_import
 from time import sleep
 
-from vntq import TqApi
+from .vntq import TqApi
 
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
 
 # 接口对象
 api = None
@@ -12,43 +18,39 @@ api = None
 #----------------------------------------------------------------------
 def onQuote(symbol):
     """Tick更新"""
-    print '-' * 30
-    print 'onQuote'
+    print('-' * 30)
+    print('onQuote')
     quote = api.get_quote(symbol)
-    print quote
+    print(quote)
 
 #----------------------------------------------------------------------
 def onChart(symbol, seconds):
     """K线更新"""
-    print '-' * 30
-    print 'onChart'
-    
+    print('-' * 30)
+    print('onChart')
+
     if seconds == 0:
         serial = api.get_tick_serial(symbol)
     else:
         serial = api.get_kline_serial(symbol, seconds)
-        
-    print serial
-    
+
+    print(serial)
+
 
 if __name__ == "__main__":
     symbol = 'IF1710'
-    
+
     api = TqApi()
-    
+
     api.connect()
-    
+
     # 订阅Tick推送
     #api.subscribe_quote([symbol], onQuote)
-    
+
     # 订阅Tick图表
     #api.subscribe_chart(symbol, 0, 100, onChart)
-    
+
     # 订阅K线图表
     api.subscribe_chart(symbol, 60, 1000, onChart)
-    
+
     raw_input()
-    
-    
-    
-    

--- a/vnpy/data/tq/vntq.py
+++ b/vnpy/data/tq/vntq.py
@@ -5,6 +5,7 @@
 使用时需要在本机先启动一个天勤终端进程
 天勤行情终端: http://www.tq18.cn
 """
+from __future__ import print_function
 
 
 import json
@@ -215,7 +216,7 @@ class TqApi(object):
         if 'data' in pack:
             l = pack["data"]
         else:
-            print u'on_receive_msg收到的数据中没有data字段，数据内容%s' %str(pack)
+            print(u'on_receive_msg收到的数据中没有data字段，数据内容%s' %str(pack))
 
         for data in l:
             # 合并更新数据字典

--- a/vnpy/event/eventEngine.py
+++ b/vnpy/event/eventEngine.py
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
 # 系统模块
+from __future__ import print_function
 from queue import Queue, Empty
 from threading import Thread
 from time import sleep

--- a/vnpy/event/eventType.py
+++ b/vnpy/event/eventType.py
@@ -10,6 +10,7 @@
 
 建议将所有的常量定义放在该文件中，便于检查是否存在重复的现象。
 '''
+from __future__ import print_function
 
 
 EVENT_TIMER = 'eTimer'                  # 计时器事件，每隔1秒发送一次

--- a/vnpy/rpc/testClient.py
+++ b/vnpy/rpc/testClient.py
@@ -1,8 +1,10 @@
 # encoding: UTF-8
 
+from __future__ import print_function
+from __future__ import absolute_import
 from time import sleep
 
-from vnrpc import RpcClient
+from .vnrpc import RpcClient
 
 
 ########################################################################
@@ -17,7 +19,7 @@ class TestClient(RpcClient):
     #----------------------------------------------------------------------
     def callback(self, topic, data):
         """回调函数实现"""
-        print 'client received topic:', topic, ', data:', data
+        print('client received topic:', topic, ', data:', data)
     
 
 if __name__ == '__main__':
@@ -29,5 +31,5 @@ if __name__ == '__main__':
     tc.start()
     
     while 1:
-        print tc.add(1, 3)
+        print(tc.add(1, 3))
         sleep(2)

--- a/vnpy/rpc/testServer.py
+++ b/vnpy/rpc/testServer.py
@@ -1,8 +1,10 @@
 # encoding: UTF-8
 
+from __future__ import print_function
+from __future__ import absolute_import
 from time import sleep, time
 
-from vnrpc import RpcServer
+from .vnrpc import RpcServer
 
 
 ########################################################################
@@ -19,7 +21,7 @@ class TestServer(RpcServer):
     #----------------------------------------------------------------------
     def add(self, a, b):
         """测试函数"""
-        print 'receiving: %s, %s' % (a,b)
+        print('receiving: %s, %s' % (a,b))
         return a + b
 
 
@@ -32,6 +34,6 @@ if __name__ == '__main__':
     
     while 1:
         content = 'current server time is %s' % time()
-        print content
+        print(content)
         ts.publish('test', content)
         sleep(2)

--- a/vnpy/trader/app/ctaStrategy/ctaBacktesting.py
+++ b/vnpy/trader/app/ctaStrategy/ctaBacktesting.py
@@ -5,6 +5,7 @@
 可以使用和实盘相同的代码进行回测。
 '''
 from __future__ import division
+from __future__ import print_function
 
 from datetime import datetime, timedelta
 from collections import OrderedDict
@@ -112,7 +113,7 @@ class BacktestingEngine(object):
     #----------------------------------------------------------------------
     def output(self, content):
         """输出内容"""
-        print str(datetime.now()) + "\t" + content     
+        print(str(datetime.now()) + "\t" + content)     
     
     #------------------------------------------------
     # 参数设置相关
@@ -1209,11 +1210,11 @@ class OptimizationSetting(object):
             return 
         
         if end < start:
-            print u'参数起始点必须不大于终止点'
+            print(u'参数起始点必须不大于终止点')
             return
         
         if step <= 0:
-            print u'参数布进必须大于0'
+            print(u'参数布进必须大于0')
             return
         
         l = []

--- a/vnpy/trader/app/ctaStrategy/ctaHistoryData.py
+++ b/vnpy/trader/app/ctaStrategy/ctaHistoryData.py
@@ -7,6 +7,7 @@
 3. 将交易开拓者导出的历史数据载入到MongoDB中的函数
 4. 将OKEX下载的历史数据载入到MongoDB中的函数
 """
+from __future__ import print_function
 
 import csv
 from datetime import datetime, timedelta
@@ -25,7 +26,7 @@ def downloadEquityDailyBarts(self, symbol):
     """
     下载股票的日行情，symbol是股票代码
     """
-    print u'开始下载%s日行情' %symbol
+    print(u'开始下载%s日行情' %symbol)
     
     # 查询数据库中已有数据的最后日期
     cl = self.dbClient[DAILY_DB_NAME][symbol]
@@ -61,14 +62,14 @@ def downloadEquityDailyBarts(self, symbol):
                 bar.datetime = datetime.strptime(bar.date, '%Y%m%d')
                 bar.volume = d.get('volume')
             except KeyError:
-                print d
+                print(d)
             
             flt = {'datetime': bar.datetime}
             self.dbClient[DAILY_DB_NAME][symbol].update_one(flt, {'$set':bar.__dict__}, upsert=True)            
         
-        print u'%s下载完成' %symbol
+        print(u'%s下载完成' %symbol)
     else:
-        print u'找不到合约%s' %symbol
+        print(u'找不到合约%s' %symbol)
 
 #----------------------------------------------------------------------
 def loadMcCsv(fileName, dbName, symbol):
@@ -76,7 +77,7 @@ def loadMcCsv(fileName, dbName, symbol):
     import csv
     
     start = time()
-    print u'开始读取CSV文件%s中的数据插入到%s的%s中' %(fileName, dbName, symbol)
+    print(u'开始读取CSV文件%s中的数据插入到%s的%s中' %(fileName, dbName, symbol))
     
     # 锁定集合，并创建索引
     client = pymongo.MongoClient(globalSetting['mongoHost'], globalSetting['mongoPort']) 
@@ -100,9 +101,9 @@ def loadMcCsv(fileName, dbName, symbol):
 
         flt = {'datetime': bar.datetime}
         collection.update_one(flt, {'$set':bar.__dict__}, upsert=True)  
-        print bar.date, bar.time
+        print(bar.date, bar.time)
     
-    print u'插入完毕，耗时：%s' % (time()-start)
+    print(u'插入完毕，耗时：%s' % (time()-start))
 
 #----------------------------------------------------------------------
 def loadTbCsv(fileName, dbName, symbol):
@@ -110,7 +111,7 @@ def loadTbCsv(fileName, dbName, symbol):
     import csv
     
     start = time()
-    print u'开始读取CSV文件%s中的数据插入到%s的%s中' %(fileName, dbName, symbol)
+    print(u'开始读取CSV文件%s中的数据插入到%s的%s中' %(fileName, dbName, symbol))
     
     # 锁定集合，并创建索引
     client = pymongo.MongoClient(globalSetting['mongoHost'], globalSetting['mongoPort'])
@@ -135,9 +136,9 @@ def loadTbCsv(fileName, dbName, symbol):
 
         flt = {'datetime': bar.datetime}
         collection.update_one(flt, {'$set':bar.__dict__}, upsert=True)  
-        print bar.date, bar.time
+        print(bar.date, bar.time)
     
-    print u'插入完毕，耗时：%s' % (time()-start)
+    print(u'插入完毕，耗时：%s' % (time()-start))
     
  #----------------------------------------------------------------------
 def loadTbPlusCsv(fileName, dbName, symbol):
@@ -145,7 +146,7 @@ def loadTbPlusCsv(fileName, dbName, symbol):
     import csv    
 
     start = time()
-    print u'开始读取CSV文件%s中的数据插入到%s的%s中' %(fileName, dbName, symbol) 
+    print(u'开始读取CSV文件%s中的数据插入到%s的%s中' %(fileName, dbName, symbol)) 
 
     # 锁定集合，并创建索引
     client = pymongo.MongoClient(globalSetting['mongoHost'], globalSetting['mongoPort'])
@@ -172,9 +173,9 @@ def loadTbPlusCsv(fileName, dbName, symbol):
         bar.openInterest = d[7]
         flt = {'datetime': bar.datetime}
         collection.update_one(flt, {'$set':bar.__dict__}, upsert=True)  
-        print bar.date, bar.time    
+        print(bar.date, bar.time)    
 
-    print u'插入完毕，耗时：%s' % (time()-start)
+    print(u'插入完毕，耗时：%s' % (time()-start))
 
 #----------------------------------------------------------------------
 def loadTdxCsv(fileName, dbName, symbol):
@@ -182,7 +183,7 @@ def loadTdxCsv(fileName, dbName, symbol):
     import csv
     
     start = time()
-    print u'开始读取CSV文件%s中的数据插入到%s的%s中' %(fileName, dbName, symbol)
+    print(u'开始读取CSV文件%s中的数据插入到%s的%s中' %(fileName, dbName, symbol))
     
     # 锁定集合，并创建索引
     client = pymongo.MongoClient(globalSetting['mongoHost'], globalSetting['mongoPort'])
@@ -207,15 +208,15 @@ def loadTdxCsv(fileName, dbName, symbol):
 
         flt = {'datetime': bar.datetime}
         collection.update_one(flt, {'$set':bar.__dict__}, upsert=True)  
-        print bar.date, bar.time
+        print(bar.date, bar.time)
     
-    print u'插入完毕，耗时：%s' % (time()-start)
+    print(u'插入完毕，耗时：%s' % (time()-start))
 
 #----------------------------------------------------------------------
 def loadOKEXCsv(fileName, dbName, symbol):
     """将OKEX导出的csv格式的历史分钟数据插入到Mongo数据库中"""
     start = time()
-    print u'开始读取CSV文件%s中的数据插入到%s的%s中' %(fileName, dbName, symbol)
+    print(u'开始读取CSV文件%s中的数据插入到%s的%s中' %(fileName, dbName, symbol))
 
     # 锁定集合，并创建索引
     client = pymongo.MongoClient(globalSetting['mongoHost'], globalSetting['mongoPort'])
@@ -246,5 +247,5 @@ def loadOKEXCsv(fileName, dbName, symbol):
             collection.update_one(flt, {'$set':bar.__dict__}, upsert=True)
             print('%s \t %s' % (bar.date, bar.time))
 
-    print u'插入完毕，耗时：%s' % (time()-start)
+    print(u'插入完毕，耗时：%s' % (time()-start))
     

--- a/vnpy/trader/app/ctaStrategy/language/__init__.py
+++ b/vnpy/trader/app/ctaStrategy/language/__init__.py
@@ -1,13 +1,14 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 import json
 import os
 import traceback
 
 # 默认设置
-from chinese import text
+from .chinese import text
 
 # 是否要使用英文
 from vnpy.trader.vtGlobal import globalSetting
 if globalSetting['language'] == 'english':
-    from english import text
+    from .english import text

--- a/vnpy/trader/app/ctaStrategy/strategy/__init__.py
+++ b/vnpy/trader/app/ctaStrategy/strategy/__init__.py
@@ -3,6 +3,7 @@
 '''
 动态载入所有的策略类
 '''
+from __future__ import print_function
 
 import os
 import importlib

--- a/vnpy/trader/app/dataRecorder/__init__.py
+++ b/vnpy/trader/app/dataRecorder/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
-from drEngine import DrEngine
-from uiDrWidget import DrEngineManager
+from __future__ import absolute_import
+from .drEngine import DrEngine
+from .uiDrWidget import DrEngineManager
 
 appName = 'DataRecorder'
 appDisplayName = u'行情记录'

--- a/vnpy/trader/app/dataRecorder/language/__init__.py
+++ b/vnpy/trader/app/dataRecorder/language/__init__.py
@@ -1,13 +1,14 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 import json
 import os
 import traceback
 
 # 默认设置
-from chinese import text
+from .chinese import text
 
 # 是否要使用英文
 from vnpy.trader.vtGlobal import globalSetting
 if globalSetting['language'] == 'english':
-    from english import text
+    from .english import text

--- a/vnpy/trader/app/jaqsService/__init__.py
+++ b/vnpy/trader/app/jaqsService/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
-from jsEngine import JsEngine
-from uiJsWidget import JsEngineManager
+from __future__ import absolute_import
+from .jsEngine import JsEngine
+from .uiJsWidget import JsEngineManager
 
 appName = 'JaqsService'
 appDisplayName = u'Jaqs服务'

--- a/vnpy/trader/app/jaqsService/jrpc_server.py
+++ b/vnpy/trader/app/jaqsService/jrpc_server.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import zmq
 import Queue
 import threading
@@ -108,11 +109,11 @@ class JRpcServer :
                         #client_addr_map[client_id] = identity
                         self._on_data_arrived(identity, data)
 
-            except zmq.error.Again, e:
+            except zmq.error.Again as e:
                 #print "RECV timeout: ", e
                 pass
-            except Exception, e:
-                print("_recv_run:", e)
+            except Exception as e:
+                print(("_recv_run:", e))
 
     def _callback_run(self):
         while not self._should_close:
@@ -120,12 +121,12 @@ class JRpcServer :
                 r = self._callback_queue.get(timeout = 1)
                 if r :
                     r()
-            except Queue.Empty, e:
+            except Queue.Empty as e:
                 pass
 
-            except Exception, e:
+            except Exception as e:
                 traceback.print_exc(e)
-                print "_callback_run", type(e), e
+                print("_callback_run", type(e), e)
 
     def _async_call(self, func):
         self._callback_queue.put( func )
@@ -164,12 +165,12 @@ class JRpcServer :
             #print "RECV", msg
 
             if not msg:
-                print "wrong message format"
+                print("wrong message format")
                 return
 
-            method = msg['method'] if msg.has_key('method') else None
+            method = msg['method'] if 'method' in msg else None
 
-            call_id = msg['id'] if msg.has_key('id') and msg['id'] else None
+            call_id = msg['id'] if 'id' in msg and msg['id'] else None
 
             if call_id and method:
                 if method == ".sys.heartbeat":
@@ -183,8 +184,8 @@ class JRpcServer :
                 if self.on_call :
                     self._async_call( lambda : self.on_call(identity, msg))
 
-        except Exception, e:
-            print( "_on_data_arrived:", e)
+        except Exception as e:
+            print(( "_on_data_arrived:", e))
             pass
     
 

--- a/vnpy/trader/app/jaqsService/jsEngine.py
+++ b/vnpy/trader/app/jaqsService/jsEngine.py
@@ -1,9 +1,10 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 import json
 from collections import defaultdict
 
-import jrpc_server
+from . import jrpc_server
 
 from vnpy.event import Event
 from vnpy.trader.vtFunction import getJsonPath

--- a/vnpy/trader/app/jaqsService/service.py
+++ b/vnpy/trader/app/jaqsService/service.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import jrpc_server
+from __future__ import print_function
+from __future__ import absolute_import
+from . import jrpc_server
 import time
 import pandas as pd
 from qdata.database import DatabaseConn
@@ -15,7 +17,7 @@ db = None
 def on_call(client_id, req):
 
     if req['method'] != '.sys.heartbeat':
-        print "on_call", req
+        print("on_call", req)
 
     if req['method'] == 'auth.login':
         server.send_rsp(client_id, req, result = { "username" : "fixme", "name": "fixme" })
@@ -25,7 +27,7 @@ def on_call(client_id, req):
         server.send_rsp(client_id, req, error=[-1, "unknown method"])
         return
 
-    if not req.has_key('params'):
+    if 'params' not in req:
         server.send_rsp(client_id, req, error=[-1, "missing params"])
         return
     
@@ -55,7 +57,7 @@ def run():
     server = jrpc_server.JRpcServer()
     server.on_call = on_call
     addr = "tcp://%s:%s"%(st.HOST, st.PORT)
-    print "listen at " + addr
+    print("listen at " + addr)
     server.listen(addr)
 
     while True:

--- a/vnpy/trader/app/optionMaster/omDate.py
+++ b/vnpy/trader/app/optionMaster/omDate.py
@@ -12,6 +12,10 @@ from collections import OrderedDict
 
 from vnpy.trader.uiQt import QtCore, QtWidgets, QtGui
 
+try:
+    reload         # Python 2
+except NameError:  # Python 3
+    from importlib import reload
 
 # 常量定义
 ANNUAL_TRADINGDAYS = 240
@@ -23,8 +27,8 @@ CALENDAR_FILEPATH = os.path.join(PATH, CALENDAR_FILENAME)
 # 加载日历数据
 try:
     with open(CALENDAR_FILEPATH, 'r') as f:
-        reader = csv.DictReader(f)        
-        CALENDAR = [d for d in reader]   
+        reader = csv.DictReader(f)
+        CALENDAR = [d for d in reader]
 except IOError:
     CALENDAR = []
 
@@ -41,7 +45,7 @@ class CalendarEditor(QtWidgets.QTableWidget):
         """Constructor"""
         super(CalendarEditor, self).__init__()
         self.initUi()
-        
+
     #----------------------------------------------------------------------
     def initUi(self):
         """初始化界面"""
@@ -49,21 +53,21 @@ class CalendarEditor(QtWidgets.QTableWidget):
         self.horizontalHeader().setVisible(True)                # 关闭左边的垂直表头
         self.verticalHeader().setVisible(False)                 # 关闭左边的垂直表头
         self.setHorizontalHeaderLabels([u'日期', u'描述'])
-        
+
     #----------------------------------------------------------------------
     def clearTable(self):
         """清空表格"""
         self.clear()
         self.initUi()
-    
+
     #----------------------------------------------------------------------
     def loadCalendar(self):
         """读取日历"""
         self.clearContents()
-        
+
         row = 0
         totalRow = self.rowCount()
-        
+
         # 如果有则打开
         try:
             with open(CALENDAR_FILEPATH, 'r') as f:
@@ -71,33 +75,33 @@ class CalendarEditor(QtWidgets.QTableWidget):
                 for d in reader:
                     cellDate = QtWidgets.QTableWidgetItem(d['date'])
                     cellDescription = QtWidgets.QTableWidgetItem(d['description'])
-                    
+
                     if row >= totalRow:
                         self.insertRow(row)
-        
+
                     self.setItem(row, 0, cellDate)
                     self.setItem(row, 1, cellDescription)
-                    
-                    row = row + 1                    
-                    
+
+                    row = row + 1
+
         # 如果没有该文件则创建
         except IOError:
             f = open(CALENDAR_FILEPATH, 'w')
             f.close()
-        
+
     #----------------------------------------------------------------------
     def saveCalendar(self):
         """保存日历"""
         totalRow = self.rowCount()
-        
+
         with open(CALENDAR_FILEPATH, 'w') as f:
             writer = csv.DictWriter(f, lineterminator='\n', fieldnames=['date', 'description'])
             writer.writeheader()
-            
+
             for row in range(totalRow):
                 cellDate = self.item(row, 0)
                 cellDescription = self.item(row, 1)
-                
+
                 if cellDescription:
                     description = cellDescription.text()
                 else:
@@ -108,7 +112,7 @@ class CalendarEditor(QtWidgets.QTableWidget):
                     'description': description
                 }
                 writer.writerow(d)
-    
+
     #----------------------------------------------------------------------
     def initCalendar(self):
         """初始化日历"""
@@ -124,35 +128,35 @@ class CalendarManager(QtWidgets.QWidget):
         """Constructor"""
         super(CalendarManager, self).__init__()
         self.initUI()
-        
+
     #----------------------------------------------------------------------
     def initUI(self):
         """"""
         self.setWindowTitle(u'日历管理')
-        
+
         self.editor = CalendarEditor()
-        
+
         buttonLoad = QtWidgets.QPushButton(u'读取日历')
         buttonSave = QtWidgets.QPushButton(u'保存日历')
         buttonInit = QtWidgets.QPushButton(u'初始化日历')
         buttonClear = QtWidgets.QPushButton(u'清空')
-        
+
         buttonLoad.clicked.connect(self.editor.loadCalendar)
         buttonSave.clicked.connect(self.editor.saveCalendar)
         buttonInit.clicked.connect(self.editor.initCalendar)
         buttonClear.clicked.connect(self.editor.clearTable)
-        
+
         hbox = QtWidgets.QHBoxLayout()
         hbox.addWidget(buttonLoad)
         hbox.addWidget(buttonSave)
         hbox.addWidget(buttonInit)
         hbox.addWidget(buttonClear)
         hbox.addStretch()
-        
+
         vbox = QtWidgets.QVBoxLayout()
         vbox.addLayout(hbox)
         vbox.addWidget(self.editor)
-        
+
         self.setLayout(vbox)
 
 
@@ -161,20 +165,20 @@ def runCalendarEditor():
     """运行日历编辑器"""
     reload(sys)
     sys.setdefaultencoding('utf8')
-    
+
     app = QtWidgets.QApplication(sys.argv)
     app.setFont(QtGui.QFont(u'微软雅黑', 12))
-    
+
     try:
         import qdarkstyle
         app.setStyleSheet(qdarkstyle.load_stylesheet(pyside=False))
     except:
-        pass        
-    
+        pass
+
     manager = CalendarManager()
     manager.showMaximized()
-    
-    sys.exit(app.exec_())    
+
+    sys.exit(app.exec_())
 
 
 #----------------------------------------------------------------------
@@ -182,19 +186,19 @@ def initCalendarCsv():
     """初始化日期文件"""
     # 读取csv中的数据并生成列表和字典
     calendarDict = OrderedDict()
-    
+
     try:
         with open(CALENDAR_FILEPATH, 'r') as f:
-            reader = csv.DictReader(f)        
+            reader = csv.DictReader(f)
             for d in reader:
                 calendarDict[d['date']] = d
     except IOError:
         pass
-    
+
     # 生成未来的数据
     today = datetime.date.today()
     oneday = datetime.timedelta(days=1)
-    
+
     t = today
     for i in range(365*2):
         # 如果日历里没有该日期的状态，则初始化（仅判断是否周末）
@@ -209,10 +213,10 @@ def initCalendarCsv():
                 'description': description
             }
             calendarDict[d['date']] = d
-            
+
         # 往下一天
         t = t + oneday
-        
+
     # 保存到csv中
     with open(CALENDAR_FILEPATH, 'w') as f:
         writer = csv.DictWriter(f, lineterminator='\n', fieldnames=d.keys())
@@ -227,26 +231,26 @@ def getTimeToMaturity(expiryDate):
     # 如果有缓存则直接返回
     if expiryDate in TTM_DICT:
         return TTM_DICT[expiryDate]
-    
+
     # 获取日期对象
     expiryDt = datetime.datetime.strptime(expiryDate, '%Y%m%d').date()
     todayDt = datetime.date.today()
-    
+
     tradingDays = 0
     for d in CALENDAR:
         dt = datetime.datetime.strptime(d['date'], '%Y-%m-%d').date()
         # 判断是否为交易日的条件：
         # 1. 日期大于等于今日
         # 2. 日期小于等于到期日
-        # 3. 日期没有描述（假期）        
+        # 3. 日期没有描述（假期）
         if dt>=todayDt and dt<=expiryDt and not d['description']:
             tradingDays += 1
-    
+
     # 缓存并返回年化剩余时间
     ttm = tradingDays/ANNUAL_TRADINGDAYS
     TTM_DICT[expiryDate] = ttm
     return ttm
-    
-    
+
+
 if __name__ == '__main__':
     runCalendarEditor()

--- a/vnpy/trader/app/optionMaster/strategy/__init__.py
+++ b/vnpy/trader/app/optionMaster/strategy/__init__.py
@@ -3,6 +3,7 @@
 '''
 动态载入所有的策略类
 '''
+from __future__ import print_function
 
 import os
 import importlib

--- a/vnpy/trader/app/optionMaster/uiOmManualTrader.py
+++ b/vnpy/trader/app/optionMaster/uiOmManualTrader.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.event import Event
 
 from vnpy.trader.vtConstant import DIRECTION_LONG, DIRECTION_SHORT, OFFSET_OPEN, OFFSET_CLOSE, PRICETYPE_LIMITPRICE
@@ -7,7 +8,7 @@ from vnpy.trader.vtObject import VtOrderReq
 from vnpy.trader.vtEvent import EVENT_TICK, EVENT_TRADE
 from vnpy.trader.uiBasicWidget import WorkingOrderMonitor, PositionMonitor
 
-from uiOmBase import *
+from .uiOmBase import *
 
 
 

--- a/vnpy/trader/app/optionMaster/uiOmWidget.py
+++ b/vnpy/trader/app/optionMaster/uiOmWidget.py
@@ -15,6 +15,11 @@ from .uiOmVolatilityManager import VolatilityChart, VolatilityManager
 from .uiOmAnalysisManager import AnalysisManager
 from .uiOmStrategyManager import StrategyEngineManager
 
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
+
 
 ########################################################################
 class OmManager(QtWidgets.QWidget):
@@ -25,68 +30,68 @@ class OmManager(QtWidgets.QWidget):
     def __init__(self, omEngine, eventEngine, parent=None):
         """Constructor"""
         super(OmManager, self).__init__(parent)
-        
+
         self.omEngine = omEngine
         self.eventEngine = eventEngine
-        
+
         self.widgetDict = {}
-        
+
         self.initUi()
         self.registerEvent()
-        
+
     #----------------------------------------------------------------------
     def initUi(self):
         """初始化界面"""
         self.setWindowTitle(u'OptionMaster管理')
-        
+
         # 读取配置文件
         settingFileList = []
-        
+
         path = os.getcwd()
         for root, subdirs, files in os.walk(path):
-            for name in files:      
+            for name in files:
                 if '_portfolio.json' in name:
                     settingFileList.append(name)
-        
+
         # 设置界面
         self.comboSettingFile = QtWidgets.QComboBox()
         self.comboSettingFile.addItems(settingFileList)
         self.comboSettingFile.setCurrentIndex(0)
-        
+
         self.buttonInit = QtWidgets.QPushButton(u'初始化')
         self.buttonInit.clicked.connect(self.initOmEngine)
-        
+
         self.buttonManualTrader = QtWidgets.QPushButton(u'手动交易')
         self.buttonManualTrader.clicked.connect(self.openManualTrader)
         self.buttonManualTrader.setDisabled(True)
-        
+
         self.buttonGreeksMonitor = QtWidgets.QPushButton(u'希腊值监控')
         self.buttonGreeksMonitor.clicked.connect(self.openGreeksMonitor)
         self.buttonGreeksMonitor.setDisabled(True)
-        
+
         self.buttonVolatilityChart = QtWidgets.QPushButton(u'波动率图表')
         self.buttonVolatilityChart.clicked.connect(self.openVolatilityChart)
         self.buttonVolatilityChart.setDisabled(True)
-        
+
         self.buttonVolatilityManager = QtWidgets.QPushButton(u'波动率管理')
         self.buttonVolatilityManager.clicked.connect(self.openVolatilityManager)
         self.buttonVolatilityManager.setDisabled(True)
-        
+
         self.buttonAnalysisManager = QtWidgets.QPushButton(u'持仓分析')
         self.buttonAnalysisManager.clicked.connect(self.openAnalysisManager)
         self.buttonAnalysisManager.setDisabled(True)
-        
+
         self.buttonStrategyManager = QtWidgets.QPushButton(u'策略交易')
         self.buttonStrategyManager.clicked.connect(self.openStrategyManager)
-        self.buttonStrategyManager.setDisabled(True)        
-        
+        self.buttonStrategyManager.setDisabled(True)
+
         self.buttonAdjustR = QtWidgets.QPushButton(u'拟合利率')
         self.buttonAdjustR.clicked.connect(self.omEngine.adjustR)
-        self.buttonAdjustR.setDisabled(True)        
-        
+        self.buttonAdjustR.setDisabled(True)
+
         self.logMonitor = QtWidgets.QTextEdit()
         self.logMonitor.setReadOnly(True)
-        
+
         hbox = QtWidgets.QHBoxLayout()
         hbox.addWidget(self.comboSettingFile)
         hbox.addWidget(self.buttonInit)
@@ -98,17 +103,17 @@ class OmManager(QtWidgets.QWidget):
         hbox.addWidget(self.buttonStrategyManager)
         hbox.addWidget(self.buttonAdjustR)
         hbox.addStretch()
-        
+
         hbox2 = QtWidgets.QHBoxLayout()
         hbox2.addStretch()
-        
+
         vbox = QtWidgets.QVBoxLayout()
         vbox.addLayout(hbox)
         vbox.addLayout(hbox2)
         vbox.addWidget(self.logMonitor)
-        
+
         self.setLayout(vbox)
-        
+
     #----------------------------------------------------------------------
     def initOmEngine(self):
         """初始化引擎"""
@@ -116,19 +121,19 @@ class OmManager(QtWidgets.QWidget):
         fileName = unicode(self.comboSettingFile.currentText())
         fileName = os.path.join(path, fileName)
         result = self.omEngine.initEngine(fileName)
-        
+
         if result:
             self.writeLog(u'引擎初始化成功')
             self.enableButtons()
         else:
             self.writeLog(u'请勿重复初始化引擎')
-    
+
     #----------------------------------------------------------------------
     def enableButtons(self):
         """启用按钮"""
         self.comboSettingFile.setDisabled(True)
         self.buttonInit.setDisabled(True)
-        
+
         self.buttonManualTrader.setEnabled(True)
         self.buttonGreeksMonitor.setEnabled(True)
         self.buttonVolatilityChart.setEnabled(True)
@@ -136,7 +141,7 @@ class OmManager(QtWidgets.QWidget):
         self.buttonAnalysisManager.setEnabled(True)
         self.buttonStrategyManager.setEnabled(True)
         self.buttonAdjustR.setEnabled(True)
-        
+
     #----------------------------------------------------------------------
     def writeLog(self, content, time=''):
         """记录日志"""
@@ -144,14 +149,14 @@ class OmManager(QtWidgets.QWidget):
             time = datetime.now().strftime('%H:%M:%S')
         content = time + '\t' + content
         self.logMonitor.append(content)
-    
+
     #----------------------------------------------------------------------
     def processLogEvent(self, event):
         """处理日志事件"""
         log = event.dict_['data']
         self.writeLog(log.logContent, log.logTime)
         self.raise_()
-    
+
     #----------------------------------------------------------------------
     def openManualTrader(self):
         """打开手动交易组件"""
@@ -160,7 +165,7 @@ class OmManager(QtWidgets.QWidget):
         except KeyError:
             self.widgetDict['manualTrader'] = ManualTrader(self.omEngine)
             self.widgetDict['manualTrader'].showMaximized()
-            
+
     #----------------------------------------------------------------------
     def openGreeksMonitor(self):
         """打开希腊值监控组件"""
@@ -168,8 +173,8 @@ class OmManager(QtWidgets.QWidget):
             self.widgetDict['greeksMonitor'].showMaximized()
         except KeyError:
             self.widgetDict['greeksMonitor'] = GreeksMonitor(self.omEngine)
-            self.widgetDict['greeksMonitor'].showMaximized()   
-            
+            self.widgetDict['greeksMonitor'].showMaximized()
+
     #----------------------------------------------------------------------
     def openVolatilityChart(self):
         """打开波动率图表组件"""
@@ -178,7 +183,7 @@ class OmManager(QtWidgets.QWidget):
         except KeyError:
             self.widgetDict['volatilityChart'] = VolatilityChart(self.omEngine)
             self.widgetDict['volatilityChart'].showMaximized()
-    
+
     #----------------------------------------------------------------------
     def openVolatilityManager(self):
         """打开波动率管理组件"""
@@ -186,8 +191,8 @@ class OmManager(QtWidgets.QWidget):
             self.widgetDict['volatilityManager'].show()
         except KeyError:
             self.widgetDict['volatilityManager'] = VolatilityManager(self.omEngine)
-            self.widgetDict['volatilityManager'].show()     
-            
+            self.widgetDict['volatilityManager'].show()
+
     #----------------------------------------------------------------------
     def openAnalysisManager(self):
         """打开持仓分析组件"""
@@ -195,8 +200,8 @@ class OmManager(QtWidgets.QWidget):
             self.widgetDict['analysisManager'].showMaximized()
         except KeyError:
             self.widgetDict['analysisManager'] = AnalysisManager(self.omEngine)
-            self.widgetDict['analysisManager'].showMaximized()  
-            
+            self.widgetDict['analysisManager'].showMaximized()
+
     #----------------------------------------------------------------------
     def openStrategyManager(self):
         """打开策略交易组件"""
@@ -204,19 +209,19 @@ class OmManager(QtWidgets.QWidget):
             self.widgetDict['strategyManager'].showMaximized()
         except KeyError:
             self.widgetDict['strategyManager'] = StrategyEngineManager(self.omEngine)
-            self.widgetDict['strategyManager'].showMaximized()  
+            self.widgetDict['strategyManager'].showMaximized()
 
     #----------------------------------------------------------------------
     def close(self):
         """关闭"""
         for widget in self.widgetDict.values():
             widget.close()
-            
+
         super(OmManager, self).close()
-        
+
     #----------------------------------------------------------------------
     def registerEvent(self):
         """注册事件监听"""
         self.signal.connect(self.processLogEvent)
-        
+
         self.eventEngine.register(EVENT_OM_LOG, self.signal.emit)

--- a/vnpy/trader/app/riskManager/__init__.py
+++ b/vnpy/trader/app/riskManager/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
-from rmEngine import RmEngine
-from uiRmWidget import RmEngineManager
+from __future__ import absolute_import
+from .rmEngine import RmEngine
+from .uiRmWidget import RmEngineManager
 
 appName = 'RiskManager'
 appDisplayName = u'风险管理'

--- a/vnpy/trader/app/riskManager/language/__init__.py
+++ b/vnpy/trader/app/riskManager/language/__init__.py
@@ -1,13 +1,14 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 import json
 import os
 import traceback
 
 # 默认设置
-from chinese import text
+from .chinese import text
 
 # 是否要使用英文
 from vnpy.trader.vtGlobal import globalSetting
 if globalSetting['language'] == 'english':
-    from english import text
+    from .english import text

--- a/vnpy/trader/app/spreadTrading/uiStWidget.py
+++ b/vnpy/trader/app/spreadTrading/uiStWidget.py
@@ -12,6 +12,10 @@ from .stBase import (EVENT_SPREADTRADING_TICK, EVENT_SPREADTRADING_POS,
                      EVENT_SPREADTRADING_ALGOLOG)
 from .stAlgo import StAlgoTemplate
 
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
 
 STYLESHEET_START = 'background-color: rgb(111,255,244); color: black'
 STYLESHEET_STOP = 'background-color: rgb(255,201,111); color: black'
@@ -20,12 +24,12 @@ STYLESHEET_STOP = 'background-color: rgb(255,201,111); color: black'
 ########################################################################
 class StTickMonitor(BasicMonitor):
     """价差行情监控"""
-    
+
     #----------------------------------------------------------------------
     def __init__(self, mainEngine, eventEngine, parent=None):
         """Constructor"""
         super(StTickMonitor, self).__init__(mainEngine, eventEngine, parent)
-        
+
         d = OrderedDict()
         d['name'] = {'chinese':u'价差名称', 'cellType':BasicCell}
         d['bidPrice'] = {'chinese':u'买价', 'cellType':BidCell}
@@ -35,24 +39,24 @@ class StTickMonitor(BasicMonitor):
         d['time'] = {'chinese':u'时间', 'cellType':BasicCell}
         d['symbol'] = {'chinese':u'价差公式', 'cellType':BasicCell}
         self.setHeaderDict(d)
-    
+
         self.setDataKey('name')
         self.setEventType(EVENT_SPREADTRADING_TICK)
         self.setFont(BASIC_FONT)
-    
+
         self.initTable()
-        self.registerEvent()        
+        self.registerEvent()
 
 
 ########################################################################
 class StPosMonitor(BasicMonitor):
     """价差持仓监控"""
-    
+
     #----------------------------------------------------------------------
     def __init__(self, mainEngine, eventEngine, parent=None):
         """Constructor"""
         super(StPosMonitor, self).__init__(mainEngine, eventEngine, parent)
-        
+
         d = OrderedDict()
         d['name'] = {'chinese':u'价差名称', 'cellType':BasicCell}
         d['netPos'] = {'chinese':u'净仓', 'cellType':PnlCell}
@@ -60,64 +64,64 @@ class StPosMonitor(BasicMonitor):
         d['shortPos'] = {'chinese':u'空仓', 'cellType':BasicCell}
         d['symbol'] = {'chinese':u'代码', 'cellType':BasicCell}
         self.setHeaderDict(d)
-    
+
         self.setDataKey('name')
         self.setEventType(EVENT_SPREADTRADING_POS)
         self.setFont(BASIC_FONT)
-    
+
         self.initTable()
-        self.registerEvent()        
+        self.registerEvent()
 
 
 ########################################################################
 class StLogMonitor(QtWidgets.QTextEdit):
     """价差日志监控"""
     signal = QtCore.Signal(type(Event()))
-    
+
     #----------------------------------------------------------------------
     def __init__(self, mainEngine, eventEngine, parent=None):
         """Constructor"""
         super(StLogMonitor, self).__init__(parent)
-        
+
         self.eventEngine = eventEngine
-        
+
         self.registerEvent()
-        
+
     #----------------------------------------------------------------------
     def processLogEvent(self, event):
         """处理日志事件"""
         log = event.dict_['data']
         content = '%s:%s' %(log.logTime, log.logContent)
         self.append(content)
-    
+
     #----------------------------------------------------------------------
     def registerEvent(self):
         """注册事件监听"""
         self.signal.connect(self.processLogEvent)
-        
+
         self.eventEngine.register(EVENT_SPREADTRADING_LOG, self.signal.emit)
 
 
 ########################################################################
 class StAlgoLogMonitor(BasicMonitor):
     """价差日志监控"""
-    
+
     #----------------------------------------------------------------------
     def __init__(self, mainEngine, eventEngine, parent=None):
         """Constructor"""
         super(StAlgoLogMonitor, self).__init__(mainEngine, eventEngine, parent)
-        
+
         d = OrderedDict()
         d['logTime'] = {'chinese':u'时间', 'cellType':BasicCell}
         d['logContent'] = {'chinese':u'信息', 'cellType':BasicCell}
         self.setHeaderDict(d)
-    
+
         self.setEventType(EVENT_SPREADTRADING_ALGOLOG)
         self.setFont(BASIC_FONT)
-    
+
         self.initTable()
         self.registerEvent()
-        
+
 
 ########################################################################
 class StBuyPriceSpinBox(QtWidgets.QDoubleSpinBox):
@@ -127,21 +131,21 @@ class StBuyPriceSpinBox(QtWidgets.QDoubleSpinBox):
     def __init__(self, algoEngine, spreadName, price, parent=None):
         """Constructor"""
         super(StBuyPriceSpinBox, self).__init__(parent)
-        
+
         self.algoEngine = algoEngine
         self.spreadName = spreadName
-        
+
         self.setDecimals(4)
         self.setRange(-10000, 10000)
         self.setValue(price)
-        
+
         self.valueChanged.connect(self.setPrice)
-        
+
     #----------------------------------------------------------------------
     def setPrice(self, value):
         """设置价格"""
         self.algoEngine.setAlgoBuyPrice(self.spreadName, value)
-   
+
     #----------------------------------------------------------------------
     def algoActiveChanged(self, active):
         """算法运行状态改变"""
@@ -149,7 +153,7 @@ class StBuyPriceSpinBox(QtWidgets.QDoubleSpinBox):
         if active:
             self.setEnabled(False)
         else:
-            self.setEnabled(True)    
+            self.setEnabled(True)
 
 
 ########################################################################
@@ -160,21 +164,21 @@ class StSellPriceSpinBox(QtWidgets.QDoubleSpinBox):
     def __init__(self, algoEngine, spreadName, price, parent=None):
         """Constructor"""
         super(StSellPriceSpinBox, self).__init__(parent)
-        
+
         self.algoEngine = algoEngine
         self.spreadName = spreadName
-        
+
         self.setDecimals(4)
         self.setRange(-10000, 10000)
         self.setValue(price)
-        
+
         self.valueChanged.connect(self.setPrice)
-        
+
     #----------------------------------------------------------------------
     def setPrice(self, value):
         """设置价格"""
         self.algoEngine.setAlgoSellPrice(self.spreadName, value)
-    
+
     #----------------------------------------------------------------------
     def algoActiveChanged(self, active):
         """算法运行状态改变"""
@@ -193,16 +197,16 @@ class StShortPriceSpinBox(QtWidgets.QDoubleSpinBox):
     def __init__(self, algoEngine, spreadName, price, parent=None):
         """Constructor"""
         super(StShortPriceSpinBox, self).__init__(parent)
-        
+
         self.algoEngine = algoEngine
         self.spreadName = spreadName
-        
+
         self.setDecimals(4)
         self.setRange(-10000, 10000)
         self.setValue(price)
-        
+
         self.valueChanged.connect(self.setPrice)
-        
+
     #----------------------------------------------------------------------
     def setPrice(self, value):
         """设置价格"""
@@ -226,21 +230,21 @@ class StCoverPriceSpinBox(QtWidgets.QDoubleSpinBox):
     def __init__(self, algoEngine, spreadName, price, parent=None):
         """Constructor"""
         super(StCoverPriceSpinBox, self).__init__(parent)
-        
+
         self.algoEngine = algoEngine
         self.spreadName = spreadName
-        
+
         self.setDecimals(4)
         self.setRange(-10000, 10000)
         self.setValue(price)
-        
+
         self.valueChanged.connect(self.setPrice)
-        
+
     #----------------------------------------------------------------------
     def setPrice(self, value):
         """设置价格"""
         self.algoEngine.setAlgoCoverPrice(self.spreadName, value)
-    
+
     #----------------------------------------------------------------------
     def algoActiveChanged(self, active):
         """算法运行状态改变"""
@@ -248,7 +252,7 @@ class StCoverPriceSpinBox(QtWidgets.QDoubleSpinBox):
         if active:
             self.setEnabled(False)
         else:
-            self.setEnabled(True)    
+            self.setEnabled(True)
 
 
 ########################################################################
@@ -259,15 +263,15 @@ class StMaxPosSizeSpinBox(QtWidgets.QSpinBox):
     def __init__(self, algoEngine, spreadName, size, parent=None):
         """Constructor"""
         super(StMaxPosSizeSpinBox, self).__init__(parent)
-        
+
         self.algoEngine = algoEngine
         self.spreadName = spreadName
-        
+
         self.setRange(-10000, 10000)
         self.setValue(size)
-        
+
         self.valueChanged.connect(self.setSize)
-        
+
     #----------------------------------------------------------------------
     def setSize(self, size):
         """设置价格"""
@@ -281,8 +285,8 @@ class StMaxPosSizeSpinBox(QtWidgets.QSpinBox):
             self.setEnabled(False)
         else:
             self.setEnabled(True)
-            
-            
+
+
 ########################################################################
 class StMaxOrderSizeSpinBox(QtWidgets.QSpinBox):
     """"""
@@ -291,19 +295,19 @@ class StMaxOrderSizeSpinBox(QtWidgets.QSpinBox):
     def __init__(self, algoEngine, spreadName, size, parent=None):
         """Constructor"""
         super(StMaxOrderSizeSpinBox, self).__init__(parent)
-        
+
         self.algoEngine = algoEngine
         self.spreadName = spreadName
-        
+
         self.setRange(-10000, 10000)
         self.setValue(size)
-        
+
         self.valueChanged.connect(self.setSize)
-        
+
     #----------------------------------------------------------------------
     def setSize(self, size):
         """设置价格"""
-        self.algoEngine.setAlgoMaxOrderSize(self.spreadName, size)    
+        self.algoEngine.setAlgoMaxOrderSize(self.spreadName, size)
 
     #----------------------------------------------------------------------
     def algoActiveChanged(self, active):
@@ -323,24 +327,24 @@ class StModeComboBox(QtWidgets.QComboBox):
     def __init__(self, algoEngine, spreadName, mode, parent=None):
         """Constructor"""
         super(StModeComboBox, self).__init__(parent)
-        
+
         self.algoEngine = algoEngine
         self.spreadName = spreadName
-        
-        l = [StAlgoTemplate.MODE_LONGSHORT, 
+
+        l = [StAlgoTemplate.MODE_LONGSHORT,
              StAlgoTemplate.MODE_LONGONLY,
              StAlgoTemplate.MODE_SHORTONLY]
         self.addItems(l)
         self.setCurrentIndex(l.index(mode))
-        
+
         self.currentIndexChanged.connect(self.setMode)
-        
+
     #----------------------------------------------------------------------
     def setMode(self):
         """设置模式"""
         mode = unicode(self.currentText())
         self.algoEngine.setAlgoMode(self.spreadName, mode)
-    
+
     #----------------------------------------------------------------------
     def algoActiveChanged(self, active):
         """算法运行状态改变"""
@@ -360,15 +364,15 @@ class StActiveButton(QtWidgets.QPushButton):
     def __init__(self, algoEngine, spreadName, parent=None):
         """Constructor"""
         super(StActiveButton, self).__init__(parent)
-        
+
         self.algoEngine = algoEngine
         self.spreadName = spreadName
-        
+
         self.active = False
         self.setStopped()
-        
+
         self.clicked.connect(self.buttonClicked)
-        
+
     #----------------------------------------------------------------------
     def buttonClicked(self):
         """改变运行模式"""
@@ -376,39 +380,39 @@ class StActiveButton(QtWidgets.QPushButton):
             self.stop()
         else:
             self.start()
-    
+
     #----------------------------------------------------------------------
     def stop(self):
         """停止"""
         algoActive = self.algoEngine.stopAlgo(self.spreadName)
         if not algoActive:
-            self.setStopped()        
-            
+            self.setStopped()
+
     #----------------------------------------------------------------------
     def start(self):
         """启动"""
         algoActive = self.algoEngine.startAlgo(self.spreadName)
         if algoActive:
-            self.setStarted()        
-        
+            self.setStarted()
+
     #----------------------------------------------------------------------
     def setStarted(self):
         """算法启动"""
         self.setText(u'运行中')
         self.setStyleSheet(STYLESHEET_START)
-        
+
         self.active = True
         self.signalActive.emit(self.active)
-    
+
     #----------------------------------------------------------------------
     def setStopped(self):
         """算法停止"""
         self.setText(u'已停止')
         self.setStyleSheet(STYLESHEET_STOP)
-        
+
         self.active = False
         self.signalActive.emit(self.active)
-    
+
 
 ########################################################################
 class StAlgoManager(QtWidgets.QTableWidget):
@@ -418,13 +422,13 @@ class StAlgoManager(QtWidgets.QTableWidget):
     def __init__(self, stEngine, parent=None):
         """Constructor"""
         super(StAlgoManager, self).__init__(parent)
-        
+
         self.algoEngine = stEngine.algoEngine
-        
+
         self.buttonActiveDict = {}       # spreadName: buttonActive
-        
+
         self.initUi()
-        
+
     #----------------------------------------------------------------------
     def initUi(self):
         """初始化表格"""
@@ -441,19 +445,19 @@ class StAlgoManager(QtWidgets.QTableWidget):
         self.setColumnCount(len(headers))
         self.setHorizontalHeaderLabels(headers)
         self.horizontalHeader().setResizeMode(QtWidgets.QHeaderView.Stretch)
-        
+
         self.verticalHeader().setVisible(False)
         self.setEditTriggers(self.NoEditTriggers)
-        
+
     #----------------------------------------------------------------------
     def initCells(self):
         """初始化单元格"""
         algoEngine = self.algoEngine
-        
+
         l = self.algoEngine.getAllAlgoParams()
         self.setRowCount(len(l))
-        
-        for row, d in enumerate(l):            
+
+        for row, d in enumerate(l):
             cellSpreadName = QtWidgets.QTableWidgetItem(d['spreadName'])
             cellAlgoName = QtWidgets.QTableWidgetItem(d['algoName'])
             spinBuyPrice = StBuyPriceSpinBox(algoEngine, d['spreadName'], d['buyPrice'])
@@ -464,7 +468,7 @@ class StAlgoManager(QtWidgets.QTableWidget):
             spinMaxPosSize = StMaxPosSizeSpinBox(algoEngine, d['spreadName'], d['maxPosSize'])
             comboMode = StModeComboBox(algoEngine, d['spreadName'], d['mode'])
             buttonActive = StActiveButton(algoEngine, d['spreadName'])
-            
+
             self.setItem(row, 0, cellSpreadName)
             self.setItem(row, 1, cellAlgoName)
             self.setCellWidget(row, 2, spinBuyPrice)
@@ -475,7 +479,7 @@ class StAlgoManager(QtWidgets.QTableWidget):
             self.setCellWidget(row, 7, spinMaxPosSize)
             self.setCellWidget(row, 8, comboMode)
             self.setCellWidget(row, 9, buttonActive)
-            
+
             buttonActive.signalActive.connect(spinBuyPrice.algoActiveChanged)
             buttonActive.signalActive.connect(spinSellPrice.algoActiveChanged)
             buttonActive.signalActive.connect(spinShortPrice.algoActiveChanged)
@@ -483,14 +487,14 @@ class StAlgoManager(QtWidgets.QTableWidget):
             buttonActive.signalActive.connect(spinMaxOrderSize.algoActiveChanged)
             buttonActive.signalActive.connect(spinMaxPosSize.algoActiveChanged)
             buttonActive.signalActive.connect(comboMode.algoActiveChanged)
-            
+
             self.buttonActiveDict[d['spreadName']] = buttonActive
-            
+
     #----------------------------------------------------------------------
     def stopAll(self):
         """停止所有算法"""
         for button in self.buttonActiveDict.values():
-            button.stop()     
+            button.stop()
 
 
 ########################################################################
@@ -501,12 +505,12 @@ class StGroup(QtWidgets.QGroupBox):
     def __init__(self, widget, title, parent=None):
         """Constructor"""
         super(StGroup, self).__init__(parent)
-        
+
         self.setTitle(title)
         vbox = QtWidgets.QVBoxLayout()
         vbox.addWidget(widget)
         self.setLayout(vbox)
-        
+
 
 ########################################################################
 class StManager(QtWidgets.QWidget):
@@ -516,45 +520,45 @@ class StManager(QtWidgets.QWidget):
     def __init__(self, stEngine, eventEngine, parent=None):
         """Constructor"""
         super(StManager, self).__init__(parent)
-        
+
         self.stEngine = stEngine
         self.mainEngine = stEngine.mainEngine
         self.eventEngine = eventEngine
-        
+
         self.initUi()
-        
+
     #----------------------------------------------------------------------
     def initUi(self):
         """初始化界面"""
         self.setWindowTitle(u'价差交易')
-        
+
         # 创建组件
         tickMonitor = StTickMonitor(self.mainEngine, self.eventEngine)
         posMonitor = StPosMonitor(self.mainEngine, self.eventEngine)
         logMonitor = StLogMonitor(self.mainEngine, self.eventEngine)
         self.algoManager = StAlgoManager(self.stEngine)
         algoLogMonitor = StAlgoLogMonitor(self.mainEngine, self.eventEngine)
-        
+
         # 创建按钮
         buttonInit = QtWidgets.QPushButton(u'初始化')
-        buttonInit.clicked.connect(self.init)       
-        
+        buttonInit.clicked.connect(self.init)
+
         buttonStopAll = QtWidgets.QPushButton(u'全部停止')
         buttonStopAll.clicked.connect(self.algoManager.stopAll)
-        
+
         # 创建集合
         groupTick = StGroup(tickMonitor, u'价差行情')
         groupPos = StGroup(posMonitor, u'价差持仓')
         groupLog = StGroup(logMonitor, u'日志信息')
         groupAlgo = StGroup(self.algoManager, u'价差算法')
         groupAlgoLog = StGroup(algoLogMonitor, u'算法信息')
-        
+
         # 设置布局
         hbox = QtWidgets.QHBoxLayout()
         hbox.addWidget(buttonInit)
         hbox.addStretch()
         hbox.addWidget(buttonStopAll)
-        
+
         grid = QtWidgets.QGridLayout()
         grid.addLayout(hbox, 0, 0, 1, 2)
         grid.addWidget(groupTick, 1, 0)
@@ -564,18 +568,14 @@ class StManager(QtWidgets.QWidget):
         grid.addWidget(groupAlgoLog, 3, 1)
 
         self.setLayout(grid)
-        
+
     #----------------------------------------------------------------------
     def show(self):
         """重载显示"""
         self.showMaximized()
-        
+
     #----------------------------------------------------------------------
     def init(self):
         """初始化"""
         self.stEngine.init()
         self.algoManager.initCells()
-    
-    
-    
-    

--- a/vnpy/trader/gateway/cshshlpGateway/__init__.py
+++ b/vnpy/trader/gateway/cshshlpGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from cshshlpGateway import CshshlpGateway
+from .cshshlpGateway import CshshlpGateway
 
 gatewayClass = CshshlpGateway
 gatewayName = 'CSHSHLP'

--- a/vnpy/trader/gateway/ctpGateway/__init__.py
+++ b/vnpy/trader/gateway/ctpGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from ctpGateway import CtpGateway
+from .ctpGateway import CtpGateway
 
 gatewayClass = CtpGateway
 gatewayName = 'CTP'

--- a/vnpy/trader/gateway/ctpGateway/language/__init__.py
+++ b/vnpy/trader/gateway/ctpGateway/language/__init__.py
@@ -1,15 +1,16 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 import json
 import os
 import traceback
 
 # 默认设置
-from chinese import text
+from .chinese import text
 
 # 获取全局配置
 from vnpy.trader.vtGlobal import globalSetting
 
 # 打开配置文件，读取语言配置
 if globalSetting['language'] == 'english':
-    from english import text
+    from .english import text

--- a/vnpy/trader/gateway/femasGateway/__init__.py
+++ b/vnpy/trader/gateway/femasGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from femasGateway import FemasGateway
+from .femasGateway import FemasGateway
 
 gatewayClass = FemasGateway
 gatewayName = 'FEMAS'

--- a/vnpy/trader/gateway/femasGateway/femasGateway.py
+++ b/vnpy/trader/gateway/femasGateway/femasGateway.py
@@ -5,6 +5,7 @@ vn.femas的gateway接入
 
 考虑到飞马只对接期货（目前只有中金所）, vtSymbol直接使用symbol
 '''
+from __future__ import print_function
 
 
 import os
@@ -599,10 +600,10 @@ class FemasTdApi(TdApi):
         # 如果登录成功，推送日志信息
         if error['ErrorID'] == 0:
             for k, v in data.items():
-                print k, ':', v
+                print(k, ':', v)
             if data['MaxOrderLocalID']:
                 self.localID = int(data['MaxOrderLocalID'])    # 目前最大本地报单号
-                print 'id now', self.localID
+                print('id now', self.localID)
             
             self.loginStatus = True
             self.gateway.mdConnected = True

--- a/vnpy/trader/gateway/futuGateway/__init__.py
+++ b/vnpy/trader/gateway/futuGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from futuGateway import FutuGateway
+from .futuGateway import FutuGateway
 
 gatewayClass = FutuGateway
 gatewayName = 'FUTU'

--- a/vnpy/trader/gateway/fxcmGateway/__init__.py
+++ b/vnpy/trader/gateway/fxcmGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from fxcmGateway import FxcmGateway
+from .fxcmGateway import FxcmGateway
 
 gatewayClass = FxcmGateway
 gatewayName = 'FXCM'

--- a/vnpy/trader/gateway/fxcmGateway/fxcmGateway.py
+++ b/vnpy/trader/gateway/fxcmGateway/fxcmGateway.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import os
 import json
 from datetime import datetime
@@ -434,22 +435,22 @@ class Api(FxcmApi):
     #----------------------------------------------------------------------
     def onOpenTrade(self, data, reqid):
         """开仓回调"""
-        print data, reqid
+        print(data, reqid)
         
     #----------------------------------------------------------------------
     def onCloseTrade(self, data, reqid):
         """平仓回调"""
-        print data, reqid 
+        print(data, reqid) 
         
     #----------------------------------------------------------------------
     def onChangeOrder(self, data, reqid):
         """改单回调"""
-        print data, reqid       
+        print(data, reqid)       
 
     #----------------------------------------------------------------------
     def onDeleteOrder(self, data, reqid):
         """撤单回调"""
-        print data, reqid       
+        print(data, reqid)       
     
     #----------------------------------------------------------------------
     def onPriceUpdate(self, data):

--- a/vnpy/trader/gateway/ibGateway/__init__.py
+++ b/vnpy/trader/gateway/ibGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from ibGateway import IbGateway
+from .ibGateway import IbGateway
 
 gatewayClass = IbGateway
 gatewayName = 'IB'

--- a/vnpy/trader/gateway/ibGateway/ibGateway.py
+++ b/vnpy/trader/gateway/ibGateway/ibGateway.py
@@ -10,6 +10,7 @@ Interactive Brokers的gateway接入，已经替换为vn.ib封装。
 4. 目前只支持股票和期货交易，ib api里期权合约的确定是基于Contract对象的多个字段，比较复杂暂时没做
 5. 海外市场的交易规则和国内有很多细节上的不同，所以一些字段类型的映射可能不合理，如果发现问题欢迎指出
 '''
+from __future__ import print_function
 
 import os
 import json
@@ -375,7 +376,7 @@ class IbWrapper(IbApi):
                 newtick = copy(tick)
                 self.gateway.onTick(newtick)
         else:
-            print field
+            print(field)
         
     #----------------------------------------------------------------------
     def tickSize(self, tickerId, field, size):
@@ -385,7 +386,7 @@ class IbWrapper(IbApi):
             key = tickFieldMap[field]
             tick.__setattr__(key, size)   
         else:
-            print field
+            print(field)
         
     #----------------------------------------------------------------------
     def tickOptionComputation(self, tickerId, tickType, impliedVol, delta, optPrice, pvDividend, gamma, vega, theta, undPrice):

--- a/vnpy/trader/gateway/ibGateway/language/__init__.py
+++ b/vnpy/trader/gateway/ibGateway/language/__init__.py
@@ -1,11 +1,12 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 import json
 import os
 import traceback
 
 # 默认设置
-from chinese import text
+from .chinese import text
 
 # 获取目录上级路径
 path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
@@ -14,10 +15,10 @@ SETTING_FILENAME = os.path.join(path, SETTING_FILENAME)
 
 # 打开配置文件，读取语言配置
 try:
-    f = file(SETTING_FILENAME)
+    f = open(SETTING_FILENAME)
     setting = json.load(f)
     if setting['language'] == 'english':
-        from english import text
+        from .english import text
     f.close()
 except:
     traceback.print_exc()

--- a/vnpy/trader/gateway/ksgoldGateway/__init__.py
+++ b/vnpy/trader/gateway/ksgoldGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from ksgoldGateway import KsgoldGateway
+from .ksgoldGateway import KsgoldGateway
 
 gatewayClass = KsgoldGateway
 gatewayName = 'KSGOLD'

--- a/vnpy/trader/gateway/ksotpGateway/__init__.py
+++ b/vnpy/trader/gateway/ksotpGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from ksotpGateway import KsotpGateway
+from .ksotpGateway import KsotpGateway
 
 gatewayClass = KsotpGateway
 gatewayName = 'KSOTP'

--- a/vnpy/trader/gateway/lbankGateway/__init__.py
+++ b/vnpy/trader/gateway/lbankGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from lbankGateway import LbankGateway
+from .lbankGateway import LbankGateway
 
 gatewayClass = lbankGateway
 gatewayName = 'LBANK'

--- a/vnpy/trader/gateway/lbankGateway/lbankGateway.py
+++ b/vnpy/trader/gateway/lbankGateway/lbankGateway.py
@@ -3,6 +3,7 @@
 '''
 vn.lhang的gateway接入
 '''
+from __future__ import print_function
 
 
 import os
@@ -244,11 +245,11 @@ class LbankApi(LbankApi):
     # ----------------------------------------------------------------------
     def onGetTrades(self, data, req, reqID):
         """查询历史成交"""
-        print data, reqID
+        print(data, reqID)
 
     # ----------------------------------------------------------------------
     def onGetKline(self, data, req, reqID):
-        print data, reqID
+        print(data, reqID)
     
     # ----------------------------------------------------------------------
     def onGetUserInfo(self, data, req, reqID):

--- a/vnpy/trader/gateway/ltsGateway/__init__.py
+++ b/vnpy/trader/gateway/ltsGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from ltsGateway import LtsGateway
+from .ltsGateway import LtsGateway
 
 gatewayClass = LtsGateway
 gatewayName = 'LTS'

--- a/vnpy/trader/gateway/ltsGateway/ltsGateway.py
+++ b/vnpy/trader/gateway/ltsGateway/ltsGateway.py
@@ -3,6 +3,7 @@
 '''
 vn.lts的gateway接入
 '''
+from __future__ import print_function
 
 import os
 import json
@@ -980,7 +981,7 @@ class LtsQryApi(QryApi):
         elif data['ProductClass'] == '8':
             contract.productClass = PRODUCT_EQUITY
         else:
-            print data['ProductClass']
+            print(data['ProductClass'])
         
         # 期权类型
         if data['InstrumentType'] == '1':

--- a/vnpy/trader/gateway/oandaGateway/__init__.py
+++ b/vnpy/trader/gateway/oandaGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from oandaGateway import OandaGateway
+from .oandaGateway import OandaGateway
 
 gatewayClass = OandaGateway
 gatewayName = 'OANDA'

--- a/vnpy/trader/gateway/qdpGateway/__init__.py
+++ b/vnpy/trader/gateway/qdpGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from qdpGateway import QdpGateway
+from .qdpGateway import QdpGateway
 
 gatewayClass = QdpGateway
 gatewayName = 'QDP'

--- a/vnpy/trader/gateway/secGateway/__init__.py
+++ b/vnpy/trader/gateway/secGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from secGateway import SecGateway
+from .secGateway import SecGateway
 
 gatewayClass = SecGateway
 gatewayName = 'SEC'

--- a/vnpy/trader/gateway/secGateway/secGateway.py
+++ b/vnpy/trader/gateway/secGateway/secGateway.py
@@ -3,6 +3,7 @@
 '''
 vn.sec的gateway接入
 '''
+from __future__ import print_function
 
 import os
 import json
@@ -50,11 +51,11 @@ exchangeMapReverse = {v:k for k,v in exchangeMap.items()}
 #----------------------------------------------------------------------
 def print_dict(d):
     """"""
-    print '-' * 30
+    print('-' * 30)
     l = d.keys()
     l.sort()
     for k in l:
-        print '%s:%s' %(k, d[k])
+        print('%s:%s' %(k, d[k]))
     
 
 ########################################################################

--- a/vnpy/trader/gateway/sgitGateway/__init__.py
+++ b/vnpy/trader/gateway/sgitGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from sgitGateway import SgitGateway
+from .sgitGateway import SgitGateway
 
 gatewayClass = SgitGateway
 gatewayName = 'SGIT'

--- a/vnpy/trader/gateway/shzdGateway/__init__.py
+++ b/vnpy/trader/gateway/shzdGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from shzdGateway import ShzdGateway
+from .shzdGateway import ShzdGateway
 
 gatewayClass = ShzdGateway
 gatewayName = 'SHZD'

--- a/vnpy/trader/gateway/shzdGateway/shzdGateway.py
+++ b/vnpy/trader/gateway/shzdGateway/shzdGateway.py
@@ -8,6 +8,7 @@ vn.shzd的gateway接入
 3. 持仓全部平光后，再次查询时会没有该合约的推送（和CTP不同），为了避免最后平仓
    不更新的情况，使用缓存机制来处理
 '''
+from __future__ import print_function
 
 
 import os
@@ -721,9 +722,9 @@ class ShzdGatewayApi(ShzdApi):
 #----------------------------------------------------------------------
 def printDict(d):
     """打印字典"""
-    print '-' * 50
+    print('-' * 50)
     l = d.keys()
     l.sort()
     for k in l:
-        print k, ':', d[k]
+        print(k, ':', d[k])
     

--- a/vnpy/trader/gateway/tkproGateway/tkproGateway.py
+++ b/vnpy/trader/gateway/tkproGateway/tkproGateway.py
@@ -570,7 +570,7 @@ class TkproDataApi(object):
             tick.lowerLimit = data['limit_down']
     
             self.gateway.onTick(tick)
-        except Exception, e:
+        except Exception as e:
             self.writeLog(u'行情更新失败，错误信息：%s' % str(e))
 
     #----------------------------------------------------------------------

--- a/vnpy/trader/gateway/windGateway/__init__.py
+++ b/vnpy/trader/gateway/windGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from windGateway import WindGateway
+from .windGateway import WindGateway
 
 gatewayClass = WindGateway
 gatewayName = 'WIND'

--- a/vnpy/trader/gateway/windGateway/windGateway.py
+++ b/vnpy/trader/gateway/windGateway/windGateway.py
@@ -3,6 +3,7 @@
 '''
 Wind Python API的gateway接入
 '''
+from __future__ import print_function
 
 from copy import copy
 
@@ -11,7 +12,7 @@ w = None
 try:
     from WindPy import w
 except ImportError:
-    print u'请先安装WindPy接口'
+    print(u'请先安装WindPy接口')
 
 from vnpy.trader.vtGateway import *
 

--- a/vnpy/trader/gateway/xspeedGateway/__init__.py
+++ b/vnpy/trader/gateway/xspeedGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from xspeedGateway import XspeedGateway
+from .xspeedGateway import XspeedGateway
 
 gatewayClass = XspeedGateway
 gatewayName = 'XSPEED'

--- a/vnpy/trader/gateway/xtpGateway/__init__.py
+++ b/vnpy/trader/gateway/xtpGateway/__init__.py
@@ -1,7 +1,8 @@
 # encoding: UTF-8
 
+from __future__ import absolute_import
 from vnpy.trader import vtConstant
-from xtpGateway import XtpGateway
+from .xtpGateway import XtpGateway
 
 gatewayClass = XtpGateway
 gatewayName = 'XTP'

--- a/vnpy/trader/vtEngine.py
+++ b/vnpy/trader/vtEngine.py
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
 from __future__ import division
+from __future__ import print_function
 
 import os
 import shelve
@@ -968,11 +969,11 @@ class PositionDetail(object):
     #----------------------------------------------------------------------
     def output(self):
         """"""
-        print self.vtSymbol, '-'*30
-        print 'long, total:%s, td:%s, yd:%s' %(self.longPos, self.longTd, self.longYd)
-        print 'long frozen, total:%s, td:%s, yd:%s' %(self.longPosFrozen, self.longTdFrozen, self.longYdFrozen)
-        print 'short, total:%s, td:%s, yd:%s' %(self.shortPos, self.shortTd, self.shortYd)
-        print 'short frozen, total:%s, td:%s, yd:%s' %(self.shortPosFrozen, self.shortTdFrozen, self.shortYdFrozen)        
+        print(self.vtSymbol, '-'*30)
+        print('long, total:%s, td:%s, yd:%s' %(self.longPos, self.longTd, self.longYd))
+        print('long frozen, total:%s, td:%s, yd:%s' %(self.longPosFrozen, self.longTdFrozen, self.longYdFrozen))
+        print('short, total:%s, td:%s, yd:%s' %(self.shortPos, self.shortTd, self.shortYd))
+        print('short frozen, total:%s, td:%s, yd:%s' %(self.shortPosFrozen, self.shortTdFrozen, self.shortYdFrozen))        
     
     #----------------------------------------------------------------------
     def convertOrderReq(self, req):

--- a/vnpy/trader/vtFunction.py
+++ b/vnpy/trader/vtFunction.py
@@ -10,6 +10,11 @@ import json
 from datetime import datetime
 from math import isnan
 
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
+
 
 MAX_NUMBER = 10000000000000
 MAX_DECIMAL = 4
@@ -18,23 +23,23 @@ MAX_DECIMAL = 4
 def safeUnicode(value):
     """检查接口数据潜在的错误，保证转化为的字符串正确"""
     # 检查是数字接近0时会出现的浮点数上限
-    if type(value) is int or type(value) is float:
+    if isinstance(value, (int, float)):
         if value > MAX_NUMBER or isnan(value):
             value = 0
-    
+
     # 检查防止小数点位过多
     if type(value) is float:
         d = decimal.Decimal(str(value))
         if abs(d.as_tuple().exponent) > MAX_DECIMAL:
             value = round(value, ndigits=MAX_DECIMAL)
-    
+
     return unicode(value)
 
 
 #----------------------------------------------------------------------
 def todayDate():
     """获取当前本机电脑时间的日期"""
-    return datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)    
+    return datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
 
 
 # 图标路径
@@ -48,10 +53,10 @@ for root, subdirs, files in os.walk(path):
 
 #----------------------------------------------------------------------
 def loadIconPath(iconName):
-    """加载程序图标路径"""   
+    """加载程序图标路径"""
     global iconPathDict
-    return iconPathDict.get(iconName, '')    
-    
+    return iconPathDict.get(iconName, '')
+
 
 
 #----------------------------------------------------------------------
@@ -60,7 +65,7 @@ def getTempPath(name):
     tempPath = os.path.join(os.getcwd(), 'temp')
     if not os.path.exists(tempPath):
         os.makedirs(tempPath)
-        
+
     path = os.path.join(tempPath, name)
     return path
 
@@ -80,12 +85,8 @@ def getJsonPath(name, moduleFile):
     if os.path.isfile(currentJsonPath):
         jsonPathDict[name] = currentJsonPath
         return currentJsonPath
-    
+
     moduleFolder = os.path.abspath(os.path.dirname(moduleFile))
     moduleJsonPath = os.path.join(moduleFolder, '.', name)
     jsonPathDict[name] = moduleJsonPath
     return moduleJsonPath
-
-    
-    
-    


### PR DESCRIPTION
Make the minimal, safe changes to make the codebase syntax compatible with both Python 2 and Python 3.  Being syntax compatible with Python 3 does __not__ mean that the port is complete.

1. $ pip install flake8 future # http://python-future.org/futurize_cheatsheet.html
2. $ git checkout -b modernize-python2-code
3. $ python2 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
4. $ futurize --stage1 -w .
5. manually fix up __file(), raw_input(), reload(), unicode(), xrange()__, etc.
6. $ python3 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
7. $ git commit -am "Modernize Python 2 code to get ready for Python 3"
8. $ git push --force origin modernize-python2-code