### PR TITLE
stopAlgo 缺少short控制，导致一启动算法就立即发出卖出委托

### DIFF
--- a/vnpy/trader/app/algoTrading/algo/stopAlgo.py
+++ b/vnpy/trader/app/algoTrading/algo/stopAlgo.py
@@ -62,14 +62,17 @@ class StopAlgo(AlgoTemplate):
                 price = min(price, tick.upperLimit)
                 
             func = self.buy
-        else:
+        elif (self.direction == DIRECTION_SHORT and 
+            tick.lastPrice <= self.stopPrice):
             price = self.stopPrice - self.priceAdd
             
             if tick.lowerLimit:
                 price = max(price, tick.lowerLimit)
                 
             func = self.sell
-            
+        else:
+            return
+          
         self.vtOrderID = func(self.vtSymbol, price, self.totalVolume, offset=self.offset)
         
         msg = u'停止单已触发，代码：%s，方向：%s, 价格：%s，数量：%s，开平：%s' %(self.vtSymbol,


### PR DESCRIPTION
stopAlgo 缺少short控制，导致一启动算法就立即发出卖出委托，增加short控制，已修复。

建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 
2. 
3.

## 相关的Issue号（如有）

Close #