### PR TITLE
Futurize older examples/F*,J*,S*,T*

### DIFF
--- a/examples/FutuDataService/dataService.py
+++ b/examples/FutuDataService/dataService.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import sys
 import json
 from datetime import datetime, timedelta
@@ -56,7 +57,7 @@ def downMinuteBarBySymbol(symbol):
     
     code, data = quote.get_history_kline(symbol, start=startDate, ktype='K_1M')
     if code:
-        print u'合约%s数据下载失败：%s' %(symbol, data)
+        print(u'合约%s数据下载失败：%s' %(symbol, data))
         return
         
     data = data.sort_index()
@@ -70,24 +71,24 @@ def downMinuteBarBySymbol(symbol):
     end = time()
     cost = (end - start) * 1000
 
-    print u'合约%s数据下载完成%s - %s，耗时%s毫秒' %(symbol, data.iloc[0]['time_key'], 
-                                                  data.iloc[-1]['time_key'], cost)
+    print(u'合约%s数据下载完成%s - %s，耗时%s毫秒' %(symbol, data.iloc[0]['time_key'], 
+                                                  data.iloc[-1]['time_key'], cost))
 
     
 #----------------------------------------------------------------------
 def downloadAllMinuteBar():
     """下载所有配置中的合约的分钟线数据"""
-    print '-' * 50
-    print u'开始下载合约分钟线数据'
-    print '-' * 50
+    print('-' * 50)
+    print(u'开始下载合约分钟线数据')
+    print('-' * 50)
     
     # 添加下载任务
     for symbol in SYMBOLS:
         downMinuteBarBySymbol(str(symbol))
     
-    print '-' * 50
-    print u'合约分钟线数据下载完成'
-    print '-' * 50
+    print('-' * 50)
+    print(u'合约分钟线数据下载完成')
+    print('-' * 50)
     
 
 

--- a/examples/FutuDataService/runService.py
+++ b/examples/FutuDataService/runService.py
@@ -3,6 +3,7 @@
 """
 定时服务，可无人值守运行，实现每日自动下载更新历史行情数据到数据库中。
 """
+from __future__ import print_function
 
 import time
 import datetime
@@ -27,6 +28,6 @@ if __name__ == '__main__':
             # 更新任务完成的日期
             taskCompletedDate = t.date()
         else:
-            print u'当前时间%s，任务定时%s' %(t, taskTime)
+            print(u'当前时间%s，任务定时%s' %(t, taskTime))
     
         time.sleep(60)

--- a/examples/JaqsService/run.py
+++ b/examples/JaqsService/run.py
@@ -2,8 +2,11 @@
 
 # 重载sys模块，设置默认字符串编码方式为utf8
 import sys
-reload(sys)
-sys.setdefaultencoding('utf8')
+try:
+    reload(sys)  # Python 2
+    sys.setdefaultencoding('utf8')
+except NameError:
+    pass         # Python 3
 
 from time import sleep
 

--- a/examples/JaqsService/runUI.py
+++ b/examples/JaqsService/runUI.py
@@ -2,8 +2,11 @@
 
 # 重载sys模块，设置默认字符串编码方式为utf8
 import sys
-reload(sys)
-sys.setdefaultencoding('utf8')
+try:
+    reload(sys)  # Python 2
+    sys.setdefaultencoding('utf8')
+except NameError:
+    pass         # Python 3
 
 # 判断操作系统
 import platform

--- a/examples/ServerClient/client.py
+++ b/examples/ServerClient/client.py
@@ -2,8 +2,11 @@
 
 # 重载sys模块，设置默认字符串编码方式为utf8
 import sys
-reload(sys)
-sys.setdefaultencoding('utf8')
+try:
+    reload(sys)  # Python 2
+    sys.setdefaultencoding('utf8')
+except NameError:
+    pass         # Python 3
 
 # 判断操作系统
 import platform

--- a/examples/ServerClient/server.py
+++ b/examples/ServerClient/server.py
@@ -2,8 +2,11 @@
 
 # 重载sys模块，设置默认字符串编码方式为utf8
 import sys
-reload(sys)
-sys.setdefaultencoding('utf8')
+try:
+    reload(sys)  # Python 2
+    sys.setdefaultencoding('utf8')
+except NameError:
+    pass         # Python 3
 
 from time import sleep
 

--- a/examples/ShcifcoDataService/dataService.py
+++ b/examples/ShcifcoDataService/dataService.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import json
 import time
 import datetime
@@ -57,7 +58,7 @@ def downMinuteBarBySymbol(symbol, num):
     
     l = api.getHisBar(symbol, num, period=PERIOD_1MIN)
     if not l:
-        print u'%s数据下载失败' %symbol
+        print(u'%s数据下载失败' %symbol)
         return
     
     for d in l:
@@ -69,23 +70,23 @@ def downMinuteBarBySymbol(symbol, num):
     end = time.time()
     cost = (end - start) * 1000
 
-    print u'合约%s数据下载完成%s - %s，耗时%s毫秒' %(symbol, generateVtBar(l[0]).datetime,
-                                                  generateVtBar(l[-1]).datetime, cost)
+    print(u'合约%s数据下载完成%s - %s，耗时%s毫秒' %(symbol, generateVtBar(l[0]).datetime,
+                                                  generateVtBar(l[-1]).datetime, cost))
 
 #----------------------------------------------------------------------
 def downloadAllMinuteBar(num):
     """下载所有配置中的合约的分钟线数据"""
-    print '-' * 50
-    print u'开始下载合约分钟线数据'
-    print '-' * 50
+    print('-' * 50)
+    print(u'开始下载合约分钟线数据')
+    print('-' * 50)
     
     for symbol in SYMBOLS:
         downMinuteBarBySymbol(symbol, num)
         time.sleep(1)
 
-    print '-' * 50
-    print u'合约分钟线数据下载完成'
-    print '-' * 50
+    print('-' * 50)
+    print(u'合约分钟线数据下载完成')
+    print('-' * 50)
 
 
     

--- a/examples/ShcifcoDataService/runService.py
+++ b/examples/ShcifcoDataService/runService.py
@@ -3,6 +3,7 @@
 """
 定时服务，可无人值守运行，实现每日自动下载更新历史行情数据到数据库中。
 """
+from __future__ import print_function
 
 from dataService import *
 
@@ -25,6 +26,6 @@ if __name__ == '__main__':
             # 更新任务完成的日期
             taskCompletedDate = t.date()
         else:
-            print u'当前时间%s，任务定时%s' %(t, taskTime)
+            print(u'当前时间%s，任务定时%s' %(t, taskTime))
     
         time.sleep(60)

--- a/examples/TqDataService/dataService.py
+++ b/examples/TqDataService/dataService.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import sys
 import json
 from datetime import datetime
@@ -67,7 +68,7 @@ def onChart(symbol, seconds):
     
     start = datetime.fromtimestamp(l[0]['datetime']/1000000000)
     end = datetime.fromtimestamp(l[-1]['datetime']/1000000000)
-    print u'合约%s下载完成%s - %s' %(symbol, start, end)
+    print(u'合约%s下载完成%s - %s' %(symbol, start, end))
     
     # 移除已经完成的任务
     if symbol in taskList:
@@ -81,9 +82,9 @@ def downMinuteBarBySymbol(symbol, num):
 #----------------------------------------------------------------------
 def downloadAllMinuteBar(num, symbols):
     """下载所有配置中的合约的分钟线数据"""
-    print '-' * 50
-    print u'开始下载合约分钟线数据'
-    print '-' * 50
+    print('-' * 50)
+    print(u'开始下载合约分钟线数据')
+    print('-' * 50)
     
     # 添加下载任务
     taskList.extend(symbols)
@@ -96,9 +97,9 @@ def downloadAllMinuteBar(num, symbols):
 
         # 如果任务列表为空，则说明数据已经全部下载完成
         if not taskList:
-            print '-' * 50
-            print u'合约分钟线数据下载完成'
-            print '-' * 50
+            print('-' * 50)
+            print(u'合约分钟线数据下载完成')
+            print('-' * 50)
             return       
     
 

--- a/examples/TqDataService/runService.py
+++ b/examples/TqDataService/runService.py
@@ -5,6 +5,7 @@
 
 注意: 请确保本程序运行时, 本机天勤终端 (0.8.0 以上版本)正在运行中
 """
+from __future__ import print_function
 
 import time
 import datetime
@@ -34,6 +35,6 @@ if __name__ == '__main__':
             # 更新任务完成的日期
             taskCompletedDate = t.date()
         else:
-            print u'当前时间%s，任务定时%s' %(t, taskTime)
+            print(u'当前时间%s，任务定时%s' %(t, taskTime))
     
         time.sleep(60)

--- a/examples/TushareDataService/dataService.py
+++ b/examples/TushareDataService/dataService.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import sys
 import json
 from datetime import datetime
@@ -72,23 +73,23 @@ def downMinuteBarBySymbol(symbol):
     end = time()
     cost = (end - start) * 1000
 
-    print u'合约%s数据下载完成%s - %s，耗时%s毫秒' %(symbol, df.index[0], df.index[-1], cost)
+    print(u'合约%s数据下载完成%s - %s，耗时%s毫秒' %(symbol, df.index[0], df.index[-1], cost))
 
     
 #----------------------------------------------------------------------
 def downloadAllMinuteBar():
     """下载所有配置中的合约的分钟线数据"""
-    print '-' * 50
-    print u'开始下载合约分钟线数据'
-    print '-' * 50
+    print('-' * 50)
+    print(u'开始下载合约分钟线数据')
+    print('-' * 50)
     
     # 添加下载任务
     for symbol in SYMBOLS:
         downMinuteBarBySymbol(str(symbol))
     
-    print '-' * 50
-    print u'合约分钟线数据下载完成'
-    print '-' * 50
+    print('-' * 50)
+    print(u'合约分钟线数据下载完成')
+    print('-' * 50)
     
 
 

--- a/examples/TushareDataService/runService.py
+++ b/examples/TushareDataService/runService.py
@@ -3,6 +3,7 @@
 """
 定时服务，可无人值守运行，实现每日自动下载更新历史行情数据到数据库中。
 """
+from __future__ import print_function
 
 import time
 import datetime
@@ -27,6 +28,6 @@ if __name__ == '__main__':
             # 更新任务完成的日期
             taskCompletedDate = t.date()
         else:
-            print u'当前时间%s，任务定时%s' %(t, taskTime)
+            print(u'当前时间%s，任务定时%s' %(t, taskTime))
     
         time.sleep(60)


### PR DESCRIPTION
Continue the porting process described in #818

Run [__futurize --stage1 -w__](http://python-future.org/futurize_cheatsheet.html) on the older examples:
* examples/F*: FutuDataService
* examples/J*: JaqsService
* examples/S*: ServerClient, ShcifcoDataService
* examples/T*: TqDataService, TushareDataService
---
* __print()__ is a function in Python 3
* [__reload()__ was moved to importlib](https://docs.python.org/3/library/importlib.html#importlib.reload) in Python 3 because it was overused and led to difficult to solve bugs.  __reload()__ is being used here to reset the default encoding to utf-8 but this is not needed in Python 3 because utf-8 is already the default.