### PR TITLE
Add Travis CI to automatically run flake8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+group: travis_latest
+language: python
+cache: pip
+python:
+    - 2.7
+    - 3.6
+matrix:
+    allow_failures:
+        - python: 3.6
+install:
+    - pip install -r requirements.txt
+    - pip install flake8  # pytest  # add another testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # pytest --capture=sys  # add other tests here
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
Step 1 of #818

There are tons of tools in the [GitHub Marketplace](https://github.com/marketplace) but the one that I use the most is [Travis CI](https://travis-ci.org) because it is free for Open Source projects like this one and it is quite flexible at running tests.  This config file has Travis run [flake8](http://flake8.pycqa.org) tests on every pull request so that we can quickly see if there are breaking changes.  At https://travis-ci.org/profile you would need to flip the switch on for this repo on and then commit any change to the repo for the testing to begin.