### PR TITLE
[Fix] 修复了当bitmexgateway.socketapi响应onTrade时，遇到side字段为''导致异常的情况。

### DIFF
--- a/vnpy/trader/gateway/bitmexGateway/bitmexGateway.py
+++ b/vnpy/trader/gateway/bitmexGateway/bitmexGateway.py
@@ -6,6 +6,7 @@
 
 from __future__ import print_function
 
+import logging
 import os
 import json
 import hashlib
@@ -573,8 +574,9 @@ class BitmexWebsocketApi(WebsocketClient):
         trade.tradeID = tradeID
         trade.vtTradeID = '.'.join([trade.gatewayName, trade.tradeID])
         
-        if 'side' not in d:
-            print('no side : \n', d)
+        # bug check:
+        if d['side'] not in directionMapReverse:
+            logging.debug('trade wthout side : %s', d)
             return
         
         trade.direction = directionMapReverse[d['side']]


### PR DESCRIPTION
[Fix] 修复了当bitmexgateway.socketapi响应onTrade时，遇到side字段为''导致异常的情况。

下面是一个side字段为空的例子：
{
 'execID': '***', 'execType': 'Funding',
 'ordStatus': 'Filled', 'lastLiquidityInd': '', 'exDestination': 'XBME',
 'text': 'Funding',
 'lastQty': 508, 'timeInForce': 'AtTheClose', 'currency': 'USD', 'pegPriceType': '',
 'simpleLeavesQty': None, 'transactTime': '***', 'ordRejReason': '',
 'underlyingLastPx': None, 'execCost': 8051292, 'clOrdID': '', 'settlCurrency': 'XBt',
 'cumQty': 508, 'displayQty': None, 'lastPx': 6309.35, 'homeNotional': -0.08051292,
 'commission': -0.0001, 'avgPx': 6309.35, 'lastMkt': 'XBME', 'price': 6309.35,
 'trdMatchID': '***', 'simpleOrderQty': None,
 'contingencyType': '', 'triggered': '', 'timestamp': '***',
 'symbol': 'XBTUSD', 'foreignNotional': 508, 'pegOffsetValue': None, 'execInst': '',
 'simpleCumQty': None, 'execComm': -805, 'orderID': '***',
 'multiLegReportingType': 'SingleSecurity', 'account': ***, 'stopPx': None,
 'leavesQty': 0, 'tradePublishIndicator': '', 'orderQty': 508, 'workingIndicator': False,
 'ordType': 'Limit', 'clOrdLinkID': '',
 'side': ''
}