### PR TITLE
时间回退1分钟，0：00时跨日回退错误

### DIFF
--- a/examples/QuantosDataService/dataService.py
+++ b/examples/QuantosDataService/dataService.py
@@ -62,7 +62,6 @@ def generateVtBar(row):
     bar.low = row['low']
     bar.close = row['close']
     bar.volume = row['volume']
-    
     bar.date = str(row['date'])
     bar.time = str(row['time']).rjust(6, '0')
    
@@ -70,6 +69,19 @@ def generateVtBar(row):
     hour=bar.time[0:2]
     minute=bar.time[2:4]
     sec=bar.time[4:6]
+
+    # ------------------------------add by yzl :start
+    # print(row.date, type(row.date), row.time, type(row.time))# add by yzl to show the date type and value
+    # 20180328 < type'long' > 93400 < type'long' >
+    # 最佳改进方法： 构建一个datetime,然后滞后一分钟，不能简单0：00：00处理，日期减一，弊端:处理量太大
+    # 改进2：找出 0：00,此时日期回退一天
+    if int(hour) == 0 and int(minute) == 0:
+        temp_date = datetime(int(bar.date[:4]), int(bar.date[4:6]), int(bar.date[6:])).date()
+        temp_date = temp_date - timedelta(days=1)
+        bar.date = temp_date.strftime("%Y%m%d")
+
+    # -------------------------------add by yzl :end
+
     if minute=="00":
         minute="59"
         
@@ -81,6 +93,8 @@ def generateVtBar(row):
     else:
         minute=str(int(minute)-1).rjust(2,'0')
     bar.time=hour+minute+sec
+
+
    
     bar.datetime = datetime.strptime(' '.join([bar.date, bar.time]), '%Y%m%d %H%M%S')
     


### PR DESCRIPTION
0：00时，人家日期时新的一天，而回退到23：59没有回退日期

建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 
2. 
3.

## 相关的Issue号（如有）

Close #966