### PR TITLE
[Fix] 修正一个UI错误：修复了最大化app之后关闭再打开会显示一大片空白的问题

### DIFF
--- a/vnpy/trader/uiMainWindow.py
+++ b/vnpy/trader/uiMainWindow.py
@@ -206,13 +206,15 @@ class MainWindow(QtWidgets.QMainWindow):
         :return 返回app的窗口
         """
         appName = appDetail['appName']
-        try:
-            self.widgetDict[appName].show()
-        except KeyError:
-            appEngine = self.mainEngine.getApp(appName)
-            self.widgetDict[appName] = appDetail['appWidget'](appEngine, self.eventEngine)
-            self.widgetDict[appName].show()
-        return self.widgetDict[appName]
+        if appName not in self.widgetDict:
+            self.widgetDict[appName] = appDetail['appWidget'](self.mainEngine.getApp(appName),
+                                                              self.eventEngine)
+        app = self.widgetDict[appName]  # type: QtWidgets.QWidget
+        app.show()
+        app.resize(app.size())  # 修正最大化后的空白
+        app.raise_()            # 移到前台
+        app.activateWindow()    # 移到前台并获取焦点
+        return app
 
     #----------------------------------------------------------------------
     def createOpenAppFunction(self, appDetail):


### PR DESCRIPTION
[Fix] 修正一个UI错误：修复了最大化app之后关闭再打开会显示一大片空白的问题
[Add] UI功能性增强：点击某个app之后，该app一定会被移到前台。
[Mod] 判断一个app是否打开：去掉了try_catch，改用if



显示一大片空白的根本原因还不知道，但是使用resize(size)能保证解决这个问题。
移动到前台时同时调用了QWidget.raise()和QWidget.activateWindow()。从文档说明上看，activeWindow应该包含了raise()。为了防止activeWindow仅仅是获取焦点，所以一起调用了。即便重复，多调用一次问题也不大。