### PR TITLE
修改策略回测引擎calculateBacktestingResult，无交易返回空字典的bug

### DIFF
--- a/vnpy/trader/app/ctaStrategy/ctaBacktesting.py
+++ b/vnpy/trader/app/ctaStrategy/ctaBacktesting.py
@@ -617,7 +617,28 @@ class BacktestingEngine(object):
         # 检查成交记录
         if not self.tradeDict:
             self.output(u'成交记录为空，无法计算回测结果')
-            return {}
+            noResult = {}
+            noResult['capital'] = 0
+            noResult['maxCapital'] = 0
+            noResult['drawdown'] = 0
+            noResult['totalResult'] = 0
+            noResult['totalTurnover'] = 0
+            noResult['totalCommission'] = 0
+            noResult['totalSlippage'] = 0
+            noResult['timeList'] = 0
+            noResult['pnlList'] = 0
+            noResult['capitalList'] = 0
+            noResult['drawdownList'] = 0
+            noResult['winningRate'] = 0
+            noResult['averageWinning'] = 0
+            noResult['averageLosing'] = 0
+            noResult['profitLossRatio'] = 0
+            noResult['posList'] = 0
+            noResult['tradeTimeList'] = 0
+            noResult['resultList'] = 0
+            noResult['maxDrawdown'] = 0
+            return noResult            
+            
         
         # 首先基于回测后的成交记录，计算每笔交易的盈亏
         resultList = []             # 交易结果列表
@@ -760,12 +781,14 @@ class BacktestingEngine(object):
         winningResult = 0       # 盈利次数
         losingResult = 0        # 亏损次数		
         totalWinning = 0        # 总盈利金额		
-        totalLosing = 0         # 总亏损金额        
+        totalLosing = 0         # 总亏损金额
+        maxDrawdown = 0         # 最大回撤              
         
         for result in resultList:
             capital += result.pnl
             maxCapital = max(capital, maxCapital)
             drawdown = capital - maxCapital
+            maxDrawdown = min(drawdown, maxDrawdown)
             
             pnlList.append(result.pnl)
             timeList.append(result.exitDt)      # 交易的时间戳使用平仓时间
@@ -818,7 +841,7 @@ class BacktestingEngine(object):
         d['posList'] = posList
         d['tradeTimeList'] = tradeTimeList
         d['resultList'] = resultList
-        
+        d['maxDrawdown']  = maxDrawdown    
         return d
         
     #----------------------------------------------------------------------
@@ -833,7 +856,7 @@ class BacktestingEngine(object):
         
         self.output(u'总交易次数：\t%s' % formatNumber(d['totalResult']))        
         self.output(u'总盈亏：\t%s' % formatNumber(d['capital']))
-        self.output(u'最大回撤: \t%s' % formatNumber(min(d['drawdownList'])))                
+        self.output(u'最大回撤: \t%s' % formatNumber(d['maxDrawdown']))                
         
         self.output(u'平均每笔盈利：\t%s' %formatNumber(d['capital']/d['totalResult']))
         self.output(u'平均每笔滑点：\t%s' %formatNumber(d['totalSlippage']/d['totalResult']))


### PR DESCRIPTION
两个修改：
若无成交，calculateBacktestingResult返回的是0，而不是空的字典

calculateBacktestingResult直接获取maxDrawdown的值

