### PR TITLE
[Mod] constant can be both UPPER_CASE or CamelCase

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -153,11 +153,11 @@ class-naming-style=PascalCase
 #class-rgx=
 
 # Naming style matching correct constant names.
-const-naming-style=UPPER_CASE
+#const-naming-style=UPPER_CASE
 
 # Regular expression matching correct constant names. Overrides const-naming-
 # style.
-#const-rgx=
+const-rgx=(([A-Z_][A-Za-z0-9_]*)|(__.*__))$
 
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.


### PR DESCRIPTION
[Mod] constant can be both UPPER_CASE or CamelCase
UPPER_CASE for normal constant, CamelCase for Type aliases.