### PR TITLE
[mod] 修复火币中tick和newtick混用错误

### DIFF
--- a/vnpy/trader/gateway/huobiGateway/huobiGateway.py
+++ b/vnpy/trader/gateway/huobiGateway/huobiGateway.py
@@ -288,7 +288,7 @@ class HuobiDataApi(DataApi):
 
         if tick.lastPrice:
             newtick = copy(tick)
-            self.gateway.onTick(tick)
+            self.gateway.onTick(newtick)
 
     #----------------------------------------------------------------------
     def onTradeDetail(self, data):
@@ -318,7 +318,7 @@ class HuobiDataApi(DataApi):
 
         if tick.bidPrice1:
             newtick = copy(tick)
-            self.gateway.onTick(tick)
+            self.gateway.onTick(newtick)
 
 
 ########################################################################


### PR DESCRIPTION
建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 修复火币中tick和newtick混用错误，应该用newtick，此处用的是tick
2. 
3.

## 相关的Issue号（如有）

Close #