### PR TITLE
OkexApi的几个函数多出一个参数 ws

### DIFF
--- a/vnpy/api/okex/vnokex.py
+++ b/vnpy/api/okex/vnokex.py
@@ -190,7 +190,7 @@ class OkexApi(object):
         print('onOpen')
     
     #----------------------------------------------------------------------
-    def onMessageCallback(self, ws, evt):
+    def onMessageCallback(self, evt):
         """""" 
         data = self.readData(evt)
         if 'event' in data:
@@ -199,17 +199,17 @@ class OkexApi(object):
             self.onMessage(data[0])
         
     #----------------------------------------------------------------------
-    def onErrorCallback(self, ws, evt):
+    def onErrorCallback(self, evt):
         """"""
         self.onError(evt)
         
     #----------------------------------------------------------------------
-    def onCloseCallback(self, ws):
+    def onCloseCallback(self):
         """"""
         self.onClose()
         
     #----------------------------------------------------------------------
-    def onOpenCallback(self, ws):
+    def onOpenCallback(self):
         """"""
         if not self.heartbeatThread:
             self.heartbeatThread = Thread(target=self.heartbeat)

--- a/vnpy/trader/app/algoTrading/algo/stopAlgo.py
+++ b/vnpy/trader/app/algoTrading/algo/stopAlgo.py
@@ -62,17 +62,21 @@ class StopAlgo(AlgoTemplate):
                 price = min(price, tick.upperLimit)
                 
             func = self.buy
-        else:
+        elif (self.direction == DIRECTION_SHORT and
+            tick.lastPrice <= self.stopPrice):
             price = self.stopPrice - self.priceAdd
             
             if tick.lowerLimit:
                 price = max(price, tick.lowerLimit)
                 
             func = self.sell
-            
-        self.vtOrderID = func(self.vtSymbol, price, self.volume, offset=self.offset)
-        
-        msg = u'停止单已触发，代码：%s，方向：%s, 价格：%s，数量：%s，开平：%s' %(self.vtSymbol,
+        else:
+            func = None
+
+        if func:
+            self.vtOrderID = func(self.vtSymbol, price, self.volume, offset=self.offset)
+
+            msg = u'停止单已触发，代码：%s，方向：%s, 价格：%s，数量：%s，开平：%s' %(self.vtSymbol,
                                                                                 self.direction,
                                                                                 self.stopPrice,
                                                                                 self.totalVolume,


### PR DESCRIPTION
建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. vnpy/api/okex/vnokex.py脚本 OkexApi类中 多个函数的参数有ws参数，但是gateway中调用这几个函数时，没有传入ws参数，导致函数的参数个数不同而出错。

## 相关的Issue号（如有）

Close #