### PR TITLE
修复飞创接口sleep未引用问题；修复点击价差交易pyqt报错问题

### DIFF
--- a/vnpy/trader/app/spreadTrading/uiStWidget.py
+++ b/vnpy/trader/app/spreadTrading/uiStWidget.py
@@ -440,8 +440,8 @@ class StAlgoManager(QtWidgets.QTableWidget):
                    u'状态']
         self.setColumnCount(len(headers))
         self.setHorizontalHeaderLabels(headers)
-        self.horizontalHeader().setResizeMode(QtWidgets.QHeaderView.Stretch)
-        
+        self.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
+
         self.verticalHeader().setVisible(False)
         self.setEditTriggers(self.NoEditTriggers)
         

--- a/vnpy/trader/gateway/xspeedGateway/xspeedGateway.py
+++ b/vnpy/trader/gateway/xspeedGateway/xspeedGateway.py
@@ -7,6 +7,7 @@ vn.xspeed的gateway接入
 import os
 import json
 import time
+from time import sleep
 from copy import copy
 
 from vnpy.api.xspeed import MdApi, TdApi, defineDict


### PR DESCRIPTION
## 改进内容

1. 修复飞创接口sleep未引用问题
2. 修复点击价差交易pyqt报错问题

## 相关的Issue号（如有）

Close #