### PR TITLE
[Fix] 添加gitignore，忽略掉CMake的临时文件，还有build/文件夹

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,15 @@ Release/
 *.log
 *.bak
 
+# 编译临时文件夹
+build/
+
+# CMake临时文件
+CMakeCache.txt
+CMakeFiles/
+build/cmake_install.cmake
+build/Makefile
+
 # 目录
 .idea
 .vscode


### PR DESCRIPTION
1. 增加了一些gitignore

我在清理文件的时候发现了一些build/下的文件，所以就想着要不要把这些文件加进gitignore里面来了。