### PR TITLE
stAlgo.py

### DIFF
--- a/vnpy/trader/app/spreadTrading/stAlgo.py
+++ b/vnpy/trader/app/spreadTrading/stAlgo.py
@@ -240,6 +240,8 @@ class SniperAlgo(StAlgoTemplate):
 
         vtOrderID = order.vtOrderID
         vtSymbol = order.vtSymbol
+		if vtOrderID not in self.legOrderDict[vtSymbol]:
+			return
         newTradedVolume = order.tradedVolume
         lastTradedVolume = self.orderTradedDict.get(vtOrderID, 0)
         


### PR DESCRIPTION
在SpreadTrading中，自己下的价差交易品种订单会被误认为是价差交易程序下的单，做了一个判断，不是这个程序下的单不会补腿。

初次PR，多多指教哈！