### PR TITLE
修改打开日志文件模式为append

### DIFF
--- a/vnpy/trader/vtEngine.py
+++ b/vnpy/trader/vtEngine.py
@@ -700,7 +700,7 @@ class LogEngine(object):
             if not filename:
                 filename = 'vt_' + datetime.now().strftime('%Y%m%d') + '.log'
             filepath = getTempPath(filename)
-            self.fileHandler = logging.FileHandler(filepath, mode='w', encoding='utf-8')
+            self.fileHandler = logging.FileHandler(filepath, mode='a', encoding='utf-8')
             self.fileHandler.setLevel(self.level)
             self.fileHandler.setFormatter(self.formatter)
             self.logger.addHandler(self.fileHandler)


### PR DESCRIPTION
修改打开日志文件模式为append，否则每次重启进程都会导致之前的日志被清空。