### PR TITLE
多帐号支持 add_multi_gateway

### DIFF
--- a/examples/CryptoTrader/OKEX1_connect.json
+++ b/examples/CryptoTrader/OKEX1_connect.json
@@ -1,0 +1,6 @@
+{
+    "apiKey": "",
+    "secretKey": "",
+    "trace": false,
+    "symbols": ["eth_btc", "btc_usdt", "eth_usdt"]
+}

--- a/examples/CryptoTrader/OKEX2_connect.json
+++ b/examples/CryptoTrader/OKEX2_connect.json
@@ -1,0 +1,6 @@
+{
+    "apiKey": "",
+    "secretKey": "",
+    "trace": false,
+    "symbols": ["eth_btc", "btc_usdt", "eth_usdt"]
+}

--- a/examples/CryptoTrader/run.py
+++ b/examples/CryptoTrader/run.py
@@ -21,6 +21,8 @@ from vnpy.trader.gateway import (huobiGateway, okexGateway, okexfGateway,
                                  bigoneGateway, lbankGateway,
                                  coinbaseGateway, ccxtGateway)
 
+from vnpy.trader.gateway.okexGateway import OkexGateway
+
 # 加载上层应用
 from vnpy.trader.app import (algoTrading)
 
@@ -51,7 +53,13 @@ def main():
     me.addGateway(okexGateway)
     me.addGateway(binanceGateway)
     me.addGateway(bitfinexGateway)
-    
+
+    # 同交易所多帐号
+    okex1 = OkexGateway(gatewayName='OKEX1')
+    okex2 = OkexGateway(gatewayName='OKEX2')
+    me.addMultiGateway(okex1)
+    me.addMultiGateway(okex2)
+
     # 添加上层应用
     me.addApp(algoTrading)
     

--- a/vnpy/trader/gateway/okexGateway/okexGateway.py
+++ b/vnpy/trader/gateway/okexGateway/okexGateway.py
@@ -21,6 +21,7 @@ from time import sleep
 from vnpy.api.okex import OkexSpotApi, OKEX_SPOT_HOST
 from vnpy.trader.vtGateway import *
 from vnpy.trader.vtFunction import getJsonPath
+from vnpy.trader import vtConstant
 
 # 价格类型映射
 # 买卖类型： 限价单（buy/sell） 市价单（buy_market/sell_market）
@@ -45,13 +46,15 @@ class OkexGateway(VtGateway):
     """OKEX交易接口"""
     
     #----------------------------------------------------------------------
-    def __init__(self, eventEngine, gatewayName='OKEX'):
+    def __init__(self, eventEngine=None, gatewayName='OKEX'):
         """Constructor"""
         super(OkexGateway, self).__init__(eventEngine, gatewayName)
-        
+        self.gatewayType = vtConstant.GATEWAYTYPE_BTC
+        self.gatewayQryEnabled = True
+        self.gatewayDisplayName = gatewayName
+
         self.spotApi = SpotApi(self)     
-        # self.api_contract = Api_contract(self)
-        
+
         self.leverage = 0
         self.connected = False
         
@@ -232,7 +235,7 @@ class SpotApi(OkexSpotApi):
             contract.gatewayName = self.gatewayName
             contract.symbol = symbol
             contract.exchange = EXCHANGE_OKEX
-            contract.vtSymbol = '.'.join([contract.symbol, contract.exchange])
+            contract.vtSymbol = '.'.join([contract.symbol, contract.gatewayName])
             contract.name = symbol
             contract.size = 0.00001
             contract.priceTick = 0.00001
@@ -281,9 +284,9 @@ class SpotApi(OkexSpotApi):
             tick = VtTickData()
             tick.symbol = symbol
             tick.exchange = EXCHANGE_OKEX
-            tick.vtSymbol = '.'.join([tick.symbol, tick.exchange])
             tick.gatewayName = self.gatewayName
-            
+            tick.vtSymbol = '.'.join([tick.symbol, tick.gatewayName])
+
             self.tickDict[symbol] = tick
         else:
             tick = self.tickDict[symbol]
@@ -309,8 +312,8 @@ class SpotApi(OkexSpotApi):
             tick = VtTickData()
             tick.symbol = symbol
             tick.exchange = EXCHANGE_OKEX
-            tick.vtSymbol = '.'.join([tick.symbol, tick.exchange])
             tick.gatewayName = self.gatewayName
+            tick.vtSymbol = '.'.join([tick.symbol, tick.gatewayName])
 
             self.tickDict[symbol] = tick
         else:
@@ -431,7 +434,7 @@ class SpotApi(OkexSpotApi):
                 
                 order.symbol = d['symbol']
                 order.exchange = EXCHANGE_OKEX
-                order.vtSymbol = '.'.join([order.symbol, order.exchange])
+                order.vtSymbol = '.'.join([order.symbol, order.gatewayName])
     
                 order.orderID = localNo
                 order.vtOrderID = '.'.join([self.gatewayName, order.orderID])
@@ -477,7 +480,7 @@ class SpotApi(OkexSpotApi):
             order.gatewayName = self.gatewayName
             order.symbol = rawData['symbol']
             order.exchange = EXCHANGE_OKEX
-            order.vtSymbol = '.'.join([order.symbol, order.exchange])
+            order.vtSymbol = '.'.join([order.symbol, order.gatewayName])
             order.orderID = localNo
             order.vtOrderID = '.'.join([self.gatewayName, localNo])
             order.direction, priceType = priceTypeMap[rawData['tradeType']]

--- a/vnpy/trader/vtEngine.py
+++ b/vnpy/trader/vtEngine.py
@@ -78,6 +78,27 @@ class MainEngine(object):
         self.gatewayDetailList.append(d)
         
     #----------------------------------------------------------------------
+    def addMultiGateway(self, gatewayModule):
+        """添加底层接口"""
+        gatewayName = gatewayModule.gatewayName
+        gatewayModule.eventEngine = self.eventEngine
+
+        # 创建接口实例
+        self.gatewayDict[gatewayName] = gatewayModule
+
+        # 设置接口轮询
+        if gatewayModule.gatewayQryEnabled:
+            self.gatewayDict[gatewayName].setQryEnabled(gatewayModule.gatewayQryEnabled)
+
+        # 保存接口详细信息
+        d = {
+            'gatewayName': gatewayModule.gatewayName,
+            'gatewayDisplayName': gatewayModule.gatewayDisplayName,
+            'gatewayType': gatewayModule.gatewayType
+        }
+        self.gatewayDetailList.append(d)
+
+    # ----------------------------------------------------------------------
     def addApp(self, appModule):
         """添加上层应用"""
         appName = appModule.appName


### PR DESCRIPTION
建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 在不影响原功能的情况下, 多帐号交易功能, 一个交易所实例接入多帐号
2. 使用方法, 修改run.py
3. 交易所gateway的vtSymbol bug,这个bug会在一个交易所接入多帐号时影响下单功能、行情系统的显示。原来很多使用symbol+exchange现改为symbol+gatewayName。我只修改了okex的，其它的gateway应该都有这个问题

## 相关的Issue号（如有）

Close #
Open #244

## 使用方法, 修改run.py

导入gateway
from vnpy.trader.gateway.okexGateway import OkexGateway

多帐号设置, gatewayName对应创建的配置文件，比如gatewayName是OKEX1，对应OKEX1_connect.json
okex1 = OkexGateway(gatewayName='OKEX1')
okex2 = OkexGateway(gatewayName='OKEX2')
me.addMultiGateway(okex1)
me.addMultiGateway(okex2)