### PR TITLE
xquote_api_struct中的结构体，未加typedef时生成py结构错误

### DIFF
--- a/vnpy/api/xtp/pyscript/generate_struct_quote.py
+++ b/vnpy/api/xtp/pyscript/generate_struct_quote.py
@@ -54,7 +54,10 @@ def main():
         # 结构体申明
         elif 'struct ' in line:
             content = line.split(' ')
-            name = content[2].replace('\n','')
+            if 'typedef' in line:
+                name = content[2].replace('\n','')
+            else:
+                name = content[1].replace('\n', '')
             name = name.replace('\r', '')
             py_line = '%s = {}\n' % name
 


### PR DESCRIPTION
建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 
2. 
3.

## 相关的Issue号（如有）

Close #