### PR TITLE
忽略pyenv自动创建的.python-version文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ vn.ctp/build/*
 vn.lts/build/*
 .idea
 .vscode
+.python-version
 .gitignore
 
 vn.trader/ctaAlgo/data/*


### PR DESCRIPTION
## 改进内容

1. 忽略pyenv自动创建的.python-version文件
