### PR TITLE
Futurize older examples

### DIFF
--- a/examples/CtaBacktesting/runOptimization.py
+++ b/examples/CtaBacktesting/runOptimization.py
@@ -5,6 +5,7 @@
 """
 
 from __future__ import division
+from __future__ import print_function
 
 
 from vnpy.trader.app.ctaStrategy.ctaBacktesting import BacktestingEngine, MINUTE_DB_NAME, OptimizationSetting
@@ -49,4 +50,4 @@ if __name__ == '__main__':
     # 多进程优化，耗时：89秒
     engine.runParallelOptimization(AtrRsiStrategy, setting)
     
-    print u'耗时：%s' %(time.time()-start)
+    print(u'耗时：%s' %(time.time()-start))

--- a/examples/CtaTrading/runCtaTrading.py
+++ b/examples/CtaTrading/runCtaTrading.py
@@ -1,8 +1,12 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import sys
-reload(sys)
-sys.setdefaultencoding('utf8')
+try:
+    reload(sys)  # Python 2
+    sys.setdefaultencoding('utf8')
+except NameError:
+    pass         # Python 3
 
 import multiprocessing
 from time import sleep
@@ -24,12 +28,12 @@ def processErrorEvent(event):
     错误信息在每次登陆后，会将当日所有已产生的均推送一遍，所以不适合写入日志
     """
     error = event.dict_['data']
-    print u'错误代码：%s，错误信息：%s' %(error.errorID, error.errorMsg)
+    print(u'错误代码：%s，错误信息：%s' %(error.errorID, error.errorMsg))
     
 #----------------------------------------------------------------------
 def runChildProcess():
     """子进程运行函数"""
-    print '-'*20
+    print('-'*20)
     
     # 创建日志引擎
     le = LogEngine()

--- a/examples/DataRecording/runDataCleaning.py
+++ b/examples/DataRecording/runDataCleaning.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import json
 from datetime import datetime, timedelta, time
 
@@ -22,7 +23,7 @@ NIGHT_END = time(2, 30)
 #----------------------------------------------------------------------
 def cleanData(dbName, collectionName, start):
     """清洗数据"""
-    print u'\n清洗数据库：%s, 集合：%s, 起始日：%s' %(dbName, collectionName, start)
+    print(u'\n清洗数据库：%s, 集合：%s, 起始日：%s' %(dbName, collectionName, start))
     
     mc = MongoClient('localhost', 27017)    # 创建MongoClient
     cl = mc[dbName][collectionName]         # 获取数据集合
@@ -47,17 +48,17 @@ def cleanData(dbName, collectionName, start):
         
         # 如果需要清洗
         if cleanRequired:
-            print u'删除无效数据，时间戳：%s' %data['datetime']
+            print(u'删除无效数据，时间戳：%s' %data['datetime'])
             cl.delete_one(data)
     
-    print u'清洗完成，数据库：%s, 集合：%s' %(dbName, collectionName)
+    print(u'清洗完成，数据库：%s, 集合：%s' %(dbName, collectionName))
     
 
 
 #----------------------------------------------------------------------
 def runDataCleaning():
     """运行数据清洗"""
-    print u'开始数据清洗工作'
+    print(u'开始数据清洗工作')
     
     # 加载配置
     setting = {}
@@ -77,7 +78,7 @@ def runDataCleaning():
         symbol = l[0]
         cleanData(MINUTE_DB_NAME, symbol, start)
     
-    print u'数据清洗工作完成'
+    print(u'数据清洗工作完成')
     
 
 if __name__ == '__main__':

--- a/examples/DataRecording/runDataRecording.py
+++ b/examples/DataRecording/runDataRecording.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import multiprocessing
 from time import sleep
 from datetime import datetime, time
@@ -18,12 +19,12 @@ def processErrorEvent(event):
     错误信息在每次登陆后，会将当日所有已产生的均推送一遍，所以不适合写入日志
     """
     error = event.dict_['data']
-    print u'错误代码：%s，错误信息：%s' %(error.errorID, error.errorMsg)
+    print(u'错误代码：%s，错误信息：%s' %(error.errorID, error.errorMsg))
 
 #----------------------------------------------------------------------
 def runChildProcess():
     """子进程运行函数"""
-    print '-'*20
+    print('-'*20)
 
     # 创建日志引擎
     le = LogEngine()

--- a/examples/OptionMaster/run.py
+++ b/examples/OptionMaster/run.py
@@ -2,8 +2,11 @@
 
 # 重载sys模块，设置默认字符串编码方式为utf8
 import sys
-reload(sys)
-sys.setdefaultencoding('utf8')
+try:
+    reload(sys)  # Python 2
+    sys.setdefaultencoding('utf8')
+except NameError:
+    pass         # Python 3
 
 # 判断操作系统
 import platform

--- a/examples/QuantosDataService/dataService.py
+++ b/examples/QuantosDataService/dataService.py
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+from __future__ import print_function
 import sys
 import json
 from datetime import datetime, timedelta
@@ -128,15 +129,15 @@ def downMinuteBarBySymbol(api, vtSymbol, startDate, endDate=''):
     e = time()
     cost = (e - start) * 1000
 
-    print u'合约%s数据下载完成%s - %s，耗时%s毫秒' %(vtSymbol, startDate, end.strftime('%Y%m%d'), cost)
+    print(u'合约%s数据下载完成%s - %s，耗时%s毫秒' %(vtSymbol, startDate, end.strftime('%Y%m%d'), cost))
 
     
 #----------------------------------------------------------------------
 def downloadAllMinuteBar(api, days=10):
     """下载所有配置中的合约的分钟线数据"""
-    print '-' * 50
-    print u'开始下载合约分钟线数据'
-    print '-' * 50
+    print('-' * 50)
+    print(u'开始下载合约分钟线数据')
+    print('-' * 50)
     
     startDt = datetime.today() - days * timedelta(1)
     startDate = startDt.strftime('%Y%m%d')
@@ -145,7 +146,7 @@ def downloadAllMinuteBar(api, days=10):
     for symbol in SYMBOLS:
         downMinuteBarBySymbol(api, str(symbol), startDate)
     
-    print '-' * 50
-    print u'合约分钟线数据下载完成'
-    print '-' * 50
+    print('-' * 50)
+    print(u'合约分钟线数据下载完成')
+    print('-' * 50)
     

--- a/examples/QuantosDataService/downloadData.py
+++ b/examples/QuantosDataService/downloadData.py
@@ -3,6 +3,7 @@
 """
 立即下载数据到数据库中，用于手动执行更新操作。
 """
+from __future__ import print_function
 
 import json
 
@@ -16,7 +17,7 @@ if __name__ == '__main__':
     info, msg = api.login(USERNAME, TOKEN)
     
     if not info:
-        print u'数据服务器登录失败，原因：%s' %msg    
+        print(u'数据服务器登录失败，原因：%s' %msg)    
 
     # 下载数据
     downloadAllMinuteBar(api, 100)

--- a/examples/QuantosDataService/runService.py
+++ b/examples/QuantosDataService/runService.py
@@ -3,6 +3,7 @@
 """
 定时服务，可无人值守运行，实现每日自动下载更新历史行情数据到数据库中。
 """
+from __future__ import print_function
 
 import datetime as ddt
 
@@ -26,7 +27,7 @@ if __name__ == '__main__':
             info, msg = api.login(USERNAME, TOKEN)
             
             if not info:
-                print u'数据服务器登录失败，原因：%s' %msg    
+                print(u'数据服务器登录失败，原因：%s' %msg)    
         
             # 下载数据
             downloadAllMinuteBar(api)            
@@ -34,6 +35,6 @@ if __name__ == '__main__':
             # 更新任务完成的日期
             taskCompletedDate = t.date()
         else:
-            print u'当前时间%s，任务定时%s' %(t, taskTime)
+            print(u'当前时间%s，任务定时%s' %(t, taskTime))
     
         sleep(60)

--- a/examples/VnTrader/run_simple.py
+++ b/examples/VnTrader/run_simple.py
@@ -2,9 +2,11 @@
 
 # 重载sys模块，设置默认字符串编码方式为utf8
 import sys
-
-reload(sys)
-sys.setdefaultencoding('utf8')
+try:
+    reload(sys)  # Python 2
+    sys.setdefaultencoding('utf8')
+except NameError:
+    pass         # Python 3
 
 # 判断操作系统
 import platform

--- a/examples/WebTrader/run.py
+++ b/examples/WebTrader/run.py
@@ -1,9 +1,13 @@
 # encoding: UTF-8
 
 # 修改编码
+from __future__ import print_function
 import sys
-reload(sys)
-sys.setdefaultencoding('utf8')
+try:
+    reload(sys)  # Python 2
+    sys.setdefaultencoding('utf8')
+except NameError:
+    pass         # Python 3
 
 # 创建主引擎代理对象
 from vnpy.event import EventEngine2
@@ -25,7 +29,7 @@ me.init(reqAddress, subAddress)
 def printLog(event):
     """打印日志"""
     log = event.dict_['data']
-    print log.logTime, log.logContent
+    print(log.logTime, log.logContent)
     
 ee.register(EVENT_LOG, printLog)
     
@@ -112,7 +116,7 @@ class Gateway(Resource):
         args = self.parser.parse_args()
         token = args['token']
         if token != TOKEN:
-            print 'token error'
+            print('token error')
             return {'result_code':'error','message':'token error'}
                 
         gatewayName = args['gatewayName']
@@ -164,7 +168,7 @@ class Order(Resource):
         token = args['token']
         if token != TOKEN:
             return {'result_code':'error','message':'token error'}
-        print args
+        print(args)
         vtSymbol = args['vtSymbol']        
         price = args['price']        
         volume = args['volume']        
@@ -300,7 +304,7 @@ class Position(Resource):
             return {'result_code':'error','message':'token error'}
         
         data = me.getAllPositions()
-        print 'position',data
+        print('position',data)
         l = [o.__dict__ for o in data]
         return {'result_code':'success','data':l}
 
@@ -327,7 +331,7 @@ class Contract(Resource):
             return {'result_code':'error','message':'token error'}
         
         data = me.getAllContracts()
-        print 'Contract',data
+        print('Contract',data)
         l = [o.__dict__ for o in data]
         return {'result_code':'success','data':l}        
 

--- a/examples/WebTrader/server.py
+++ b/examples/WebTrader/server.py
@@ -2,8 +2,11 @@
 
 # 重载sys模块，设置默认字符串编码方式为utf8
 import sys
-reload(sys)
-sys.setdefaultencoding('utf8')
+try:
+    reload(sys)  # Python 2
+    sys.setdefaultencoding('utf8')
+except NameError:
+    pass         # Python 3
 
 import signal
 from time import sleep


### PR DESCRIPTION
Continue the porting process described in #825

Run [__futurize --stage1 -w__](http://python-future.org/futurize_cheatsheet.html) on the older examples:
* __print()__ is a function in Python 3
* [__reload()__ was moved to importlib](https://docs.python.org/3/library/importlib.html#importlib.reload) in Python 3 because it was overused and led to difficult to solve bugs.  __reload()__ is being used here to reset the default encoding to utf-8 but this is not needed in Python 3 because utf-8 is already the default.