### PR TITLE
Typo in variable name: LbankGateway --> lbankGateway

### DIFF
--- a/vnpy/trader/gateway/lbankGateway/__init__.py
+++ b/vnpy/trader/gateway/lbankGateway/__init__.py
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 
 from vnpy.trader import vtConstant
-from lbankGateway import LbankGateway
+from lbankGateway import lbankGateway
 
 gatewayClass = lbankGateway
 gatewayName = 'LBANK'


### PR DESCRIPTION
Part of step 2 of #818 -- Fixes one of three issues in:

$ python2 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics

./beta/api/korbit/vnkorbit.py:76:13: F821 undefined name 'logging'
            logging.error("exception: {}, response_text: {}".format(e, response.text))
            ^
./examples/VnTrader/run.py:54:23: F821 undefined name 'xtpGateway'
        me.addGateway(xtpGateway)
                      ^
./vnpy/trader/gateway/lbankGateway/__init__.py:6:16: F821 undefined name 'lbankGateway'
gatewayClass = lbankGateway
               ^
3     F821 undefined name 'logging'
3
