### PR TITLE
Fix undefined name xtpGateway (to dev this time)

### DIFF
--- a/examples/VnTrader/run.py
+++ b/examples/VnTrader/run.py
@@ -1,6 +1,10 @@
 # encoding: UTF-8
 
 # 重载sys模块，设置默认字符串编码方式为utf8
+try:
+    reload         # Python 2
+except NameError:  # Python 3
+    from importlib import reload
 import sys
 reload(sys)
 sys.setdefaultencoding('utf8')
@@ -16,11 +20,13 @@ from vnpy.trader.uiQt import createQApp
 from vnpy.trader.uiMainWindow import MainWindow
 
 # 加载底层接口
-from vnpy.trader.gateway import (ctpGateway, oandaGateway, 
+from vnpy.trader.gateway import (ctpGateway, oandaGateway,
                                  ibGateway)
 
-if system == 'Windows':
-    from vnpy.trader.gateway import (femasGateway, xspeedGateway, 
+if system == 'Linux':
+    from vnpy.trader.gateway import xtpGateway
+elif system == 'Windows':
+    from vnpy.trader.gateway import (femasGateway, xspeedGateway,
                                      futuGateway, secGateway)
 
 # 加载上层应用
@@ -32,36 +38,36 @@ def main():
     """主程序入口"""
     # 创建Qt应用对象
     qApp = createQApp()
-    
+
     # 创建事件引擎
     ee = EventEngine()
-    
+
     # 创建主引擎
     me = MainEngine(ee)
-    
+
     # 添加交易接口
     me.addGateway(ctpGateway)
     me.addGateway(oandaGateway)
     me.addGateway(ibGateway)
-    
+
     if system == 'Windows':
         me.addGateway(femasGateway)
         me.addGateway(xspeedGateway)
         me.addGateway(secGateway)
         me.addGateway(futuGateway)
-        
+
     if system == 'Linux':
         me.addGateway(xtpGateway)
-        
+
     # 添加上层应用
     me.addApp(riskManager)
     me.addApp(ctaStrategy)
     me.addApp(spreadTrading)
-    
+
     # 创建主窗口
     mw = MainWindow(me, ee)
     mw.showMaximized()
-    
+
     # 在主线程中启动Qt事件循环
     sys.exit(qApp.exec_())
 


### PR DESCRIPTION
Part of step 2 of #818 -- Fixes one of three issues in:

$ __python2 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./beta/api/korbit/vnkorbit.py:76:13: F821 undefined name 'logging'
            logging.error("exception: {}, response_text: {}".format(e, response.text))
            ^
./examples/VnTrader/run.py:54:23: F821 undefined name 'xtpGateway'
        me.addGateway(xtpGateway)
                      ^
./vnpy/trader/gateway/lbankGateway/__init__.py:6:16: F821 undefined name 'lbankGateway'
gatewayClass = lbankGateway
               ^
3     F821 undefined name 'logging'
3
```