### PR TITLE
[Fix] 稍稍改一下ctp到python的转换

### DIFF
--- a/vnpy/api/ctp/generator/generate_api_functions.py
+++ b/vnpy/api/ctp/generator/generate_api_functions.py
@@ -122,9 +122,9 @@ class ApiGenerator:
                     elif type_ == "bool":
                         l.append("bool last")
                     elif type_ == "CThostFtdcRspInfoField":
-                        l.append("dict error")
+                        l.append("const dict &error")
                     else:
-                        l.append("dict data")
+                        l.append("const dict &data")
                 
                 args_str = ", ".join(l)
                 line = f"virtual void {name}({args_str}) {{}};\n\n"
@@ -137,7 +137,7 @@ class ApiGenerator:
         with open(filename, "w") as f:
             for name in self.functions.keys():
                 name = name.replace("Req", "req")
-                line = f"int {name}(dict req, int reqid);\n\n"
+                line = f"int {name}(const dict &req, int reqid);\n\n"
                 f.write(line)      
     
     def generate_source_task(self):
@@ -254,7 +254,7 @@ class ApiGenerator:
                 req_name = name.replace("Req", "req")
                 type_ = list(d.values())[0]
                 
-                f.write(f"int {self.class_name}::{req_name}(dict req, int reqid)\n")
+                f.write(f"int {self.class_name}::{req_name}(const dict &req, int reqid)\n")
                 f.write("{\n")
                 f.write(f"\t{type_} myreq = {type_}();\n")
                 f.write("\tmemset(&myreq, 0, sizeof(myreq));\n")
@@ -289,10 +289,10 @@ class ApiGenerator:
                         args.append("bool last")
                         bind_args.append("last")
                     elif type_ == "CThostFtdcRspInfoField":
-                        args.append("dict error")
+                        args.append("const dict &error")
                         bind_args.append("error")
                     else:
-                        args.append("dict data")
+                        args.append("const dict &data")
                         bind_args.append("data")
                 
                 args_str = ", ".join(args)
@@ -302,7 +302,7 @@ class ApiGenerator:
                 f.write("{\n")
                 f.write("\ttry\n")
                 f.write("\t{\n")
-                f.write(f"\t\tPYBIND11_OVERLOAD_PURE({bind_args_str});\n")
+                f.write(f"\t\tPYBIND11_OVERLOAD({bind_args_str});\n")
                 f.write("\t}\n")
                 f.write("\tcatch (const error_already_set &e)\n")
                 f.write("\t{\n")

--- a/vnpy/api/ctp/vnctp/vnctp.h
+++ b/vnpy/api/ctp/vnctp/vnctp.h
@@ -18,125 +18,95 @@ using namespace pybind11;
 //任务结构体
 struct Task
 {
-	int task_name;		//回调函数名称对应的常量
-	void *task_data;	//数据指针
-	void *task_error;	//错误指针
-	int task_id;		//请求id
-	bool task_last;		//是否为最后返回
+    int task_name;		//回调函数名称对应的常量
+    void *task_data;	//数据指针
+    void *task_error;	//错误指针
+    int task_id;		//请求id
+    bool task_last;		//是否为最后返回
 };
 
 
 class TaskQueue
 {
 private:
-	queue<Task> queue_;						//标准库队列
-	mutex mutex_;							//互斥锁
-	condition_variable cond_;				//条件变量
+    queue<Task> queue_;						//标准库队列
+    mutex mutex_;							//互斥锁
+    condition_variable cond_;				//条件变量
 
 public:
 
-	//存入新的任务
-	void push(const Task &task)
-	{
-		unique_lock<mutex > mlock(mutex_);
-		queue_.push(task);					//向队列中存入数据
-		mlock.unlock();						//释放锁
-		cond_.notify_one();					//通知正在阻塞等待的线程
-	}
+    //存入新的任务
+    void push(const Task &task)
+    {
+        unique_lock<mutex > mlock(mutex_);
+        queue_.push(task);					//向队列中存入数据
+        mlock.unlock();						//释放锁
+        cond_.notify_one();					//通知正在阻塞等待的线程
+    }
 
-	//取出老的任务
-	Task pop()
-	{
-		unique_lock<mutex> mlock(mutex_);
-		while (queue_.empty())				//当队列为空时
-		{
-			cond_.wait(mlock);				//等待条件变量通知
-		}
-		Task task = queue_.front();			//获取队列中的最后一个任务
-		queue_.pop();						//删除该任务
-		return task;						//返回该任务
-	}
+    //取出老的任务
+    Task pop()
+    {
+        unique_lock<mutex> mlock(mutex_);
+        while (queue_.empty())				//当队列为空时
+        {
+            cond_.wait(mlock);				//等待条件变量通知
+        }
+        Task task = queue_.front();			//获取队列中的最后一个任务
+        queue_.pop();						//删除该任务
+        return task;						//返回该任务
+    }
 
 };
 
 
 //从字典中获取某个建值对应的整数，并赋值到请求结构体对象的值上
-void getInt(dict d, const char *key, int *value)
+void getInt(const dict &d, const char *key, int *value)
 {
-	if (d.contains(key))		//检查字典中是否存在该键值
-	{
-		object o = d[key];		//获取该键值
-		try
-		{
-			*value = o.cast<int>();
-		}
-		catch (const error_already_set &e)
-		{
-			cout << e.what() << endl;
-		}
-	}
+    if (d.contains(key))		//检查字典中是否存在该键值
+    {
+        object o = d[key];		//获取该键值
+        *value = o.cast<int>();
+    }
 };
 
 
 //从字典中获取某个建值对应的浮点数，并赋值到请求结构体对象的值上
-void getDouble(dict d, const char *key, double *value)
+void getDouble(const dict &d, const char *key, double *value)
 {
-	if (d.contains(key))
-	{
-		object o = d[key];
-		try
-		{
-			*value = o.cast<double>();
-		}
-		catch (const error_already_set &e)
-		{
-			cout << e.what() << endl;
-		}
-	}
+    if (d.contains(key))
+    {
+        object o = d[key];
+        *value = o.cast<double>();
+    }
 };
 
 
 //从字典中获取某个建值对应的字符，并赋值到请求结构体对象的值上
-void getChar(dict d, const char *key, char *value)
+void getChar(const dict &d, const char *key, char *value)
 {
-	if (d.contains(key))
-	{
-		object o = d[key];
-
-		try
-		{
-			*value = o.cast<char>();
-		}
-		catch (const error_already_set &e)
-		{
-			cout << e.what() << endl;
-		}
-	}
+    if (d.contains(key))
+    {
+        object o = d[key];
+        *value = o.cast<char>();
+    }
 };
 
 
-//从字典中获取某个建值对应的字符串，并赋值到请求结构体对象的值上
-void getString(dict d, const char *key, char *value)
-{
-	if (d.contains(key))
-	{
-		object o = d[key];
-		try
-		{
-			string s = o.cast<string>();
-			const char *buf = s.c_str();
+template <size_t size>
+using string_literal = char[size];
 
-#ifdef _MSC_VER //WIN32
-			strcpy_s(value, strlen(buf) + 1, buf);
-#elif __GNUC__
-			strncpy(value, buffer, strlen(buffer) + 1);
-#endif
-		}
-		catch (const error_already_set &e)
-		{
-			cout << e.what() << endl;
-		}
-	}
+//从字典中获取某个建值对应的字符串，并赋值到请求结构体对象的值上
+template <size_t size>
+void getString(const pybind11::dict &d, const char *key, string_literal<size> &value)
+{
+    if (d.contains(key))
+    {
+        object o = d[key];
+        std::string s = o.cast<std::string>();
+        const char *buf = s.c_str();
+        strcpy(value, buf);
+    }
 };
 
 //将GBK编码的字符串转换为UTF8

--- a/vnpy/api/ctp/vnctp/vnctp.h
+++ b/vnpy/api/ctp/vnctp/vnctp.h
@@ -140,29 +140,28 @@ void getString(dict d, const char *key, char *value)
 };
 
 //将GBK编码的字符串转换为UTF8
-string toUtf(string strGb2312)
+inline std::string toUtf(const std::string &gb2312)
 {
-	std::vector<wchar_t> buff(strGb2312.size());
 #ifdef _MSC_VER
-	std::locale loc("zh-CN");
+    const static std::locale loc("zh-CN");
 #else
-	std::locale loc("zh_CN.GB18030");
+    const static std::locale loc("zh_CN.GB18030");
 #endif
-	wchar_t* pwszNext = nullptr;
-	const char* pszNext = nullptr;
-	mbstate_t state = {};
-	int res = std::use_facet<std::codecvt<wchar_t, char, mbstate_t> >
-		(loc).in(state,
-			strGb2312.data(), strGb2312.data() + strGb2312.size(), pszNext,
-			buff.data(), buff.data() + buff.size(), pwszNext);
 
-	if (std::codecvt_base::ok == res)
-	{
-		std::wstring_convert<std::codecvt_utf8<wchar_t>> cutf8;
-		return cutf8.to_bytes(std::wstring(buff.data(), pwszNext));
-	}
+    std::vector<wchar_t> wstr(gb2312.size());
+    wchar_t* wstrEnd = nullptr;
+    const char* gbEnd = nullptr;
+    std::mbstate_t state = {};
+    int res = std::use_facet<std::codecvt<wchar_t, char, mbstate_t> >
+        (loc).in(state,
+            gb2312.data(), gb2312.data() + gb2312.size(), gbEnd,
+            wstr.data(), wstr.data() + wstr.size(), wstrEnd);
 
-	return "";
+    if (std::codecvt_base::ok == res)
+    {
+        std::wstring_convert<std::codecvt_utf8<wchar_t>> cutf8;
+        return cutf8.to_bytes(std::wstring(wstr.data(), wstrEnd));
+    }
+
+    return std::string();
 }
-
-

--- a/vnpy/api/ctp/vnctp/vnctpmd/vnctpmd.cpp
+++ b/vnpy/api/ctp/vnctp/vnctpmd/vnctpmd.cpp
@@ -613,7 +613,7 @@ int MdApi::unSubscribeForQuoteRsp(string instrumentID)
 	return i;
 };
 
-int MdApi::reqUserLogin(dict req, int reqid)
+int MdApi::reqUserLogin(const dict &req, int reqid)
 {
 	CThostFtdcReqUserLoginField myreq = CThostFtdcReqUserLoginField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -632,7 +632,7 @@ int MdApi::reqUserLogin(dict req, int reqid)
 	return i;
 };
 
-int MdApi::reqUserLogout(dict req, int reqid)
+int MdApi::reqUserLogout(const dict &req, int reqid)
 {
 	CThostFtdcUserLogoutField myreq = CThostFtdcUserLogoutField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -656,7 +656,7 @@ public:
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, MdApi, onFrontConnected);
+			PYBIND11_OVERLOAD(void, MdApi, onFrontConnected);
 		}
 		catch (const error_already_set &e)
 		{
@@ -668,7 +668,7 @@ public:
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, MdApi, onFrontDisconnected, reqid);
+			PYBIND11_OVERLOAD(void, MdApi, onFrontDisconnected, reqid);
 		}
 		catch (const error_already_set &e)
 		{
@@ -680,7 +680,7 @@ public:
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, MdApi, onHeartBeatWarning, reqid);
+			PYBIND11_OVERLOAD(void, MdApi, onHeartBeatWarning, reqid);
 		}
 		catch (const error_already_set &e)
 		{
@@ -688,11 +688,11 @@ public:
 		}
 	};
 
-	void onRspUserLogin(dict data, dict error, int reqid, bool last) override
+	void onRspUserLogin(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, MdApi, onRspUserLogin, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, MdApi, onRspUserLogin, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -700,11 +700,11 @@ public:
 		}
 	};
 
-	void onRspUserLogout(dict data, dict error, int reqid, bool last) override
+	void onRspUserLogout(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, MdApi, onRspUserLogout, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, MdApi, onRspUserLogout, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -712,11 +712,11 @@ public:
 		}
 	};
 
-	void onRspError(dict error, int reqid, bool last) override
+	void onRspError(const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, MdApi, onRspError, error, reqid, last);
+			PYBIND11_OVERLOAD(void, MdApi, onRspError, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -724,11 +724,11 @@ public:
 		}
 	};
 
-	void onRspSubMarketData(dict data, dict error, int reqid, bool last) override
+	void onRspSubMarketData(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, MdApi, onRspSubMarketData, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, MdApi, onRspSubMarketData, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -736,11 +736,11 @@ public:
 		}
 	};
 
-	void onRspUnSubMarketData(dict data, dict error, int reqid, bool last) override
+	void onRspUnSubMarketData(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, MdApi, onRspUnSubMarketData, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, MdApi, onRspUnSubMarketData, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -748,11 +748,11 @@ public:
 		}
 	};
 
-	void onRspSubForQuoteRsp(dict data, dict error, int reqid, bool last) override
+	void onRspSubForQuoteRsp(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, MdApi, onRspSubForQuoteRsp, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, MdApi, onRspSubForQuoteRsp, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -760,11 +760,11 @@ public:
 		}
 	};
 
-	void onRspUnSubForQuoteRsp(dict data, dict error, int reqid, bool last) override
+	void onRspUnSubForQuoteRsp(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, MdApi, onRspUnSubForQuoteRsp, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, MdApi, onRspUnSubForQuoteRsp, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -772,11 +772,11 @@ public:
 		}
 	};
 
-	void onRtnDepthMarketData(dict data) override
+	void onRtnDepthMarketData(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, MdApi, onRtnDepthMarketData, data);
+			PYBIND11_OVERLOAD(void, MdApi, onRtnDepthMarketData, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -784,11 +784,11 @@ public:
 		}
 	};
 
-	void onRtnForQuoteRsp(dict data) override
+	void onRtnForQuoteRsp(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, MdApi, onRtnForQuoteRsp, data);
+			PYBIND11_OVERLOAD(void, MdApi, onRtnForQuoteRsp, data);
 		}
 		catch (const error_already_set &e)
 		{

--- a/vnpy/api/ctp/vnctp/vnctpmd/vnctpmd.h
+++ b/vnpy/api/ctp/vnctp/vnctpmd/vnctpmd.h
@@ -145,23 +145,23 @@ public:
 
 	virtual void onHeartBeatWarning(int reqid) {};
 
-	virtual void onRspUserLogin(dict data, dict error, int reqid, bool last) {};
+	virtual void onRspUserLogin(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspUserLogout(dict data, dict error, int reqid, bool last) {};
+	virtual void onRspUserLogout(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspError(dict error, int reqid, bool last) {};
+	virtual void onRspError(const dict &error, int reqid, bool last) {};
 
-	virtual void onRspSubMarketData(dict data, dict error, int reqid, bool last) {};
+	virtual void onRspSubMarketData(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspUnSubMarketData(dict data, dict error, int reqid, bool last) {};
+	virtual void onRspUnSubMarketData(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspSubForQuoteRsp(dict data, dict error, int reqid, bool last) {};
+	virtual void onRspSubForQuoteRsp(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspUnSubForQuoteRsp(dict data, dict error, int reqid, bool last) {};
+	virtual void onRspUnSubForQuoteRsp(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRtnDepthMarketData(dict data) {};
+	virtual void onRtnDepthMarketData(const dict &data) {};
 
-	virtual void onRtnForQuoteRsp(dict data) {};
+	virtual void onRtnForQuoteRsp(const dict &data) {};
 
 	//-------------------------------------------------------------------------------------
 	//req:主动函数的请求字典
@@ -189,7 +189,7 @@ public:
 
 	int unSubscribeForQuoteRsp(string instrumentID);
 
-	int reqUserLogin(dict req, int reqid);
+	int reqUserLogin(const dict &req, int reqid);
 
-	int reqUserLogout(dict req, int reqid);
+	int reqUserLogout(const dict &req, int reqid);
 };

--- a/vnpy/api/ctp/vnctp/vnctptd/vnctptd.cpp
+++ b/vnpy/api/ctp/vnctp/vnctptd/vnctptd.cpp
@@ -2953,4933 +2953,4934 @@ void TdApi::processTask()
 
 void TdApi::processFrontConnected(Task *task)
 {
-	gil_scoped_acquire acquire;
-	this->onFrontConnected();
+    gil_scoped_acquire acquire;
+    this->onFrontConnected();
 };
 
 void TdApi::processFrontDisconnected(Task *task)
 {
-	gil_scoped_acquire acquire;
-	this->onFrontDisconnected(task->task_id);
+    gil_scoped_acquire acquire;
+    this->onFrontDisconnected(task->task_id);
 };
 
 void TdApi::processHeartBeatWarning(Task *task)
 {
-	gil_scoped_acquire acquire;
-	this->onHeartBeatWarning(task->task_id);
+    gil_scoped_acquire acquire;
+    this->onHeartBeatWarning(task->task_id);
 };
 
 void TdApi::processRspAuthenticate(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcRspAuthenticateField *task_data = (CThostFtdcRspAuthenticateField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspAuthenticate(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcRspAuthenticateField *task_data = (CThostFtdcRspAuthenticateField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspAuthenticate(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspUserLogin(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcRspUserLoginField *task_data = (CThostFtdcRspUserLoginField*)task->task_data;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["LoginTime"] = toUtf(task_data->LoginTime);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["SystemName"] = toUtf(task_data->SystemName);
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["MaxOrderRef"] = toUtf(task_data->MaxOrderRef);
-		data["SHFETime"] = toUtf(task_data->SHFETime);
-		data["DCETime"] = toUtf(task_data->DCETime);
-		data["CZCETime"] = toUtf(task_data->CZCETime);
-		data["FFEXTime"] = toUtf(task_data->FFEXTime);
-		data["INETime"] = toUtf(task_data->INETime);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspUserLogin(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcRspUserLoginField *task_data = (CThostFtdcRspUserLoginField*)task->task_data;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["LoginTime"] = toUtf(task_data->LoginTime);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["SystemName"] = toUtf(task_data->SystemName);
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["MaxOrderRef"] = toUtf(task_data->MaxOrderRef);
+        data["SHFETime"] = toUtf(task_data->SHFETime);
+        data["DCETime"] = toUtf(task_data->DCETime);
+        data["CZCETime"] = toUtf(task_data->CZCETime);
+        data["FFEXTime"] = toUtf(task_data->FFEXTime);
+        data["INETime"] = toUtf(task_data->INETime);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspUserLogin(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspUserLogout(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcUserLogoutField *task_data = (CThostFtdcUserLogoutField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["UserID"] = toUtf(task_data->UserID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspUserLogout(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcUserLogoutField *task_data = (CThostFtdcUserLogoutField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["UserID"] = toUtf(task_data->UserID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspUserLogout(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspUserPasswordUpdate(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcUserPasswordUpdateField *task_data = (CThostFtdcUserPasswordUpdateField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["OldPassword"] = toUtf(task_data->OldPassword);
-		data["NewPassword"] = toUtf(task_data->NewPassword);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspUserPasswordUpdate(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcUserPasswordUpdateField *task_data = (CThostFtdcUserPasswordUpdateField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["OldPassword"] = toUtf(task_data->OldPassword);
+        data["NewPassword"] = toUtf(task_data->NewPassword);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspUserPasswordUpdate(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspTradingAccountPasswordUpdate(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcTradingAccountPasswordUpdateField *task_data = (CThostFtdcTradingAccountPasswordUpdateField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["OldPassword"] = toUtf(task_data->OldPassword);
-		data["NewPassword"] = toUtf(task_data->NewPassword);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspTradingAccountPasswordUpdate(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcTradingAccountPasswordUpdateField *task_data = (CThostFtdcTradingAccountPasswordUpdateField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["OldPassword"] = toUtf(task_data->OldPassword);
+        data["NewPassword"] = toUtf(task_data->NewPassword);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspTradingAccountPasswordUpdate(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspOrderInsert(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInputOrderField *task_data = (CThostFtdcInputOrderField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["OrderRef"] = toUtf(task_data->OrderRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["OrderPriceType"] = task_data->OrderPriceType;
-		data["Direction"] = task_data->Direction;
-		data["CombOffsetFlag"] = toUtf(task_data->CombOffsetFlag);
-		data["CombHedgeFlag"] = toUtf(task_data->CombHedgeFlag);
-		data["LimitPrice"] = task_data->LimitPrice;
-		data["VolumeTotalOriginal"] = task_data->VolumeTotalOriginal;
-		data["TimeCondition"] = task_data->TimeCondition;
-		data["GTDDate"] = toUtf(task_data->GTDDate);
-		data["VolumeCondition"] = task_data->VolumeCondition;
-		data["MinVolume"] = task_data->MinVolume;
-		data["ContingentCondition"] = task_data->ContingentCondition;
-		data["StopPrice"] = task_data->StopPrice;
-		data["ForceCloseReason"] = task_data->ForceCloseReason;
-		data["IsAutoSuspend"] = task_data->IsAutoSuspend;
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["RequestID"] = task_data->RequestID;
-		data["UserForceClose"] = task_data->UserForceClose;
-		data["IsSwapOrder"] = task_data->IsSwapOrder;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspOrderInsert(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInputOrderField *task_data = (CThostFtdcInputOrderField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["OrderRef"] = toUtf(task_data->OrderRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["OrderPriceType"] = task_data->OrderPriceType;
+        data["Direction"] = task_data->Direction;
+        data["CombOffsetFlag"] = toUtf(task_data->CombOffsetFlag);
+        data["CombHedgeFlag"] = toUtf(task_data->CombHedgeFlag);
+        data["LimitPrice"] = task_data->LimitPrice;
+        data["VolumeTotalOriginal"] = task_data->VolumeTotalOriginal;
+        data["TimeCondition"] = task_data->TimeCondition;
+        data["GTDDate"] = toUtf(task_data->GTDDate);
+        data["VolumeCondition"] = task_data->VolumeCondition;
+        data["MinVolume"] = task_data->MinVolume;
+        data["ContingentCondition"] = task_data->ContingentCondition;
+        data["StopPrice"] = task_data->StopPrice;
+        data["ForceCloseReason"] = task_data->ForceCloseReason;
+        data["IsAutoSuspend"] = task_data->IsAutoSuspend;
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["RequestID"] = task_data->RequestID;
+        data["UserForceClose"] = task_data->UserForceClose;
+        data["IsSwapOrder"] = task_data->IsSwapOrder;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspOrderInsert(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspParkedOrderInsert(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcParkedOrderField *task_data = (CThostFtdcParkedOrderField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["OrderRef"] = toUtf(task_data->OrderRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["OrderPriceType"] = task_data->OrderPriceType;
-		data["Direction"] = task_data->Direction;
-		data["CombOffsetFlag"] = toUtf(task_data->CombOffsetFlag);
-		data["CombHedgeFlag"] = toUtf(task_data->CombHedgeFlag);
-		data["LimitPrice"] = task_data->LimitPrice;
-		data["VolumeTotalOriginal"] = task_data->VolumeTotalOriginal;
-		data["TimeCondition"] = task_data->TimeCondition;
-		data["GTDDate"] = toUtf(task_data->GTDDate);
-		data["VolumeCondition"] = task_data->VolumeCondition;
-		data["MinVolume"] = task_data->MinVolume;
-		data["ContingentCondition"] = task_data->ContingentCondition;
-		data["StopPrice"] = task_data->StopPrice;
-		data["ForceCloseReason"] = task_data->ForceCloseReason;
-		data["IsAutoSuspend"] = task_data->IsAutoSuspend;
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["RequestID"] = task_data->RequestID;
-		data["UserForceClose"] = task_data->UserForceClose;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ParkedOrderID"] = toUtf(task_data->ParkedOrderID);
-		data["UserType"] = task_data->UserType;
-		data["Status"] = task_data->Status;
-		data["ErrorID"] = task_data->ErrorID;
-		data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
-		data["IsSwapOrder"] = task_data->IsSwapOrder;
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspParkedOrderInsert(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcParkedOrderField *task_data = (CThostFtdcParkedOrderField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["OrderRef"] = toUtf(task_data->OrderRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["OrderPriceType"] = task_data->OrderPriceType;
+        data["Direction"] = task_data->Direction;
+        data["CombOffsetFlag"] = toUtf(task_data->CombOffsetFlag);
+        data["CombHedgeFlag"] = toUtf(task_data->CombHedgeFlag);
+        data["LimitPrice"] = task_data->LimitPrice;
+        data["VolumeTotalOriginal"] = task_data->VolumeTotalOriginal;
+        data["TimeCondition"] = task_data->TimeCondition;
+        data["GTDDate"] = toUtf(task_data->GTDDate);
+        data["VolumeCondition"] = task_data->VolumeCondition;
+        data["MinVolume"] = task_data->MinVolume;
+        data["ContingentCondition"] = task_data->ContingentCondition;
+        data["StopPrice"] = task_data->StopPrice;
+        data["ForceCloseReason"] = task_data->ForceCloseReason;
+        data["IsAutoSuspend"] = task_data->IsAutoSuspend;
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["RequestID"] = task_data->RequestID;
+        data["UserForceClose"] = task_data->UserForceClose;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ParkedOrderID"] = toUtf(task_data->ParkedOrderID);
+        data["UserType"] = task_data->UserType;
+        data["Status"] = task_data->Status;
+        data["ErrorID"] = task_data->ErrorID;
+        data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
+        data["IsSwapOrder"] = task_data->IsSwapOrder;
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspParkedOrderInsert(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspParkedOrderAction(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcParkedOrderActionField *task_data = (CThostFtdcParkedOrderActionField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["OrderActionRef"] = task_data->OrderActionRef;
-		data["OrderRef"] = toUtf(task_data->OrderRef);
-		data["RequestID"] = task_data->RequestID;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["OrderSysID"] = toUtf(task_data->OrderSysID);
-		data["ActionFlag"] = task_data->ActionFlag;
-		data["LimitPrice"] = task_data->LimitPrice;
-		data["VolumeChange"] = task_data->VolumeChange;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["ParkedOrderActionID"] = toUtf(task_data->ParkedOrderActionID);
-		data["UserType"] = task_data->UserType;
-		data["Status"] = task_data->Status;
-		data["ErrorID"] = task_data->ErrorID;
-		data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspParkedOrderAction(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcParkedOrderActionField *task_data = (CThostFtdcParkedOrderActionField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["OrderActionRef"] = task_data->OrderActionRef;
+        data["OrderRef"] = toUtf(task_data->OrderRef);
+        data["RequestID"] = task_data->RequestID;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["OrderSysID"] = toUtf(task_data->OrderSysID);
+        data["ActionFlag"] = task_data->ActionFlag;
+        data["LimitPrice"] = task_data->LimitPrice;
+        data["VolumeChange"] = task_data->VolumeChange;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["ParkedOrderActionID"] = toUtf(task_data->ParkedOrderActionID);
+        data["UserType"] = task_data->UserType;
+        data["Status"] = task_data->Status;
+        data["ErrorID"] = task_data->ErrorID;
+        data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspParkedOrderAction(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspOrderAction(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInputOrderActionField *task_data = (CThostFtdcInputOrderActionField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["OrderActionRef"] = task_data->OrderActionRef;
-		data["OrderRef"] = toUtf(task_data->OrderRef);
-		data["RequestID"] = task_data->RequestID;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["OrderSysID"] = toUtf(task_data->OrderSysID);
-		data["ActionFlag"] = task_data->ActionFlag;
-		data["LimitPrice"] = task_data->LimitPrice;
-		data["VolumeChange"] = task_data->VolumeChange;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspOrderAction(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInputOrderActionField *task_data = (CThostFtdcInputOrderActionField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["OrderActionRef"] = task_data->OrderActionRef;
+        data["OrderRef"] = toUtf(task_data->OrderRef);
+        data["RequestID"] = task_data->RequestID;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["OrderSysID"] = toUtf(task_data->OrderSysID);
+        data["ActionFlag"] = task_data->ActionFlag;
+        data["LimitPrice"] = task_data->LimitPrice;
+        data["VolumeChange"] = task_data->VolumeChange;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspOrderAction(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQueryMaxOrderVolume(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcQueryMaxOrderVolumeField *task_data = (CThostFtdcQueryMaxOrderVolumeField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["Direction"] = task_data->Direction;
-		data["OffsetFlag"] = task_data->OffsetFlag;
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["MaxVolume"] = task_data->MaxVolume;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQueryMaxOrderVolume(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcQueryMaxOrderVolumeField *task_data = (CThostFtdcQueryMaxOrderVolumeField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["Direction"] = task_data->Direction;
+        data["OffsetFlag"] = task_data->OffsetFlag;
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["MaxVolume"] = task_data->MaxVolume;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQueryMaxOrderVolume(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspSettlementInfoConfirm(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcSettlementInfoConfirmField *task_data = (CThostFtdcSettlementInfoConfirmField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["ConfirmDate"] = toUtf(task_data->ConfirmDate);
-		data["ConfirmTime"] = toUtf(task_data->ConfirmTime);
-		data["SettlementID"] = task_data->SettlementID;
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspSettlementInfoConfirm(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcSettlementInfoConfirmField *task_data = (CThostFtdcSettlementInfoConfirmField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["ConfirmDate"] = toUtf(task_data->ConfirmDate);
+        data["ConfirmTime"] = toUtf(task_data->ConfirmTime);
+        data["SettlementID"] = task_data->SettlementID;
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspSettlementInfoConfirm(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspRemoveParkedOrder(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcRemoveParkedOrderField *task_data = (CThostFtdcRemoveParkedOrderField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["ParkedOrderID"] = toUtf(task_data->ParkedOrderID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspRemoveParkedOrder(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcRemoveParkedOrderField *task_data = (CThostFtdcRemoveParkedOrderField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["ParkedOrderID"] = toUtf(task_data->ParkedOrderID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspRemoveParkedOrder(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspRemoveParkedOrderAction(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcRemoveParkedOrderActionField *task_data = (CThostFtdcRemoveParkedOrderActionField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["ParkedOrderActionID"] = toUtf(task_data->ParkedOrderActionID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspRemoveParkedOrderAction(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcRemoveParkedOrderActionField *task_data = (CThostFtdcRemoveParkedOrderActionField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["ParkedOrderActionID"] = toUtf(task_data->ParkedOrderActionID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspRemoveParkedOrderAction(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspExecOrderInsert(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInputExecOrderField *task_data = (CThostFtdcInputExecOrderField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["ExecOrderRef"] = toUtf(task_data->ExecOrderRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["Volume"] = task_data->Volume;
-		data["RequestID"] = task_data->RequestID;
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["OffsetFlag"] = task_data->OffsetFlag;
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["ActionType"] = task_data->ActionType;
-		data["PosiDirection"] = task_data->PosiDirection;
-		data["ReservePositionFlag"] = task_data->ReservePositionFlag;
-		data["CloseFlag"] = task_data->CloseFlag;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspExecOrderInsert(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInputExecOrderField *task_data = (CThostFtdcInputExecOrderField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["ExecOrderRef"] = toUtf(task_data->ExecOrderRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["Volume"] = task_data->Volume;
+        data["RequestID"] = task_data->RequestID;
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["OffsetFlag"] = task_data->OffsetFlag;
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["ActionType"] = task_data->ActionType;
+        data["PosiDirection"] = task_data->PosiDirection;
+        data["ReservePositionFlag"] = task_data->ReservePositionFlag;
+        data["CloseFlag"] = task_data->CloseFlag;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspExecOrderInsert(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspExecOrderAction(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInputExecOrderActionField *task_data = (CThostFtdcInputExecOrderActionField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["ExecOrderActionRef"] = task_data->ExecOrderActionRef;
-		data["ExecOrderRef"] = toUtf(task_data->ExecOrderRef);
-		data["RequestID"] = task_data->RequestID;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ExecOrderSysID"] = toUtf(task_data->ExecOrderSysID);
-		data["ActionFlag"] = task_data->ActionFlag;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspExecOrderAction(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInputExecOrderActionField *task_data = (CThostFtdcInputExecOrderActionField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["ExecOrderActionRef"] = task_data->ExecOrderActionRef;
+        data["ExecOrderRef"] = toUtf(task_data->ExecOrderRef);
+        data["RequestID"] = task_data->RequestID;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ExecOrderSysID"] = toUtf(task_data->ExecOrderSysID);
+        data["ActionFlag"] = task_data->ActionFlag;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspExecOrderAction(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspForQuoteInsert(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInputForQuoteField *task_data = (CThostFtdcInputForQuoteField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["ForQuoteRef"] = toUtf(task_data->ForQuoteRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspForQuoteInsert(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInputForQuoteField *task_data = (CThostFtdcInputForQuoteField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["ForQuoteRef"] = toUtf(task_data->ForQuoteRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspForQuoteInsert(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQuoteInsert(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInputQuoteField *task_data = (CThostFtdcInputQuoteField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["QuoteRef"] = toUtf(task_data->QuoteRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["AskPrice"] = task_data->AskPrice;
-		data["BidPrice"] = task_data->BidPrice;
-		data["AskVolume"] = task_data->AskVolume;
-		data["BidVolume"] = task_data->BidVolume;
-		data["RequestID"] = task_data->RequestID;
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["AskOffsetFlag"] = task_data->AskOffsetFlag;
-		data["BidOffsetFlag"] = task_data->BidOffsetFlag;
-		data["AskHedgeFlag"] = task_data->AskHedgeFlag;
-		data["BidHedgeFlag"] = task_data->BidHedgeFlag;
-		data["AskOrderRef"] = toUtf(task_data->AskOrderRef);
-		data["BidOrderRef"] = toUtf(task_data->BidOrderRef);
-		data["ForQuoteSysID"] = toUtf(task_data->ForQuoteSysID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQuoteInsert(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInputQuoteField *task_data = (CThostFtdcInputQuoteField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["QuoteRef"] = toUtf(task_data->QuoteRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["AskPrice"] = task_data->AskPrice;
+        data["BidPrice"] = task_data->BidPrice;
+        data["AskVolume"] = task_data->AskVolume;
+        data["BidVolume"] = task_data->BidVolume;
+        data["RequestID"] = task_data->RequestID;
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["AskOffsetFlag"] = task_data->AskOffsetFlag;
+        data["BidOffsetFlag"] = task_data->BidOffsetFlag;
+        data["AskHedgeFlag"] = task_data->AskHedgeFlag;
+        data["BidHedgeFlag"] = task_data->BidHedgeFlag;
+        data["AskOrderRef"] = toUtf(task_data->AskOrderRef);
+        data["BidOrderRef"] = toUtf(task_data->BidOrderRef);
+        data["ForQuoteSysID"] = toUtf(task_data->ForQuoteSysID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQuoteInsert(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQuoteAction(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInputQuoteActionField *task_data = (CThostFtdcInputQuoteActionField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["QuoteActionRef"] = task_data->QuoteActionRef;
-		data["QuoteRef"] = toUtf(task_data->QuoteRef);
-		data["RequestID"] = task_data->RequestID;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["QuoteSysID"] = toUtf(task_data->QuoteSysID);
-		data["ActionFlag"] = task_data->ActionFlag;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQuoteAction(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInputQuoteActionField *task_data = (CThostFtdcInputQuoteActionField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["QuoteActionRef"] = task_data->QuoteActionRef;
+        data["QuoteRef"] = toUtf(task_data->QuoteRef);
+        data["RequestID"] = task_data->RequestID;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["QuoteSysID"] = toUtf(task_data->QuoteSysID);
+        data["ActionFlag"] = task_data->ActionFlag;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQuoteAction(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspBatchOrderAction(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInputBatchOrderActionField *task_data = (CThostFtdcInputBatchOrderActionField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["OrderActionRef"] = task_data->OrderActionRef;
-		data["RequestID"] = task_data->RequestID;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspBatchOrderAction(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInputBatchOrderActionField *task_data = (CThostFtdcInputBatchOrderActionField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["OrderActionRef"] = task_data->OrderActionRef;
+        data["RequestID"] = task_data->RequestID;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspBatchOrderAction(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspOptionSelfCloseInsert(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInputOptionSelfCloseField *task_data = (CThostFtdcInputOptionSelfCloseField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["OptionSelfCloseRef"] = toUtf(task_data->OptionSelfCloseRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["Volume"] = task_data->Volume;
-		data["RequestID"] = task_data->RequestID;
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["OptSelfCloseFlag"] = task_data->OptSelfCloseFlag;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspOptionSelfCloseInsert(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInputOptionSelfCloseField *task_data = (CThostFtdcInputOptionSelfCloseField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["OptionSelfCloseRef"] = toUtf(task_data->OptionSelfCloseRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["Volume"] = task_data->Volume;
+        data["RequestID"] = task_data->RequestID;
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["OptSelfCloseFlag"] = task_data->OptSelfCloseFlag;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspOptionSelfCloseInsert(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspOptionSelfCloseAction(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInputOptionSelfCloseActionField *task_data = (CThostFtdcInputOptionSelfCloseActionField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["OptionSelfCloseActionRef"] = task_data->OptionSelfCloseActionRef;
-		data["OptionSelfCloseRef"] = toUtf(task_data->OptionSelfCloseRef);
-		data["RequestID"] = task_data->RequestID;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["OptionSelfCloseSysID"] = toUtf(task_data->OptionSelfCloseSysID);
-		data["ActionFlag"] = task_data->ActionFlag;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspOptionSelfCloseAction(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInputOptionSelfCloseActionField *task_data = (CThostFtdcInputOptionSelfCloseActionField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["OptionSelfCloseActionRef"] = task_data->OptionSelfCloseActionRef;
+        data["OptionSelfCloseRef"] = toUtf(task_data->OptionSelfCloseRef);
+        data["RequestID"] = task_data->RequestID;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["OptionSelfCloseSysID"] = toUtf(task_data->OptionSelfCloseSysID);
+        data["ActionFlag"] = task_data->ActionFlag;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspOptionSelfCloseAction(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspCombActionInsert(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInputCombActionField *task_data = (CThostFtdcInputCombActionField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["CombActionRef"] = toUtf(task_data->CombActionRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["Direction"] = task_data->Direction;
-		data["Volume"] = task_data->Volume;
-		data["CombDirection"] = task_data->CombDirection;
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspCombActionInsert(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInputCombActionField *task_data = (CThostFtdcInputCombActionField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["CombActionRef"] = toUtf(task_data->CombActionRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["Direction"] = task_data->Direction;
+        data["Volume"] = task_data->Volume;
+        data["CombDirection"] = task_data->CombDirection;
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspCombActionInsert(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryOrder(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcOrderField *task_data = (CThostFtdcOrderField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["OrderRef"] = toUtf(task_data->OrderRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["OrderPriceType"] = task_data->OrderPriceType;
-		data["Direction"] = task_data->Direction;
-		data["CombOffsetFlag"] = toUtf(task_data->CombOffsetFlag);
-		data["CombHedgeFlag"] = toUtf(task_data->CombHedgeFlag);
-		data["LimitPrice"] = task_data->LimitPrice;
-		data["VolumeTotalOriginal"] = task_data->VolumeTotalOriginal;
-		data["TimeCondition"] = task_data->TimeCondition;
-		data["GTDDate"] = toUtf(task_data->GTDDate);
-		data["VolumeCondition"] = task_data->VolumeCondition;
-		data["MinVolume"] = task_data->MinVolume;
-		data["ContingentCondition"] = task_data->ContingentCondition;
-		data["StopPrice"] = task_data->StopPrice;
-		data["ForceCloseReason"] = task_data->ForceCloseReason;
-		data["IsAutoSuspend"] = task_data->IsAutoSuspend;
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["RequestID"] = task_data->RequestID;
-		data["OrderLocalID"] = toUtf(task_data->OrderLocalID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ParticipantID"] = toUtf(task_data->ParticipantID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
-		data["TraderID"] = toUtf(task_data->TraderID);
-		data["InstallID"] = task_data->InstallID;
-		data["OrderSubmitStatus"] = task_data->OrderSubmitStatus;
-		data["NotifySequence"] = task_data->NotifySequence;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["SettlementID"] = task_data->SettlementID;
-		data["OrderSysID"] = toUtf(task_data->OrderSysID);
-		data["OrderSource"] = task_data->OrderSource;
-		data["OrderStatus"] = task_data->OrderStatus;
-		data["OrderType"] = task_data->OrderType;
-		data["VolumeTraded"] = task_data->VolumeTraded;
-		data["VolumeTotal"] = task_data->VolumeTotal;
-		data["InsertDate"] = toUtf(task_data->InsertDate);
-		data["InsertTime"] = toUtf(task_data->InsertTime);
-		data["ActiveTime"] = toUtf(task_data->ActiveTime);
-		data["SuspendTime"] = toUtf(task_data->SuspendTime);
-		data["UpdateTime"] = toUtf(task_data->UpdateTime);
-		data["CancelTime"] = toUtf(task_data->CancelTime);
-		data["ActiveTraderID"] = toUtf(task_data->ActiveTraderID);
-		data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
-		data["SequenceNo"] = task_data->SequenceNo;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
-		data["StatusMsg"] = toUtf(task_data->StatusMsg);
-		data["UserForceClose"] = task_data->UserForceClose;
-		data["ActiveUserID"] = toUtf(task_data->ActiveUserID);
-		data["BrokerOrderSeq"] = task_data->BrokerOrderSeq;
-		data["RelativeOrderSysID"] = toUtf(task_data->RelativeOrderSysID);
-		data["ZCETotalTradedVolume"] = task_data->ZCETotalTradedVolume;
-		data["IsSwapOrder"] = task_data->IsSwapOrder;
-		data["BranchID"] = toUtf(task_data->BranchID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryOrder(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcOrderField *task_data = (CThostFtdcOrderField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["OrderRef"] = toUtf(task_data->OrderRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["OrderPriceType"] = task_data->OrderPriceType;
+        data["Direction"] = task_data->Direction;
+        data["CombOffsetFlag"] = toUtf(task_data->CombOffsetFlag);
+        data["CombHedgeFlag"] = toUtf(task_data->CombHedgeFlag);
+        data["LimitPrice"] = task_data->LimitPrice;
+        data["VolumeTotalOriginal"] = task_data->VolumeTotalOriginal;
+        data["TimeCondition"] = task_data->TimeCondition;
+        data["GTDDate"] = toUtf(task_data->GTDDate);
+        data["VolumeCondition"] = task_data->VolumeCondition;
+        data["MinVolume"] = task_data->MinVolume;
+        data["ContingentCondition"] = task_data->ContingentCondition;
+        data["StopPrice"] = task_data->StopPrice;
+        data["ForceCloseReason"] = task_data->ForceCloseReason;
+        data["IsAutoSuspend"] = task_data->IsAutoSuspend;
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["RequestID"] = task_data->RequestID;
+        data["OrderLocalID"] = toUtf(task_data->OrderLocalID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ParticipantID"] = toUtf(task_data->ParticipantID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
+        data["TraderID"] = toUtf(task_data->TraderID);
+        data["InstallID"] = task_data->InstallID;
+        data["OrderSubmitStatus"] = task_data->OrderSubmitStatus;
+        data["NotifySequence"] = task_data->NotifySequence;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["SettlementID"] = task_data->SettlementID;
+        data["OrderSysID"] = toUtf(task_data->OrderSysID);
+        data["OrderSource"] = task_data->OrderSource;
+        data["OrderStatus"] = task_data->OrderStatus;
+        data["OrderType"] = task_data->OrderType;
+        data["VolumeTraded"] = task_data->VolumeTraded;
+        data["VolumeTotal"] = task_data->VolumeTotal;
+        data["InsertDate"] = toUtf(task_data->InsertDate);
+        data["InsertTime"] = toUtf(task_data->InsertTime);
+        data["ActiveTime"] = toUtf(task_data->ActiveTime);
+        data["SuspendTime"] = toUtf(task_data->SuspendTime);
+        data["UpdateTime"] = toUtf(task_data->UpdateTime);
+        data["CancelTime"] = toUtf(task_data->CancelTime);
+        data["ActiveTraderID"] = toUtf(task_data->ActiveTraderID);
+        data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
+        data["SequenceNo"] = task_data->SequenceNo;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
+        data["StatusMsg"] = toUtf(task_data->StatusMsg);
+        data["UserForceClose"] = task_data->UserForceClose;
+        data["ActiveUserID"] = toUtf(task_data->ActiveUserID);
+        data["BrokerOrderSeq"] = task_data->BrokerOrderSeq;
+        data["RelativeOrderSysID"] = toUtf(task_data->RelativeOrderSysID);
+        data["ZCETotalTradedVolume"] = task_data->ZCETotalTradedVolume;
+        data["IsSwapOrder"] = task_data->IsSwapOrder;
+        data["BranchID"] = toUtf(task_data->BranchID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryOrder(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryTrade(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcTradeField *task_data = (CThostFtdcTradeField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["OrderRef"] = toUtf(task_data->OrderRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["TradeID"] = toUtf(task_data->TradeID);
-		data["Direction"] = task_data->Direction;
-		data["OrderSysID"] = toUtf(task_data->OrderSysID);
-		data["ParticipantID"] = toUtf(task_data->ParticipantID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["TradingRole"] = task_data->TradingRole;
-		data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
-		data["OffsetFlag"] = task_data->OffsetFlag;
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["Price"] = task_data->Price;
-		data["Volume"] = task_data->Volume;
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["TradeType"] = task_data->TradeType;
-		data["PriceSource"] = task_data->PriceSource;
-		data["TraderID"] = toUtf(task_data->TraderID);
-		data["OrderLocalID"] = toUtf(task_data->OrderLocalID);
-		data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["SequenceNo"] = task_data->SequenceNo;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["SettlementID"] = task_data->SettlementID;
-		data["BrokerOrderSeq"] = task_data->BrokerOrderSeq;
-		data["TradeSource"] = task_data->TradeSource;
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryTrade(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcTradeField *task_data = (CThostFtdcTradeField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["OrderRef"] = toUtf(task_data->OrderRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["TradeID"] = toUtf(task_data->TradeID);
+        data["Direction"] = task_data->Direction;
+        data["OrderSysID"] = toUtf(task_data->OrderSysID);
+        data["ParticipantID"] = toUtf(task_data->ParticipantID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["TradingRole"] = task_data->TradingRole;
+        data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
+        data["OffsetFlag"] = task_data->OffsetFlag;
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["Price"] = task_data->Price;
+        data["Volume"] = task_data->Volume;
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["TradeType"] = task_data->TradeType;
+        data["PriceSource"] = task_data->PriceSource;
+        data["TraderID"] = toUtf(task_data->TraderID);
+        data["OrderLocalID"] = toUtf(task_data->OrderLocalID);
+        data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["SequenceNo"] = task_data->SequenceNo;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["SettlementID"] = task_data->SettlementID;
+        data["BrokerOrderSeq"] = task_data->BrokerOrderSeq;
+        data["TradeSource"] = task_data->TradeSource;
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryTrade(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryInvestorPosition(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInvestorPositionField *task_data = (CThostFtdcInvestorPositionField*)task->task_data;
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["PosiDirection"] = task_data->PosiDirection;
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["PositionDate"] = task_data->PositionDate;
-		data["YdPosition"] = task_data->YdPosition;
-		data["Position"] = task_data->Position;
-		data["LongFrozen"] = task_data->LongFrozen;
-		data["ShortFrozen"] = task_data->ShortFrozen;
-		data["LongFrozenAmount"] = task_data->LongFrozenAmount;
-		data["ShortFrozenAmount"] = task_data->ShortFrozenAmount;
-		data["OpenVolume"] = task_data->OpenVolume;
-		data["CloseVolume"] = task_data->CloseVolume;
-		data["OpenAmount"] = task_data->OpenAmount;
-		data["CloseAmount"] = task_data->CloseAmount;
-		data["PositionCost"] = task_data->PositionCost;
-		data["PreMargin"] = task_data->PreMargin;
-		data["UseMargin"] = task_data->UseMargin;
-		data["FrozenMargin"] = task_data->FrozenMargin;
-		data["FrozenCash"] = task_data->FrozenCash;
-		data["FrozenCommission"] = task_data->FrozenCommission;
-		data["CashIn"] = task_data->CashIn;
-		data["Commission"] = task_data->Commission;
-		data["CloseProfit"] = task_data->CloseProfit;
-		data["PositionProfit"] = task_data->PositionProfit;
-		data["PreSettlementPrice"] = task_data->PreSettlementPrice;
-		data["SettlementPrice"] = task_data->SettlementPrice;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["SettlementID"] = task_data->SettlementID;
-		data["OpenCost"] = task_data->OpenCost;
-		data["ExchangeMargin"] = task_data->ExchangeMargin;
-		data["CombPosition"] = task_data->CombPosition;
-		data["CombLongFrozen"] = task_data->CombLongFrozen;
-		data["CombShortFrozen"] = task_data->CombShortFrozen;
-		data["CloseProfitByDate"] = task_data->CloseProfitByDate;
-		data["CloseProfitByTrade"] = task_data->CloseProfitByTrade;
-		data["TodayPosition"] = task_data->TodayPosition;
-		data["MarginRateByMoney"] = task_data->MarginRateByMoney;
-		data["MarginRateByVolume"] = task_data->MarginRateByVolume;
-		data["StrikeFrozen"] = task_data->StrikeFrozen;
-		data["StrikeFrozenAmount"] = task_data->StrikeFrozenAmount;
-		data["AbandonFrozen"] = task_data->AbandonFrozen;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["YdStrikeFrozen"] = task_data->YdStrikeFrozen;
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryInvestorPosition(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInvestorPositionField *task_data = (CThostFtdcInvestorPositionField*)task->task_data;
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["PosiDirection"] = task_data->PosiDirection;
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["PositionDate"] = task_data->PositionDate;
+        data["YdPosition"] = task_data->YdPosition;
+        data["Position"] = task_data->Position;
+        data["LongFrozen"] = task_data->LongFrozen;
+        data["ShortFrozen"] = task_data->ShortFrozen;
+        data["LongFrozenAmount"] = task_data->LongFrozenAmount;
+        data["ShortFrozenAmount"] = task_data->ShortFrozenAmount;
+        data["OpenVolume"] = task_data->OpenVolume;
+        data["CloseVolume"] = task_data->CloseVolume;
+        data["OpenAmount"] = task_data->OpenAmount;
+        data["CloseAmount"] = task_data->CloseAmount;
+        data["PositionCost"] = task_data->PositionCost;
+        data["PreMargin"] = task_data->PreMargin;
+        data["UseMargin"] = task_data->UseMargin;
+        data["FrozenMargin"] = task_data->FrozenMargin;
+        data["FrozenCash"] = task_data->FrozenCash;
+        data["FrozenCommission"] = task_data->FrozenCommission;
+        data["CashIn"] = task_data->CashIn;
+        data["Commission"] = task_data->Commission;
+        data["CloseProfit"] = task_data->CloseProfit;
+        data["PositionProfit"] = task_data->PositionProfit;
+        data["PreSettlementPrice"] = task_data->PreSettlementPrice;
+        data["SettlementPrice"] = task_data->SettlementPrice;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["SettlementID"] = task_data->SettlementID;
+        data["OpenCost"] = task_data->OpenCost;
+        data["ExchangeMargin"] = task_data->ExchangeMargin;
+        data["CombPosition"] = task_data->CombPosition;
+        data["CombLongFrozen"] = task_data->CombLongFrozen;
+        data["CombShortFrozen"] = task_data->CombShortFrozen;
+        data["CloseProfitByDate"] = task_data->CloseProfitByDate;
+        data["CloseProfitByTrade"] = task_data->CloseProfitByTrade;
+        data["TodayPosition"] = task_data->TodayPosition;
+        data["MarginRateByMoney"] = task_data->MarginRateByMoney;
+        data["MarginRateByVolume"] = task_data->MarginRateByVolume;
+        data["StrikeFrozen"] = task_data->StrikeFrozen;
+        data["StrikeFrozenAmount"] = task_data->StrikeFrozenAmount;
+        data["AbandonFrozen"] = task_data->AbandonFrozen;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["YdStrikeFrozen"] = task_data->YdStrikeFrozen;
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryInvestorPosition(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryTradingAccount(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcTradingAccountField *task_data = (CThostFtdcTradingAccountField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["PreMortgage"] = task_data->PreMortgage;
-		data["PreCredit"] = task_data->PreCredit;
-		data["PreDeposit"] = task_data->PreDeposit;
-		data["PreBalance"] = task_data->PreBalance;
-		data["PreMargin"] = task_data->PreMargin;
-		data["InterestBase"] = task_data->InterestBase;
-		data["Interest"] = task_data->Interest;
-		data["Deposit"] = task_data->Deposit;
-		data["Withdraw"] = task_data->Withdraw;
-		data["FrozenMargin"] = task_data->FrozenMargin;
-		data["FrozenCash"] = task_data->FrozenCash;
-		data["FrozenCommission"] = task_data->FrozenCommission;
-		data["CurrMargin"] = task_data->CurrMargin;
-		data["CashIn"] = task_data->CashIn;
-		data["Commission"] = task_data->Commission;
-		data["CloseProfit"] = task_data->CloseProfit;
-		data["PositionProfit"] = task_data->PositionProfit;
-		data["Balance"] = task_data->Balance;
-		data["Available"] = task_data->Available;
-		data["WithdrawQuota"] = task_data->WithdrawQuota;
-		data["Reserve"] = task_data->Reserve;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["SettlementID"] = task_data->SettlementID;
-		data["Credit"] = task_data->Credit;
-		data["Mortgage"] = task_data->Mortgage;
-		data["ExchangeMargin"] = task_data->ExchangeMargin;
-		data["DeliveryMargin"] = task_data->DeliveryMargin;
-		data["ExchangeDeliveryMargin"] = task_data->ExchangeDeliveryMargin;
-		data["ReserveBalance"] = task_data->ReserveBalance;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["PreFundMortgageIn"] = task_data->PreFundMortgageIn;
-		data["PreFundMortgageOut"] = task_data->PreFundMortgageOut;
-		data["FundMortgageIn"] = task_data->FundMortgageIn;
-		data["FundMortgageOut"] = task_data->FundMortgageOut;
-		data["FundMortgageAvailable"] = task_data->FundMortgageAvailable;
-		data["MortgageableFund"] = task_data->MortgageableFund;
-		data["SpecProductMargin"] = task_data->SpecProductMargin;
-		data["SpecProductFrozenMargin"] = task_data->SpecProductFrozenMargin;
-		data["SpecProductCommission"] = task_data->SpecProductCommission;
-		data["SpecProductFrozenCommission"] = task_data->SpecProductFrozenCommission;
-		data["SpecProductPositionProfit"] = task_data->SpecProductPositionProfit;
-		data["SpecProductCloseProfit"] = task_data->SpecProductCloseProfit;
-		data["SpecProductPositionProfitByAlg"] = task_data->SpecProductPositionProfitByAlg;
-		data["SpecProductExchangeMargin"] = task_data->SpecProductExchangeMargin;
-		data["BizType"] = task_data->BizType;
-		data["FrozenSwap"] = task_data->FrozenSwap;
-		data["RemainSwap"] = task_data->RemainSwap;
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryTradingAccount(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcTradingAccountField *task_data = (CThostFtdcTradingAccountField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["PreMortgage"] = task_data->PreMortgage;
+        data["PreCredit"] = task_data->PreCredit;
+        data["PreDeposit"] = task_data->PreDeposit;
+        data["PreBalance"] = task_data->PreBalance;
+        data["PreMargin"] = task_data->PreMargin;
+        data["InterestBase"] = task_data->InterestBase;
+        data["Interest"] = task_data->Interest;
+        data["Deposit"] = task_data->Deposit;
+        data["Withdraw"] = task_data->Withdraw;
+        data["FrozenMargin"] = task_data->FrozenMargin;
+        data["FrozenCash"] = task_data->FrozenCash;
+        data["FrozenCommission"] = task_data->FrozenCommission;
+        data["CurrMargin"] = task_data->CurrMargin;
+        data["CashIn"] = task_data->CashIn;
+        data["Commission"] = task_data->Commission;
+        data["CloseProfit"] = task_data->CloseProfit;
+        data["PositionProfit"] = task_data->PositionProfit;
+        data["Balance"] = task_data->Balance;
+        data["Available"] = task_data->Available;
+        data["WithdrawQuota"] = task_data->WithdrawQuota;
+        data["Reserve"] = task_data->Reserve;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["SettlementID"] = task_data->SettlementID;
+        data["Credit"] = task_data->Credit;
+        data["Mortgage"] = task_data->Mortgage;
+        data["ExchangeMargin"] = task_data->ExchangeMargin;
+        data["DeliveryMargin"] = task_data->DeliveryMargin;
+        data["ExchangeDeliveryMargin"] = task_data->ExchangeDeliveryMargin;
+        data["ReserveBalance"] = task_data->ReserveBalance;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["PreFundMortgageIn"] = task_data->PreFundMortgageIn;
+        data["PreFundMortgageOut"] = task_data->PreFundMortgageOut;
+        data["FundMortgageIn"] = task_data->FundMortgageIn;
+        data["FundMortgageOut"] = task_data->FundMortgageOut;
+        data["FundMortgageAvailable"] = task_data->FundMortgageAvailable;
+        data["MortgageableFund"] = task_data->MortgageableFund;
+        data["SpecProductMargin"] = task_data->SpecProductMargin;
+        data["SpecProductFrozenMargin"] = task_data->SpecProductFrozenMargin;
+        data["SpecProductCommission"] = task_data->SpecProductCommission;
+        data["SpecProductFrozenCommission"] = task_data->SpecProductFrozenCommission;
+        data["SpecProductPositionProfit"] = task_data->SpecProductPositionProfit;
+        data["SpecProductCloseProfit"] = task_data->SpecProductCloseProfit;
+        data["SpecProductPositionProfitByAlg"] = task_data->SpecProductPositionProfitByAlg;
+        data["SpecProductExchangeMargin"] = task_data->SpecProductExchangeMargin;
+        data["BizType"] = task_data->BizType;
+        data["FrozenSwap"] = task_data->FrozenSwap;
+        data["RemainSwap"] = task_data->RemainSwap;
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryTradingAccount(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryInvestor(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInvestorField *task_data = (CThostFtdcInvestorField*)task->task_data;
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorGroupID"] = toUtf(task_data->InvestorGroupID);
-		data["InvestorName"] = toUtf(task_data->InvestorName);
-		data["IdentifiedCardType"] = task_data->IdentifiedCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["IsActive"] = task_data->IsActive;
-		data["Telephone"] = toUtf(task_data->Telephone);
-		data["Address"] = toUtf(task_data->Address);
-		data["OpenDate"] = toUtf(task_data->OpenDate);
-		data["Mobile"] = toUtf(task_data->Mobile);
-		data["CommModelID"] = toUtf(task_data->CommModelID);
-		data["MarginModelID"] = toUtf(task_data->MarginModelID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryInvestor(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInvestorField *task_data = (CThostFtdcInvestorField*)task->task_data;
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorGroupID"] = toUtf(task_data->InvestorGroupID);
+        data["InvestorName"] = toUtf(task_data->InvestorName);
+        data["IdentifiedCardType"] = task_data->IdentifiedCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["IsActive"] = task_data->IsActive;
+        data["Telephone"] = toUtf(task_data->Telephone);
+        data["Address"] = toUtf(task_data->Address);
+        data["OpenDate"] = toUtf(task_data->OpenDate);
+        data["Mobile"] = toUtf(task_data->Mobile);
+        data["CommModelID"] = toUtf(task_data->CommModelID);
+        data["MarginModelID"] = toUtf(task_data->MarginModelID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryInvestor(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryTradingCode(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcTradingCodeField *task_data = (CThostFtdcTradingCodeField*)task->task_data;
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["IsActive"] = task_data->IsActive;
-		data["ClientIDType"] = task_data->ClientIDType;
-		data["BranchID"] = toUtf(task_data->BranchID);
-		data["BizType"] = task_data->BizType;
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryTradingCode(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcTradingCodeField *task_data = (CThostFtdcTradingCodeField*)task->task_data;
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["IsActive"] = task_data->IsActive;
+        data["ClientIDType"] = task_data->ClientIDType;
+        data["BranchID"] = toUtf(task_data->BranchID);
+        data["BizType"] = task_data->BizType;
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryTradingCode(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryInstrumentMarginRate(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInstrumentMarginRateField *task_data = (CThostFtdcInstrumentMarginRateField*)task->task_data;
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["InvestorRange"] = task_data->InvestorRange;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["LongMarginRatioByMoney"] = task_data->LongMarginRatioByMoney;
-		data["LongMarginRatioByVolume"] = task_data->LongMarginRatioByVolume;
-		data["ShortMarginRatioByMoney"] = task_data->ShortMarginRatioByMoney;
-		data["ShortMarginRatioByVolume"] = task_data->ShortMarginRatioByVolume;
-		data["IsRelative"] = task_data->IsRelative;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryInstrumentMarginRate(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInstrumentMarginRateField *task_data = (CThostFtdcInstrumentMarginRateField*)task->task_data;
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["InvestorRange"] = task_data->InvestorRange;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["LongMarginRatioByMoney"] = task_data->LongMarginRatioByMoney;
+        data["LongMarginRatioByVolume"] = task_data->LongMarginRatioByVolume;
+        data["ShortMarginRatioByMoney"] = task_data->ShortMarginRatioByMoney;
+        data["ShortMarginRatioByVolume"] = task_data->ShortMarginRatioByVolume;
+        data["IsRelative"] = task_data->IsRelative;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryInstrumentMarginRate(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryInstrumentCommissionRate(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInstrumentCommissionRateField *task_data = (CThostFtdcInstrumentCommissionRateField*)task->task_data;
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["InvestorRange"] = task_data->InvestorRange;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["OpenRatioByMoney"] = task_data->OpenRatioByMoney;
-		data["OpenRatioByVolume"] = task_data->OpenRatioByVolume;
-		data["CloseRatioByMoney"] = task_data->CloseRatioByMoney;
-		data["CloseRatioByVolume"] = task_data->CloseRatioByVolume;
-		data["CloseTodayRatioByMoney"] = task_data->CloseTodayRatioByMoney;
-		data["CloseTodayRatioByVolume"] = task_data->CloseTodayRatioByVolume;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["BizType"] = task_data->BizType;
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryInstrumentCommissionRate(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInstrumentCommissionRateField *task_data = (CThostFtdcInstrumentCommissionRateField*)task->task_data;
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["InvestorRange"] = task_data->InvestorRange;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["OpenRatioByMoney"] = task_data->OpenRatioByMoney;
+        data["OpenRatioByVolume"] = task_data->OpenRatioByVolume;
+        data["CloseRatioByMoney"] = task_data->CloseRatioByMoney;
+        data["CloseRatioByVolume"] = task_data->CloseRatioByVolume;
+        data["CloseTodayRatioByMoney"] = task_data->CloseTodayRatioByMoney;
+        data["CloseTodayRatioByVolume"] = task_data->CloseTodayRatioByVolume;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["BizType"] = task_data->BizType;
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryInstrumentCommissionRate(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryExchange(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcExchangeField *task_data = (CThostFtdcExchangeField*)task->task_data;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ExchangeName"] = toUtf(task_data->ExchangeName);
-		data["ExchangeProperty"] = task_data->ExchangeProperty;
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryExchange(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcExchangeField *task_data = (CThostFtdcExchangeField*)task->task_data;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ExchangeName"] = toUtf(task_data->ExchangeName);
+        data["ExchangeProperty"] = task_data->ExchangeProperty;
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryExchange(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryProduct(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcProductField *task_data = (CThostFtdcProductField*)task->task_data;
-		data["ProductID"] = toUtf(task_data->ProductID);
-		data["ProductName"] = toUtf(task_data->ProductName);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ProductClass"] = task_data->ProductClass;
-		data["VolumeMultiple"] = task_data->VolumeMultiple;
-		data["PriceTick"] = task_data->PriceTick;
-		data["MaxMarketOrderVolume"] = task_data->MaxMarketOrderVolume;
-		data["MinMarketOrderVolume"] = task_data->MinMarketOrderVolume;
-		data["MaxLimitOrderVolume"] = task_data->MaxLimitOrderVolume;
-		data["MinLimitOrderVolume"] = task_data->MinLimitOrderVolume;
-		data["PositionType"] = task_data->PositionType;
-		data["PositionDateType"] = task_data->PositionDateType;
-		data["CloseDealType"] = task_data->CloseDealType;
-		data["TradeCurrencyID"] = toUtf(task_data->TradeCurrencyID);
-		data["MortgageFundUseRange"] = task_data->MortgageFundUseRange;
-		data["ExchangeProductID"] = toUtf(task_data->ExchangeProductID);
-		data["UnderlyingMultiple"] = task_data->UnderlyingMultiple;
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryProduct(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcProductField *task_data = (CThostFtdcProductField*)task->task_data;
+        data["ProductID"] = toUtf(task_data->ProductID);
+        data["ProductName"] = toUtf(task_data->ProductName);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ProductClass"] = task_data->ProductClass;
+        data["VolumeMultiple"] = task_data->VolumeMultiple;
+        data["PriceTick"] = task_data->PriceTick;
+        data["MaxMarketOrderVolume"] = task_data->MaxMarketOrderVolume;
+        data["MinMarketOrderVolume"] = task_data->MinMarketOrderVolume;
+        data["MaxLimitOrderVolume"] = task_data->MaxLimitOrderVolume;
+        data["MinLimitOrderVolume"] = task_data->MinLimitOrderVolume;
+        data["PositionType"] = task_data->PositionType;
+        data["PositionDateType"] = task_data->PositionDateType;
+        data["CloseDealType"] = task_data->CloseDealType;
+        data["TradeCurrencyID"] = toUtf(task_data->TradeCurrencyID);
+        data["MortgageFundUseRange"] = task_data->MortgageFundUseRange;
+        data["ExchangeProductID"] = toUtf(task_data->ExchangeProductID);
+        data["UnderlyingMultiple"] = task_data->UnderlyingMultiple;
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryProduct(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryInstrument(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInstrumentField *task_data = (CThostFtdcInstrumentField*)task->task_data;
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["InstrumentName"] = toUtf(task_data->InstrumentName);
-		data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
-		data["ProductID"] = toUtf(task_data->ProductID);
-		data["ProductClass"] = task_data->ProductClass;
-		data["DeliveryYear"] = task_data->DeliveryYear;
-		data["DeliveryMonth"] = task_data->DeliveryMonth;
-		data["MaxMarketOrderVolume"] = task_data->MaxMarketOrderVolume;
-		data["MinMarketOrderVolume"] = task_data->MinMarketOrderVolume;
-		data["MaxLimitOrderVolume"] = task_data->MaxLimitOrderVolume;
-		data["MinLimitOrderVolume"] = task_data->MinLimitOrderVolume;
-		data["VolumeMultiple"] = task_data->VolumeMultiple;
-		data["PriceTick"] = task_data->PriceTick;
-		data["CreateDate"] = toUtf(task_data->CreateDate);
-		data["OpenDate"] = toUtf(task_data->OpenDate);
-		data["ExpireDate"] = toUtf(task_data->ExpireDate);
-		data["StartDelivDate"] = toUtf(task_data->StartDelivDate);
-		data["EndDelivDate"] = toUtf(task_data->EndDelivDate);
-		data["InstLifePhase"] = task_data->InstLifePhase;
-		data["IsTrading"] = task_data->IsTrading;
-		data["PositionType"] = task_data->PositionType;
-		data["PositionDateType"] = task_data->PositionDateType;
-		data["LongMarginRatio"] = task_data->LongMarginRatio;
-		data["ShortMarginRatio"] = task_data->ShortMarginRatio;
-		data["MaxMarginSideAlgorithm"] = task_data->MaxMarginSideAlgorithm;
-		data["UnderlyingInstrID"] = toUtf(task_data->UnderlyingInstrID);
-		data["StrikePrice"] = task_data->StrikePrice;
-		data["OptionsType"] = task_data->OptionsType;
-		data["UnderlyingMultiple"] = task_data->UnderlyingMultiple;
-		data["CombinationType"] = task_data->CombinationType;
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryInstrument(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInstrumentField *task_data = (CThostFtdcInstrumentField*)task->task_data;
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["InstrumentName"] = toUtf(task_data->InstrumentName);
+        data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
+        data["ProductID"] = toUtf(task_data->ProductID);
+        data["ProductClass"] = task_data->ProductClass;
+        data["DeliveryYear"] = task_data->DeliveryYear;
+        data["DeliveryMonth"] = task_data->DeliveryMonth;
+        data["MaxMarketOrderVolume"] = task_data->MaxMarketOrderVolume;
+        data["MinMarketOrderVolume"] = task_data->MinMarketOrderVolume;
+        data["MaxLimitOrderVolume"] = task_data->MaxLimitOrderVolume;
+        data["MinLimitOrderVolume"] = task_data->MinLimitOrderVolume;
+        data["VolumeMultiple"] = task_data->VolumeMultiple;
+        data["PriceTick"] = task_data->PriceTick;
+        data["CreateDate"] = toUtf(task_data->CreateDate);
+        data["OpenDate"] = toUtf(task_data->OpenDate);
+        data["ExpireDate"] = toUtf(task_data->ExpireDate);
+        data["StartDelivDate"] = toUtf(task_data->StartDelivDate);
+        data["EndDelivDate"] = toUtf(task_data->EndDelivDate);
+        data["InstLifePhase"] = task_data->InstLifePhase;
+        data["IsTrading"] = task_data->IsTrading;
+        data["PositionType"] = task_data->PositionType;
+        data["PositionDateType"] = task_data->PositionDateType;
+        data["LongMarginRatio"] = task_data->LongMarginRatio;
+        data["ShortMarginRatio"] = task_data->ShortMarginRatio;
+        data["MaxMarginSideAlgorithm"] = task_data->MaxMarginSideAlgorithm;
+        data["UnderlyingInstrID"] = toUtf(task_data->UnderlyingInstrID);
+        data["StrikePrice"] = task_data->StrikePrice;
+        data["OptionsType"] = task_data->OptionsType;
+        data["UnderlyingMultiple"] = task_data->UnderlyingMultiple;
+        data["CombinationType"] = task_data->CombinationType;
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryInstrument(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryDepthMarketData(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcDepthMarketDataField *task_data = (CThostFtdcDepthMarketDataField*)task->task_data;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
-		data["LastPrice"] = task_data->LastPrice;
-		data["PreSettlementPrice"] = task_data->PreSettlementPrice;
-		data["PreClosePrice"] = task_data->PreClosePrice;
-		data["PreOpenInterest"] = task_data->PreOpenInterest;
-		data["OpenPrice"] = task_data->OpenPrice;
-		data["HighestPrice"] = task_data->HighestPrice;
-		data["LowestPrice"] = task_data->LowestPrice;
-		data["Volume"] = task_data->Volume;
-		data["Turnover"] = task_data->Turnover;
-		data["OpenInterest"] = task_data->OpenInterest;
-		data["ClosePrice"] = task_data->ClosePrice;
-		data["SettlementPrice"] = task_data->SettlementPrice;
-		data["UpperLimitPrice"] = task_data->UpperLimitPrice;
-		data["LowerLimitPrice"] = task_data->LowerLimitPrice;
-		data["PreDelta"] = task_data->PreDelta;
-		data["CurrDelta"] = task_data->CurrDelta;
-		data["UpdateTime"] = toUtf(task_data->UpdateTime);
-		data["UpdateMillisec"] = task_data->UpdateMillisec;
-		data["BidPrice1"] = task_data->BidPrice1;
-		data["BidVolume1"] = task_data->BidVolume1;
-		data["AskPrice1"] = task_data->AskPrice1;
-		data["AskVolume1"] = task_data->AskVolume1;
-		data["BidPrice2"] = task_data->BidPrice2;
-		data["BidVolume2"] = task_data->BidVolume2;
-		data["AskPrice2"] = task_data->AskPrice2;
-		data["AskVolume2"] = task_data->AskVolume2;
-		data["BidPrice3"] = task_data->BidPrice3;
-		data["BidVolume3"] = task_data->BidVolume3;
-		data["AskPrice3"] = task_data->AskPrice3;
-		data["AskVolume3"] = task_data->AskVolume3;
-		data["BidPrice4"] = task_data->BidPrice4;
-		data["BidVolume4"] = task_data->BidVolume4;
-		data["AskPrice4"] = task_data->AskPrice4;
-		data["AskVolume4"] = task_data->AskVolume4;
-		data["BidPrice5"] = task_data->BidPrice5;
-		data["BidVolume5"] = task_data->BidVolume5;
-		data["AskPrice5"] = task_data->AskPrice5;
-		data["AskVolume5"] = task_data->AskVolume5;
-		data["AveragePrice"] = task_data->AveragePrice;
-		data["ActionDay"] = toUtf(task_data->ActionDay);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryDepthMarketData(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcDepthMarketDataField *task_data = (CThostFtdcDepthMarketDataField*)task->task_data;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
+        data["LastPrice"] = task_data->LastPrice;
+        data["PreSettlementPrice"] = task_data->PreSettlementPrice;
+        data["PreClosePrice"] = task_data->PreClosePrice;
+        data["PreOpenInterest"] = task_data->PreOpenInterest;
+        data["OpenPrice"] = task_data->OpenPrice;
+        data["HighestPrice"] = task_data->HighestPrice;
+        data["LowestPrice"] = task_data->LowestPrice;
+        data["Volume"] = task_data->Volume;
+        data["Turnover"] = task_data->Turnover;
+        data["OpenInterest"] = task_data->OpenInterest;
+        data["ClosePrice"] = task_data->ClosePrice;
+        data["SettlementPrice"] = task_data->SettlementPrice;
+        data["UpperLimitPrice"] = task_data->UpperLimitPrice;
+        data["LowerLimitPrice"] = task_data->LowerLimitPrice;
+        data["PreDelta"] = task_data->PreDelta;
+        data["CurrDelta"] = task_data->CurrDelta;
+        data["UpdateTime"] = toUtf(task_data->UpdateTime);
+        data["UpdateMillisec"] = task_data->UpdateMillisec;
+        data["BidPrice1"] = task_data->BidPrice1;
+        data["BidVolume1"] = task_data->BidVolume1;
+        data["AskPrice1"] = task_data->AskPrice1;
+        data["AskVolume1"] = task_data->AskVolume1;
+        data["BidPrice2"] = task_data->BidPrice2;
+        data["BidVolume2"] = task_data->BidVolume2;
+        data["AskPrice2"] = task_data->AskPrice2;
+        data["AskVolume2"] = task_data->AskVolume2;
+        data["BidPrice3"] = task_data->BidPrice3;
+        data["BidVolume3"] = task_data->BidVolume3;
+        data["AskPrice3"] = task_data->AskPrice3;
+        data["AskVolume3"] = task_data->AskVolume3;
+        data["BidPrice4"] = task_data->BidPrice4;
+        data["BidVolume4"] = task_data->BidVolume4;
+        data["AskPrice4"] = task_data->AskPrice4;
+        data["AskVolume4"] = task_data->AskVolume4;
+        data["BidPrice5"] = task_data->BidPrice5;
+        data["BidVolume5"] = task_data->BidVolume5;
+        data["AskPrice5"] = task_data->AskPrice5;
+        data["AskVolume5"] = task_data->AskVolume5;
+        data["AveragePrice"] = task_data->AveragePrice;
+        data["ActionDay"] = toUtf(task_data->ActionDay);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryDepthMarketData(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQrySettlementInfo(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcSettlementInfoField *task_data = (CThostFtdcSettlementInfoField*)task->task_data;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["SettlementID"] = task_data->SettlementID;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["SequenceNo"] = task_data->SequenceNo;
-		data["Content"] = toUtf(task_data->Content);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQrySettlementInfo(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcSettlementInfoField *task_data = (CThostFtdcSettlementInfoField*)task->task_data;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["SettlementID"] = task_data->SettlementID;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["SequenceNo"] = task_data->SequenceNo;
+        data["Content"] = toUtf(task_data->Content);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQrySettlementInfo(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryTransferBank(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcTransferBankField *task_data = (CThostFtdcTransferBankField*)task->task_data;
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBrchID"] = toUtf(task_data->BankBrchID);
-		data["BankName"] = toUtf(task_data->BankName);
-		data["IsActive"] = task_data->IsActive;
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryTransferBank(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcTransferBankField *task_data = (CThostFtdcTransferBankField*)task->task_data;
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBrchID"] = toUtf(task_data->BankBrchID);
+        data["BankName"] = toUtf(task_data->BankName);
+        data["IsActive"] = task_data->IsActive;
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryTransferBank(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryInvestorPositionDetail(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInvestorPositionDetailField *task_data = (CThostFtdcInvestorPositionDetailField*)task->task_data;
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["Direction"] = task_data->Direction;
-		data["OpenDate"] = toUtf(task_data->OpenDate);
-		data["TradeID"] = toUtf(task_data->TradeID);
-		data["Volume"] = task_data->Volume;
-		data["OpenPrice"] = task_data->OpenPrice;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["SettlementID"] = task_data->SettlementID;
-		data["TradeType"] = task_data->TradeType;
-		data["CombInstrumentID"] = toUtf(task_data->CombInstrumentID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["CloseProfitByDate"] = task_data->CloseProfitByDate;
-		data["CloseProfitByTrade"] = task_data->CloseProfitByTrade;
-		data["PositionProfitByDate"] = task_data->PositionProfitByDate;
-		data["PositionProfitByTrade"] = task_data->PositionProfitByTrade;
-		data["Margin"] = task_data->Margin;
-		data["ExchMargin"] = task_data->ExchMargin;
-		data["MarginRateByMoney"] = task_data->MarginRateByMoney;
-		data["MarginRateByVolume"] = task_data->MarginRateByVolume;
-		data["LastSettlementPrice"] = task_data->LastSettlementPrice;
-		data["SettlementPrice"] = task_data->SettlementPrice;
-		data["CloseVolume"] = task_data->CloseVolume;
-		data["CloseAmount"] = task_data->CloseAmount;
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryInvestorPositionDetail(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInvestorPositionDetailField *task_data = (CThostFtdcInvestorPositionDetailField*)task->task_data;
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["Direction"] = task_data->Direction;
+        data["OpenDate"] = toUtf(task_data->OpenDate);
+        data["TradeID"] = toUtf(task_data->TradeID);
+        data["Volume"] = task_data->Volume;
+        data["OpenPrice"] = task_data->OpenPrice;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["SettlementID"] = task_data->SettlementID;
+        data["TradeType"] = task_data->TradeType;
+        data["CombInstrumentID"] = toUtf(task_data->CombInstrumentID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["CloseProfitByDate"] = task_data->CloseProfitByDate;
+        data["CloseProfitByTrade"] = task_data->CloseProfitByTrade;
+        data["PositionProfitByDate"] = task_data->PositionProfitByDate;
+        data["PositionProfitByTrade"] = task_data->PositionProfitByTrade;
+        data["Margin"] = task_data->Margin;
+        data["ExchMargin"] = task_data->ExchMargin;
+        data["MarginRateByMoney"] = task_data->MarginRateByMoney;
+        data["MarginRateByVolume"] = task_data->MarginRateByVolume;
+        data["LastSettlementPrice"] = task_data->LastSettlementPrice;
+        data["SettlementPrice"] = task_data->SettlementPrice;
+        data["CloseVolume"] = task_data->CloseVolume;
+        data["CloseAmount"] = task_data->CloseAmount;
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryInvestorPositionDetail(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryNotice(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcNoticeField *task_data = (CThostFtdcNoticeField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["Content"] = toUtf(task_data->Content);
-		data["SequenceLabel"] = toUtf(task_data->SequenceLabel);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryNotice(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcNoticeField *task_data = (CThostFtdcNoticeField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["Content"] = toUtf(task_data->Content);
+        data["SequenceLabel"] = toUtf(task_data->SequenceLabel);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryNotice(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQrySettlementInfoConfirm(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcSettlementInfoConfirmField *task_data = (CThostFtdcSettlementInfoConfirmField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["ConfirmDate"] = toUtf(task_data->ConfirmDate);
-		data["ConfirmTime"] = toUtf(task_data->ConfirmTime);
-		data["SettlementID"] = task_data->SettlementID;
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQrySettlementInfoConfirm(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcSettlementInfoConfirmField *task_data = (CThostFtdcSettlementInfoConfirmField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["ConfirmDate"] = toUtf(task_data->ConfirmDate);
+        data["ConfirmTime"] = toUtf(task_data->ConfirmTime);
+        data["SettlementID"] = task_data->SettlementID;
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQrySettlementInfoConfirm(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryInvestorPositionCombineDetail(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInvestorPositionCombineDetailField *task_data = (CThostFtdcInvestorPositionCombineDetailField*)task->task_data;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["OpenDate"] = toUtf(task_data->OpenDate);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["SettlementID"] = task_data->SettlementID;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["ComTradeID"] = toUtf(task_data->ComTradeID);
-		data["TradeID"] = toUtf(task_data->TradeID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["Direction"] = task_data->Direction;
-		data["TotalAmt"] = task_data->TotalAmt;
-		data["Margin"] = task_data->Margin;
-		data["ExchMargin"] = task_data->ExchMargin;
-		data["MarginRateByMoney"] = task_data->MarginRateByMoney;
-		data["MarginRateByVolume"] = task_data->MarginRateByVolume;
-		data["LegID"] = task_data->LegID;
-		data["LegMultiple"] = task_data->LegMultiple;
-		data["CombInstrumentID"] = toUtf(task_data->CombInstrumentID);
-		data["TradeGroupID"] = task_data->TradeGroupID;
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryInvestorPositionCombineDetail(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInvestorPositionCombineDetailField *task_data = (CThostFtdcInvestorPositionCombineDetailField*)task->task_data;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["OpenDate"] = toUtf(task_data->OpenDate);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["SettlementID"] = task_data->SettlementID;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["ComTradeID"] = toUtf(task_data->ComTradeID);
+        data["TradeID"] = toUtf(task_data->TradeID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["Direction"] = task_data->Direction;
+        data["TotalAmt"] = task_data->TotalAmt;
+        data["Margin"] = task_data->Margin;
+        data["ExchMargin"] = task_data->ExchMargin;
+        data["MarginRateByMoney"] = task_data->MarginRateByMoney;
+        data["MarginRateByVolume"] = task_data->MarginRateByVolume;
+        data["LegID"] = task_data->LegID;
+        data["LegMultiple"] = task_data->LegMultiple;
+        data["CombInstrumentID"] = toUtf(task_data->CombInstrumentID);
+        data["TradeGroupID"] = task_data->TradeGroupID;
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryInvestorPositionCombineDetail(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryCFMMCTradingAccountKey(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcCFMMCTradingAccountKeyField *task_data = (CThostFtdcCFMMCTradingAccountKeyField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["ParticipantID"] = toUtf(task_data->ParticipantID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["KeyID"] = task_data->KeyID;
-		data["CurrentKey"] = toUtf(task_data->CurrentKey);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryCFMMCTradingAccountKey(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcCFMMCTradingAccountKeyField *task_data = (CThostFtdcCFMMCTradingAccountKeyField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["ParticipantID"] = toUtf(task_data->ParticipantID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["KeyID"] = task_data->KeyID;
+        data["CurrentKey"] = toUtf(task_data->CurrentKey);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryCFMMCTradingAccountKey(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryEWarrantOffset(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcEWarrantOffsetField *task_data = (CThostFtdcEWarrantOffsetField*)task->task_data;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["Direction"] = task_data->Direction;
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["Volume"] = task_data->Volume;
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryEWarrantOffset(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcEWarrantOffsetField *task_data = (CThostFtdcEWarrantOffsetField*)task->task_data;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["Direction"] = task_data->Direction;
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["Volume"] = task_data->Volume;
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryEWarrantOffset(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryInvestorProductGroupMargin(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInvestorProductGroupMarginField *task_data = (CThostFtdcInvestorProductGroupMarginField*)task->task_data;
-		data["ProductGroupID"] = toUtf(task_data->ProductGroupID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["SettlementID"] = task_data->SettlementID;
-		data["FrozenMargin"] = task_data->FrozenMargin;
-		data["LongFrozenMargin"] = task_data->LongFrozenMargin;
-		data["ShortFrozenMargin"] = task_data->ShortFrozenMargin;
-		data["UseMargin"] = task_data->UseMargin;
-		data["LongUseMargin"] = task_data->LongUseMargin;
-		data["ShortUseMargin"] = task_data->ShortUseMargin;
-		data["ExchMargin"] = task_data->ExchMargin;
-		data["LongExchMargin"] = task_data->LongExchMargin;
-		data["ShortExchMargin"] = task_data->ShortExchMargin;
-		data["CloseProfit"] = task_data->CloseProfit;
-		data["FrozenCommission"] = task_data->FrozenCommission;
-		data["Commission"] = task_data->Commission;
-		data["FrozenCash"] = task_data->FrozenCash;
-		data["CashIn"] = task_data->CashIn;
-		data["PositionProfit"] = task_data->PositionProfit;
-		data["OffsetAmount"] = task_data->OffsetAmount;
-		data["LongOffsetAmount"] = task_data->LongOffsetAmount;
-		data["ShortOffsetAmount"] = task_data->ShortOffsetAmount;
-		data["ExchOffsetAmount"] = task_data->ExchOffsetAmount;
-		data["LongExchOffsetAmount"] = task_data->LongExchOffsetAmount;
-		data["ShortExchOffsetAmount"] = task_data->ShortExchOffsetAmount;
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryInvestorProductGroupMargin(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInvestorProductGroupMarginField *task_data = (CThostFtdcInvestorProductGroupMarginField*)task->task_data;
+        data["ProductGroupID"] = toUtf(task_data->ProductGroupID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["SettlementID"] = task_data->SettlementID;
+        data["FrozenMargin"] = task_data->FrozenMargin;
+        data["LongFrozenMargin"] = task_data->LongFrozenMargin;
+        data["ShortFrozenMargin"] = task_data->ShortFrozenMargin;
+        data["UseMargin"] = task_data->UseMargin;
+        data["LongUseMargin"] = task_data->LongUseMargin;
+        data["ShortUseMargin"] = task_data->ShortUseMargin;
+        data["ExchMargin"] = task_data->ExchMargin;
+        data["LongExchMargin"] = task_data->LongExchMargin;
+        data["ShortExchMargin"] = task_data->ShortExchMargin;
+        data["CloseProfit"] = task_data->CloseProfit;
+        data["FrozenCommission"] = task_data->FrozenCommission;
+        data["Commission"] = task_data->Commission;
+        data["FrozenCash"] = task_data->FrozenCash;
+        data["CashIn"] = task_data->CashIn;
+        data["PositionProfit"] = task_data->PositionProfit;
+        data["OffsetAmount"] = task_data->OffsetAmount;
+        data["LongOffsetAmount"] = task_data->LongOffsetAmount;
+        data["ShortOffsetAmount"] = task_data->ShortOffsetAmount;
+        data["ExchOffsetAmount"] = task_data->ExchOffsetAmount;
+        data["LongExchOffsetAmount"] = task_data->LongExchOffsetAmount;
+        data["ShortExchOffsetAmount"] = task_data->ShortExchOffsetAmount;
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryInvestorProductGroupMargin(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryExchangeMarginRate(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcExchangeMarginRateField *task_data = (CThostFtdcExchangeMarginRateField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["LongMarginRatioByMoney"] = task_data->LongMarginRatioByMoney;
-		data["LongMarginRatioByVolume"] = task_data->LongMarginRatioByVolume;
-		data["ShortMarginRatioByMoney"] = task_data->ShortMarginRatioByMoney;
-		data["ShortMarginRatioByVolume"] = task_data->ShortMarginRatioByVolume;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryExchangeMarginRate(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcExchangeMarginRateField *task_data = (CThostFtdcExchangeMarginRateField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["LongMarginRatioByMoney"] = task_data->LongMarginRatioByMoney;
+        data["LongMarginRatioByVolume"] = task_data->LongMarginRatioByVolume;
+        data["ShortMarginRatioByMoney"] = task_data->ShortMarginRatioByMoney;
+        data["ShortMarginRatioByVolume"] = task_data->ShortMarginRatioByVolume;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryExchangeMarginRate(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryExchangeMarginRateAdjust(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcExchangeMarginRateAdjustField *task_data = (CThostFtdcExchangeMarginRateAdjustField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["LongMarginRatioByMoney"] = task_data->LongMarginRatioByMoney;
-		data["LongMarginRatioByVolume"] = task_data->LongMarginRatioByVolume;
-		data["ShortMarginRatioByMoney"] = task_data->ShortMarginRatioByMoney;
-		data["ShortMarginRatioByVolume"] = task_data->ShortMarginRatioByVolume;
-		data["ExchLongMarginRatioByMoney"] = task_data->ExchLongMarginRatioByMoney;
-		data["ExchLongMarginRatioByVolume"] = task_data->ExchLongMarginRatioByVolume;
-		data["ExchShortMarginRatioByMoney"] = task_data->ExchShortMarginRatioByMoney;
-		data["ExchShortMarginRatioByVolume"] = task_data->ExchShortMarginRatioByVolume;
-		data["NoLongMarginRatioByMoney"] = task_data->NoLongMarginRatioByMoney;
-		data["NoLongMarginRatioByVolume"] = task_data->NoLongMarginRatioByVolume;
-		data["NoShortMarginRatioByMoney"] = task_data->NoShortMarginRatioByMoney;
-		data["NoShortMarginRatioByVolume"] = task_data->NoShortMarginRatioByVolume;
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryExchangeMarginRateAdjust(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcExchangeMarginRateAdjustField *task_data = (CThostFtdcExchangeMarginRateAdjustField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["LongMarginRatioByMoney"] = task_data->LongMarginRatioByMoney;
+        data["LongMarginRatioByVolume"] = task_data->LongMarginRatioByVolume;
+        data["ShortMarginRatioByMoney"] = task_data->ShortMarginRatioByMoney;
+        data["ShortMarginRatioByVolume"] = task_data->ShortMarginRatioByVolume;
+        data["ExchLongMarginRatioByMoney"] = task_data->ExchLongMarginRatioByMoney;
+        data["ExchLongMarginRatioByVolume"] = task_data->ExchLongMarginRatioByVolume;
+        data["ExchShortMarginRatioByMoney"] = task_data->ExchShortMarginRatioByMoney;
+        data["ExchShortMarginRatioByVolume"] = task_data->ExchShortMarginRatioByVolume;
+        data["NoLongMarginRatioByMoney"] = task_data->NoLongMarginRatioByMoney;
+        data["NoLongMarginRatioByVolume"] = task_data->NoLongMarginRatioByVolume;
+        data["NoShortMarginRatioByMoney"] = task_data->NoShortMarginRatioByMoney;
+        data["NoShortMarginRatioByVolume"] = task_data->NoShortMarginRatioByVolume;
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryExchangeMarginRateAdjust(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryExchangeRate(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcExchangeRateField *task_data = (CThostFtdcExchangeRateField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["FromCurrencyID"] = toUtf(task_data->FromCurrencyID);
-		data["FromCurrencyUnit"] = task_data->FromCurrencyUnit;
-		data["ToCurrencyID"] = toUtf(task_data->ToCurrencyID);
-		data["ExchangeRate"] = task_data->ExchangeRate;
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryExchangeRate(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcExchangeRateField *task_data = (CThostFtdcExchangeRateField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["FromCurrencyID"] = toUtf(task_data->FromCurrencyID);
+        data["FromCurrencyUnit"] = task_data->FromCurrencyUnit;
+        data["ToCurrencyID"] = toUtf(task_data->ToCurrencyID);
+        data["ExchangeRate"] = task_data->ExchangeRate;
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryExchangeRate(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQrySecAgentACIDMap(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcSecAgentACIDMapField *task_data = (CThostFtdcSecAgentACIDMapField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["BrokerSecAgentID"] = toUtf(task_data->BrokerSecAgentID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQrySecAgentACIDMap(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcSecAgentACIDMapField *task_data = (CThostFtdcSecAgentACIDMapField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["BrokerSecAgentID"] = toUtf(task_data->BrokerSecAgentID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQrySecAgentACIDMap(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryProductExchRate(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcProductExchRateField *task_data = (CThostFtdcProductExchRateField*)task->task_data;
-		data["ProductID"] = toUtf(task_data->ProductID);
-		data["QuoteCurrencyID"] = toUtf(task_data->QuoteCurrencyID);
-		data["ExchangeRate"] = task_data->ExchangeRate;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryProductExchRate(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcProductExchRateField *task_data = (CThostFtdcProductExchRateField*)task->task_data;
+        data["ProductID"] = toUtf(task_data->ProductID);
+        data["QuoteCurrencyID"] = toUtf(task_data->QuoteCurrencyID);
+        data["ExchangeRate"] = task_data->ExchangeRate;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryProductExchRate(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryProductGroup(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcProductGroupField *task_data = (CThostFtdcProductGroupField*)task->task_data;
-		data["ProductID"] = toUtf(task_data->ProductID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ProductGroupID"] = toUtf(task_data->ProductGroupID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryProductGroup(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcProductGroupField *task_data = (CThostFtdcProductGroupField*)task->task_data;
+        data["ProductID"] = toUtf(task_data->ProductID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ProductGroupID"] = toUtf(task_data->ProductGroupID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryProductGroup(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryMMInstrumentCommissionRate(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcMMInstrumentCommissionRateField *task_data = (CThostFtdcMMInstrumentCommissionRateField*)task->task_data;
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["InvestorRange"] = task_data->InvestorRange;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["OpenRatioByMoney"] = task_data->OpenRatioByMoney;
-		data["OpenRatioByVolume"] = task_data->OpenRatioByVolume;
-		data["CloseRatioByMoney"] = task_data->CloseRatioByMoney;
-		data["CloseRatioByVolume"] = task_data->CloseRatioByVolume;
-		data["CloseTodayRatioByMoney"] = task_data->CloseTodayRatioByMoney;
-		data["CloseTodayRatioByVolume"] = task_data->CloseTodayRatioByVolume;
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryMMInstrumentCommissionRate(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcMMInstrumentCommissionRateField *task_data = (CThostFtdcMMInstrumentCommissionRateField*)task->task_data;
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["InvestorRange"] = task_data->InvestorRange;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["OpenRatioByMoney"] = task_data->OpenRatioByMoney;
+        data["OpenRatioByVolume"] = task_data->OpenRatioByVolume;
+        data["CloseRatioByMoney"] = task_data->CloseRatioByMoney;
+        data["CloseRatioByVolume"] = task_data->CloseRatioByVolume;
+        data["CloseTodayRatioByMoney"] = task_data->CloseTodayRatioByMoney;
+        data["CloseTodayRatioByVolume"] = task_data->CloseTodayRatioByVolume;
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryMMInstrumentCommissionRate(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryMMOptionInstrCommRate(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcMMOptionInstrCommRateField *task_data = (CThostFtdcMMOptionInstrCommRateField*)task->task_data;
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["InvestorRange"] = task_data->InvestorRange;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["OpenRatioByMoney"] = task_data->OpenRatioByMoney;
-		data["OpenRatioByVolume"] = task_data->OpenRatioByVolume;
-		data["CloseRatioByMoney"] = task_data->CloseRatioByMoney;
-		data["CloseRatioByVolume"] = task_data->CloseRatioByVolume;
-		data["CloseTodayRatioByMoney"] = task_data->CloseTodayRatioByMoney;
-		data["CloseTodayRatioByVolume"] = task_data->CloseTodayRatioByVolume;
-		data["StrikeRatioByMoney"] = task_data->StrikeRatioByMoney;
-		data["StrikeRatioByVolume"] = task_data->StrikeRatioByVolume;
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryMMOptionInstrCommRate(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcMMOptionInstrCommRateField *task_data = (CThostFtdcMMOptionInstrCommRateField*)task->task_data;
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["InvestorRange"] = task_data->InvestorRange;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["OpenRatioByMoney"] = task_data->OpenRatioByMoney;
+        data["OpenRatioByVolume"] = task_data->OpenRatioByVolume;
+        data["CloseRatioByMoney"] = task_data->CloseRatioByMoney;
+        data["CloseRatioByVolume"] = task_data->CloseRatioByVolume;
+        data["CloseTodayRatioByMoney"] = task_data->CloseTodayRatioByMoney;
+        data["CloseTodayRatioByVolume"] = task_data->CloseTodayRatioByVolume;
+        data["StrikeRatioByMoney"] = task_data->StrikeRatioByMoney;
+        data["StrikeRatioByVolume"] = task_data->StrikeRatioByVolume;
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryMMOptionInstrCommRate(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryInstrumentOrderCommRate(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInstrumentOrderCommRateField *task_data = (CThostFtdcInstrumentOrderCommRateField*)task->task_data;
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["InvestorRange"] = task_data->InvestorRange;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["OrderCommByVolume"] = task_data->OrderCommByVolume;
-		data["OrderActionCommByVolume"] = task_data->OrderActionCommByVolume;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryInstrumentOrderCommRate(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInstrumentOrderCommRateField *task_data = (CThostFtdcInstrumentOrderCommRateField*)task->task_data;
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["InvestorRange"] = task_data->InvestorRange;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["OrderCommByVolume"] = task_data->OrderCommByVolume;
+        data["OrderActionCommByVolume"] = task_data->OrderActionCommByVolume;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryInstrumentOrderCommRate(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryOptionInstrTradeCost(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcOptionInstrTradeCostField *task_data = (CThostFtdcOptionInstrTradeCostField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["FixedMargin"] = task_data->FixedMargin;
-		data["MiniMargin"] = task_data->MiniMargin;
-		data["Royalty"] = task_data->Royalty;
-		data["ExchFixedMargin"] = task_data->ExchFixedMargin;
-		data["ExchMiniMargin"] = task_data->ExchMiniMargin;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryOptionInstrTradeCost(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcOptionInstrTradeCostField *task_data = (CThostFtdcOptionInstrTradeCostField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["FixedMargin"] = task_data->FixedMargin;
+        data["MiniMargin"] = task_data->MiniMargin;
+        data["Royalty"] = task_data->Royalty;
+        data["ExchFixedMargin"] = task_data->ExchFixedMargin;
+        data["ExchMiniMargin"] = task_data->ExchMiniMargin;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryOptionInstrTradeCost(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryOptionInstrCommRate(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcOptionInstrCommRateField *task_data = (CThostFtdcOptionInstrCommRateField*)task->task_data;
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["InvestorRange"] = task_data->InvestorRange;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["OpenRatioByMoney"] = task_data->OpenRatioByMoney;
-		data["OpenRatioByVolume"] = task_data->OpenRatioByVolume;
-		data["CloseRatioByMoney"] = task_data->CloseRatioByMoney;
-		data["CloseRatioByVolume"] = task_data->CloseRatioByVolume;
-		data["CloseTodayRatioByMoney"] = task_data->CloseTodayRatioByMoney;
-		data["CloseTodayRatioByVolume"] = task_data->CloseTodayRatioByVolume;
-		data["StrikeRatioByMoney"] = task_data->StrikeRatioByMoney;
-		data["StrikeRatioByVolume"] = task_data->StrikeRatioByVolume;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryOptionInstrCommRate(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcOptionInstrCommRateField *task_data = (CThostFtdcOptionInstrCommRateField*)task->task_data;
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["InvestorRange"] = task_data->InvestorRange;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["OpenRatioByMoney"] = task_data->OpenRatioByMoney;
+        data["OpenRatioByVolume"] = task_data->OpenRatioByVolume;
+        data["CloseRatioByMoney"] = task_data->CloseRatioByMoney;
+        data["CloseRatioByVolume"] = task_data->CloseRatioByVolume;
+        data["CloseTodayRatioByMoney"] = task_data->CloseTodayRatioByMoney;
+        data["CloseTodayRatioByVolume"] = task_data->CloseTodayRatioByVolume;
+        data["StrikeRatioByMoney"] = task_data->StrikeRatioByMoney;
+        data["StrikeRatioByVolume"] = task_data->StrikeRatioByVolume;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryOptionInstrCommRate(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryExecOrder(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcExecOrderField *task_data = (CThostFtdcExecOrderField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["ExecOrderRef"] = toUtf(task_data->ExecOrderRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["Volume"] = task_data->Volume;
-		data["RequestID"] = task_data->RequestID;
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["OffsetFlag"] = task_data->OffsetFlag;
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["ActionType"] = task_data->ActionType;
-		data["PosiDirection"] = task_data->PosiDirection;
-		data["ReservePositionFlag"] = task_data->ReservePositionFlag;
-		data["CloseFlag"] = task_data->CloseFlag;
-		data["ExecOrderLocalID"] = toUtf(task_data->ExecOrderLocalID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ParticipantID"] = toUtf(task_data->ParticipantID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
-		data["TraderID"] = toUtf(task_data->TraderID);
-		data["InstallID"] = task_data->InstallID;
-		data["OrderSubmitStatus"] = task_data->OrderSubmitStatus;
-		data["NotifySequence"] = task_data->NotifySequence;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["SettlementID"] = task_data->SettlementID;
-		data["ExecOrderSysID"] = toUtf(task_data->ExecOrderSysID);
-		data["InsertDate"] = toUtf(task_data->InsertDate);
-		data["InsertTime"] = toUtf(task_data->InsertTime);
-		data["CancelTime"] = toUtf(task_data->CancelTime);
-		data["ExecResult"] = task_data->ExecResult;
-		data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
-		data["SequenceNo"] = task_data->SequenceNo;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
-		data["StatusMsg"] = toUtf(task_data->StatusMsg);
-		data["ActiveUserID"] = toUtf(task_data->ActiveUserID);
-		data["BrokerExecOrderSeq"] = task_data->BrokerExecOrderSeq;
-		data["BranchID"] = toUtf(task_data->BranchID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryExecOrder(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcExecOrderField *task_data = (CThostFtdcExecOrderField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["ExecOrderRef"] = toUtf(task_data->ExecOrderRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["Volume"] = task_data->Volume;
+        data["RequestID"] = task_data->RequestID;
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["OffsetFlag"] = task_data->OffsetFlag;
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["ActionType"] = task_data->ActionType;
+        data["PosiDirection"] = task_data->PosiDirection;
+        data["ReservePositionFlag"] = task_data->ReservePositionFlag;
+        data["CloseFlag"] = task_data->CloseFlag;
+        data["ExecOrderLocalID"] = toUtf(task_data->ExecOrderLocalID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ParticipantID"] = toUtf(task_data->ParticipantID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
+        data["TraderID"] = toUtf(task_data->TraderID);
+        data["InstallID"] = task_data->InstallID;
+        data["OrderSubmitStatus"] = task_data->OrderSubmitStatus;
+        data["NotifySequence"] = task_data->NotifySequence;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["SettlementID"] = task_data->SettlementID;
+        data["ExecOrderSysID"] = toUtf(task_data->ExecOrderSysID);
+        data["InsertDate"] = toUtf(task_data->InsertDate);
+        data["InsertTime"] = toUtf(task_data->InsertTime);
+        data["CancelTime"] = toUtf(task_data->CancelTime);
+        data["ExecResult"] = task_data->ExecResult;
+        data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
+        data["SequenceNo"] = task_data->SequenceNo;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
+        data["StatusMsg"] = toUtf(task_data->StatusMsg);
+        data["ActiveUserID"] = toUtf(task_data->ActiveUserID);
+        data["BrokerExecOrderSeq"] = task_data->BrokerExecOrderSeq;
+        data["BranchID"] = toUtf(task_data->BranchID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryExecOrder(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryForQuote(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcForQuoteField *task_data = (CThostFtdcForQuoteField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["ForQuoteRef"] = toUtf(task_data->ForQuoteRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["ForQuoteLocalID"] = toUtf(task_data->ForQuoteLocalID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ParticipantID"] = toUtf(task_data->ParticipantID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
-		data["TraderID"] = toUtf(task_data->TraderID);
-		data["InstallID"] = task_data->InstallID;
-		data["InsertDate"] = toUtf(task_data->InsertDate);
-		data["InsertTime"] = toUtf(task_data->InsertTime);
-		data["ForQuoteStatus"] = task_data->ForQuoteStatus;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["StatusMsg"] = toUtf(task_data->StatusMsg);
-		data["ActiveUserID"] = toUtf(task_data->ActiveUserID);
-		data["BrokerForQutoSeq"] = task_data->BrokerForQutoSeq;
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryForQuote(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcForQuoteField *task_data = (CThostFtdcForQuoteField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["ForQuoteRef"] = toUtf(task_data->ForQuoteRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["ForQuoteLocalID"] = toUtf(task_data->ForQuoteLocalID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ParticipantID"] = toUtf(task_data->ParticipantID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
+        data["TraderID"] = toUtf(task_data->TraderID);
+        data["InstallID"] = task_data->InstallID;
+        data["InsertDate"] = toUtf(task_data->InsertDate);
+        data["InsertTime"] = toUtf(task_data->InsertTime);
+        data["ForQuoteStatus"] = task_data->ForQuoteStatus;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["StatusMsg"] = toUtf(task_data->StatusMsg);
+        data["ActiveUserID"] = toUtf(task_data->ActiveUserID);
+        data["BrokerForQutoSeq"] = task_data->BrokerForQutoSeq;
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryForQuote(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryQuote(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcQuoteField *task_data = (CThostFtdcQuoteField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["QuoteRef"] = toUtf(task_data->QuoteRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["AskPrice"] = task_data->AskPrice;
-		data["BidPrice"] = task_data->BidPrice;
-		data["AskVolume"] = task_data->AskVolume;
-		data["BidVolume"] = task_data->BidVolume;
-		data["RequestID"] = task_data->RequestID;
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["AskOffsetFlag"] = task_data->AskOffsetFlag;
-		data["BidOffsetFlag"] = task_data->BidOffsetFlag;
-		data["AskHedgeFlag"] = task_data->AskHedgeFlag;
-		data["BidHedgeFlag"] = task_data->BidHedgeFlag;
-		data["QuoteLocalID"] = toUtf(task_data->QuoteLocalID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ParticipantID"] = toUtf(task_data->ParticipantID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
-		data["TraderID"] = toUtf(task_data->TraderID);
-		data["InstallID"] = task_data->InstallID;
-		data["NotifySequence"] = task_data->NotifySequence;
-		data["OrderSubmitStatus"] = task_data->OrderSubmitStatus;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["SettlementID"] = task_data->SettlementID;
-		data["QuoteSysID"] = toUtf(task_data->QuoteSysID);
-		data["InsertDate"] = toUtf(task_data->InsertDate);
-		data["InsertTime"] = toUtf(task_data->InsertTime);
-		data["CancelTime"] = toUtf(task_data->CancelTime);
-		data["QuoteStatus"] = task_data->QuoteStatus;
-		data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
-		data["SequenceNo"] = task_data->SequenceNo;
-		data["AskOrderSysID"] = toUtf(task_data->AskOrderSysID);
-		data["BidOrderSysID"] = toUtf(task_data->BidOrderSysID);
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
-		data["StatusMsg"] = toUtf(task_data->StatusMsg);
-		data["ActiveUserID"] = toUtf(task_data->ActiveUserID);
-		data["BrokerQuoteSeq"] = task_data->BrokerQuoteSeq;
-		data["AskOrderRef"] = toUtf(task_data->AskOrderRef);
-		data["BidOrderRef"] = toUtf(task_data->BidOrderRef);
-		data["ForQuoteSysID"] = toUtf(task_data->ForQuoteSysID);
-		data["BranchID"] = toUtf(task_data->BranchID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryQuote(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcQuoteField *task_data = (CThostFtdcQuoteField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["QuoteRef"] = toUtf(task_data->QuoteRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["AskPrice"] = task_data->AskPrice;
+        data["BidPrice"] = task_data->BidPrice;
+        data["AskVolume"] = task_data->AskVolume;
+        data["BidVolume"] = task_data->BidVolume;
+        data["RequestID"] = task_data->RequestID;
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["AskOffsetFlag"] = task_data->AskOffsetFlag;
+        data["BidOffsetFlag"] = task_data->BidOffsetFlag;
+        data["AskHedgeFlag"] = task_data->AskHedgeFlag;
+        data["BidHedgeFlag"] = task_data->BidHedgeFlag;
+        data["QuoteLocalID"] = toUtf(task_data->QuoteLocalID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ParticipantID"] = toUtf(task_data->ParticipantID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
+        data["TraderID"] = toUtf(task_data->TraderID);
+        data["InstallID"] = task_data->InstallID;
+        data["NotifySequence"] = task_data->NotifySequence;
+        data["OrderSubmitStatus"] = task_data->OrderSubmitStatus;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["SettlementID"] = task_data->SettlementID;
+        data["QuoteSysID"] = toUtf(task_data->QuoteSysID);
+        data["InsertDate"] = toUtf(task_data->InsertDate);
+        data["InsertTime"] = toUtf(task_data->InsertTime);
+        data["CancelTime"] = toUtf(task_data->CancelTime);
+        data["QuoteStatus"] = task_data->QuoteStatus;
+        data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
+        data["SequenceNo"] = task_data->SequenceNo;
+        data["AskOrderSysID"] = toUtf(task_data->AskOrderSysID);
+        data["BidOrderSysID"] = toUtf(task_data->BidOrderSysID);
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
+        data["StatusMsg"] = toUtf(task_data->StatusMsg);
+        data["ActiveUserID"] = toUtf(task_data->ActiveUserID);
+        data["BrokerQuoteSeq"] = task_data->BrokerQuoteSeq;
+        data["AskOrderRef"] = toUtf(task_data->AskOrderRef);
+        data["BidOrderRef"] = toUtf(task_data->BidOrderRef);
+        data["ForQuoteSysID"] = toUtf(task_data->ForQuoteSysID);
+        data["BranchID"] = toUtf(task_data->BranchID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryQuote(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryOptionSelfClose(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcOptionSelfCloseField *task_data = (CThostFtdcOptionSelfCloseField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["OptionSelfCloseRef"] = toUtf(task_data->OptionSelfCloseRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["Volume"] = task_data->Volume;
-		data["RequestID"] = task_data->RequestID;
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["OptSelfCloseFlag"] = task_data->OptSelfCloseFlag;
-		data["OptionSelfCloseLocalID"] = toUtf(task_data->OptionSelfCloseLocalID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ParticipantID"] = toUtf(task_data->ParticipantID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
-		data["TraderID"] = toUtf(task_data->TraderID);
-		data["InstallID"] = task_data->InstallID;
-		data["OrderSubmitStatus"] = task_data->OrderSubmitStatus;
-		data["NotifySequence"] = task_data->NotifySequence;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["SettlementID"] = task_data->SettlementID;
-		data["OptionSelfCloseSysID"] = toUtf(task_data->OptionSelfCloseSysID);
-		data["InsertDate"] = toUtf(task_data->InsertDate);
-		data["InsertTime"] = toUtf(task_data->InsertTime);
-		data["CancelTime"] = toUtf(task_data->CancelTime);
-		data["ExecResult"] = task_data->ExecResult;
-		data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
-		data["SequenceNo"] = task_data->SequenceNo;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
-		data["StatusMsg"] = toUtf(task_data->StatusMsg);
-		data["ActiveUserID"] = toUtf(task_data->ActiveUserID);
-		data["BrokerOptionSelfCloseSeq"] = task_data->BrokerOptionSelfCloseSeq;
-		data["BranchID"] = toUtf(task_data->BranchID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryOptionSelfClose(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcOptionSelfCloseField *task_data = (CThostFtdcOptionSelfCloseField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["OptionSelfCloseRef"] = toUtf(task_data->OptionSelfCloseRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["Volume"] = task_data->Volume;
+        data["RequestID"] = task_data->RequestID;
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["OptSelfCloseFlag"] = task_data->OptSelfCloseFlag;
+        data["OptionSelfCloseLocalID"] = toUtf(task_data->OptionSelfCloseLocalID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ParticipantID"] = toUtf(task_data->ParticipantID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
+        data["TraderID"] = toUtf(task_data->TraderID);
+        data["InstallID"] = task_data->InstallID;
+        data["OrderSubmitStatus"] = task_data->OrderSubmitStatus;
+        data["NotifySequence"] = task_data->NotifySequence;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["SettlementID"] = task_data->SettlementID;
+        data["OptionSelfCloseSysID"] = toUtf(task_data->OptionSelfCloseSysID);
+        data["InsertDate"] = toUtf(task_data->InsertDate);
+        data["InsertTime"] = toUtf(task_data->InsertTime);
+        data["CancelTime"] = toUtf(task_data->CancelTime);
+        data["ExecResult"] = task_data->ExecResult;
+        data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
+        data["SequenceNo"] = task_data->SequenceNo;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
+        data["StatusMsg"] = toUtf(task_data->StatusMsg);
+        data["ActiveUserID"] = toUtf(task_data->ActiveUserID);
+        data["BrokerOptionSelfCloseSeq"] = task_data->BrokerOptionSelfCloseSeq;
+        data["BranchID"] = toUtf(task_data->BranchID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryOptionSelfClose(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryInvestUnit(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInvestUnitField *task_data = (CThostFtdcInvestUnitField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["InvestorUnitName"] = toUtf(task_data->InvestorUnitName);
-		data["InvestorGroupID"] = toUtf(task_data->InvestorGroupID);
-		data["CommModelID"] = toUtf(task_data->CommModelID);
-		data["MarginModelID"] = toUtf(task_data->MarginModelID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryInvestUnit(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInvestUnitField *task_data = (CThostFtdcInvestUnitField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["InvestorUnitName"] = toUtf(task_data->InvestorUnitName);
+        data["InvestorGroupID"] = toUtf(task_data->InvestorGroupID);
+        data["CommModelID"] = toUtf(task_data->CommModelID);
+        data["MarginModelID"] = toUtf(task_data->MarginModelID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryInvestUnit(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryCombInstrumentGuard(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcCombInstrumentGuardField *task_data = (CThostFtdcCombInstrumentGuardField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["GuarantRatio"] = task_data->GuarantRatio;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryCombInstrumentGuard(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcCombInstrumentGuardField *task_data = (CThostFtdcCombInstrumentGuardField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["GuarantRatio"] = task_data->GuarantRatio;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryCombInstrumentGuard(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryCombAction(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcCombActionField *task_data = (CThostFtdcCombActionField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["CombActionRef"] = toUtf(task_data->CombActionRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["Direction"] = task_data->Direction;
-		data["Volume"] = task_data->Volume;
-		data["CombDirection"] = task_data->CombDirection;
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["ActionLocalID"] = toUtf(task_data->ActionLocalID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ParticipantID"] = toUtf(task_data->ParticipantID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
-		data["TraderID"] = toUtf(task_data->TraderID);
-		data["InstallID"] = task_data->InstallID;
-		data["ActionStatus"] = task_data->ActionStatus;
-		data["NotifySequence"] = task_data->NotifySequence;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["SettlementID"] = task_data->SettlementID;
-		data["SequenceNo"] = task_data->SequenceNo;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
-		data["StatusMsg"] = toUtf(task_data->StatusMsg);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		data["ComTradeID"] = toUtf(task_data->ComTradeID);
-		data["BranchID"] = toUtf(task_data->BranchID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryCombAction(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcCombActionField *task_data = (CThostFtdcCombActionField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["CombActionRef"] = toUtf(task_data->CombActionRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["Direction"] = task_data->Direction;
+        data["Volume"] = task_data->Volume;
+        data["CombDirection"] = task_data->CombDirection;
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["ActionLocalID"] = toUtf(task_data->ActionLocalID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ParticipantID"] = toUtf(task_data->ParticipantID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
+        data["TraderID"] = toUtf(task_data->TraderID);
+        data["InstallID"] = task_data->InstallID;
+        data["ActionStatus"] = task_data->ActionStatus;
+        data["NotifySequence"] = task_data->NotifySequence;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["SettlementID"] = task_data->SettlementID;
+        data["SequenceNo"] = task_data->SequenceNo;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
+        data["StatusMsg"] = toUtf(task_data->StatusMsg);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        data["ComTradeID"] = toUtf(task_data->ComTradeID);
+        data["BranchID"] = toUtf(task_data->BranchID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryCombAction(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryTransferSerial(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcTransferSerialField *task_data = (CThostFtdcTransferSerialField*)task->task_data;
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["SessionID"] = task_data->SessionID;
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BankAccType"] = task_data->BankAccType;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["FutureAccType"] = task_data->FutureAccType;
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["FutureSerial"] = task_data->FutureSerial;
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["TradeAmount"] = task_data->TradeAmount;
-		data["CustFee"] = task_data->CustFee;
-		data["BrokerFee"] = task_data->BrokerFee;
-		data["AvailabilityFlag"] = task_data->AvailabilityFlag;
-		data["OperatorCode"] = toUtf(task_data->OperatorCode);
-		data["BankNewAccount"] = toUtf(task_data->BankNewAccount);
-		data["ErrorID"] = task_data->ErrorID;
-		data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryTransferSerial(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcTransferSerialField *task_data = (CThostFtdcTransferSerialField*)task->task_data;
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["SessionID"] = task_data->SessionID;
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BankAccType"] = task_data->BankAccType;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["FutureAccType"] = task_data->FutureAccType;
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["FutureSerial"] = task_data->FutureSerial;
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["TradeAmount"] = task_data->TradeAmount;
+        data["CustFee"] = task_data->CustFee;
+        data["BrokerFee"] = task_data->BrokerFee;
+        data["AvailabilityFlag"] = task_data->AvailabilityFlag;
+        data["OperatorCode"] = toUtf(task_data->OperatorCode);
+        data["BankNewAccount"] = toUtf(task_data->BankNewAccount);
+        data["ErrorID"] = task_data->ErrorID;
+        data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryTransferSerial(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryAccountregister(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcAccountregisterField *task_data = (CThostFtdcAccountregisterField*)task->task_data;
-		data["TradeDay"] = toUtf(task_data->TradeDay);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["OpenOrDestroy"] = task_data->OpenOrDestroy;
-		data["RegDate"] = toUtf(task_data->RegDate);
-		data["OutDate"] = toUtf(task_data->OutDate);
-		data["TID"] = task_data->TID;
-		data["CustType"] = task_data->CustType;
-		data["BankAccType"] = task_data->BankAccType;
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryAccountregister(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcAccountregisterField *task_data = (CThostFtdcAccountregisterField*)task->task_data;
+        data["TradeDay"] = toUtf(task_data->TradeDay);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["OpenOrDestroy"] = task_data->OpenOrDestroy;
+        data["RegDate"] = toUtf(task_data->RegDate);
+        data["OutDate"] = toUtf(task_data->OutDate);
+        data["TID"] = task_data->TID;
+        data["CustType"] = task_data->CustType;
+        data["BankAccType"] = task_data->BankAccType;
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryAccountregister(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspError(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspError(error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspError(error, task->task_id, task->task_last);
 };
 
 void TdApi::processRtnOrder(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcOrderField *task_data = (CThostFtdcOrderField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["OrderRef"] = toUtf(task_data->OrderRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["OrderPriceType"] = task_data->OrderPriceType;
-		data["Direction"] = task_data->Direction;
-		data["CombOffsetFlag"] = toUtf(task_data->CombOffsetFlag);
-		data["CombHedgeFlag"] = toUtf(task_data->CombHedgeFlag);
-		data["LimitPrice"] = task_data->LimitPrice;
-		data["VolumeTotalOriginal"] = task_data->VolumeTotalOriginal;
-		data["TimeCondition"] = task_data->TimeCondition;
-		data["GTDDate"] = toUtf(task_data->GTDDate);
-		data["VolumeCondition"] = task_data->VolumeCondition;
-		data["MinVolume"] = task_data->MinVolume;
-		data["ContingentCondition"] = task_data->ContingentCondition;
-		data["StopPrice"] = task_data->StopPrice;
-		data["ForceCloseReason"] = task_data->ForceCloseReason;
-		data["IsAutoSuspend"] = task_data->IsAutoSuspend;
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["RequestID"] = task_data->RequestID;
-		data["OrderLocalID"] = toUtf(task_data->OrderLocalID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ParticipantID"] = toUtf(task_data->ParticipantID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
-		data["TraderID"] = toUtf(task_data->TraderID);
-		data["InstallID"] = task_data->InstallID;
-		data["OrderSubmitStatus"] = task_data->OrderSubmitStatus;
-		data["NotifySequence"] = task_data->NotifySequence;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["SettlementID"] = task_data->SettlementID;
-		data["OrderSysID"] = toUtf(task_data->OrderSysID);
-		data["OrderSource"] = task_data->OrderSource;
-		data["OrderStatus"] = task_data->OrderStatus;
-		data["OrderType"] = task_data->OrderType;
-		data["VolumeTraded"] = task_data->VolumeTraded;
-		data["VolumeTotal"] = task_data->VolumeTotal;
-		data["InsertDate"] = toUtf(task_data->InsertDate);
-		data["InsertTime"] = toUtf(task_data->InsertTime);
-		data["ActiveTime"] = toUtf(task_data->ActiveTime);
-		data["SuspendTime"] = toUtf(task_data->SuspendTime);
-		data["UpdateTime"] = toUtf(task_data->UpdateTime);
-		data["CancelTime"] = toUtf(task_data->CancelTime);
-		data["ActiveTraderID"] = toUtf(task_data->ActiveTraderID);
-		data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
-		data["SequenceNo"] = task_data->SequenceNo;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
-		data["StatusMsg"] = toUtf(task_data->StatusMsg);
-		data["UserForceClose"] = task_data->UserForceClose;
-		data["ActiveUserID"] = toUtf(task_data->ActiveUserID);
-		data["BrokerOrderSeq"] = task_data->BrokerOrderSeq;
-		data["RelativeOrderSysID"] = toUtf(task_data->RelativeOrderSysID);
-		data["ZCETotalTradedVolume"] = task_data->ZCETotalTradedVolume;
-		data["IsSwapOrder"] = task_data->IsSwapOrder;
-		data["BranchID"] = toUtf(task_data->BranchID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	this->onRtnOrder(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcOrderField *task_data = (CThostFtdcOrderField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["OrderRef"] = toUtf(task_data->OrderRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["OrderPriceType"] = task_data->OrderPriceType;
+        data["Direction"] = task_data->Direction;
+        data["CombOffsetFlag"] = toUtf(task_data->CombOffsetFlag);
+        data["CombHedgeFlag"] = toUtf(task_data->CombHedgeFlag);
+        data["LimitPrice"] = task_data->LimitPrice;
+        data["VolumeTotalOriginal"] = task_data->VolumeTotalOriginal;
+        data["TimeCondition"] = task_data->TimeCondition;
+        data["GTDDate"] = toUtf(task_data->GTDDate);
+        data["VolumeCondition"] = task_data->VolumeCondition;
+        data["MinVolume"] = task_data->MinVolume;
+        data["ContingentCondition"] = task_data->ContingentCondition;
+        data["StopPrice"] = task_data->StopPrice;
+        data["ForceCloseReason"] = task_data->ForceCloseReason;
+        data["IsAutoSuspend"] = task_data->IsAutoSuspend;
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["RequestID"] = task_data->RequestID;
+        data["OrderLocalID"] = toUtf(task_data->OrderLocalID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ParticipantID"] = toUtf(task_data->ParticipantID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
+        data["TraderID"] = toUtf(task_data->TraderID);
+        data["InstallID"] = task_data->InstallID;
+        data["OrderSubmitStatus"] = task_data->OrderSubmitStatus;
+        data["NotifySequence"] = task_data->NotifySequence;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["SettlementID"] = task_data->SettlementID;
+        data["OrderSysID"] = toUtf(task_data->OrderSysID);
+        data["OrderSource"] = task_data->OrderSource;
+        data["OrderStatus"] = task_data->OrderStatus;
+        data["OrderType"] = task_data->OrderType;
+        data["VolumeTraded"] = task_data->VolumeTraded;
+        data["VolumeTotal"] = task_data->VolumeTotal;
+        data["InsertDate"] = toUtf(task_data->InsertDate);
+        data["InsertTime"] = toUtf(task_data->InsertTime);
+        data["ActiveTime"] = toUtf(task_data->ActiveTime);
+        data["SuspendTime"] = toUtf(task_data->SuspendTime);
+        data["UpdateTime"] = toUtf(task_data->UpdateTime);
+        data["CancelTime"] = toUtf(task_data->CancelTime);
+        data["ActiveTraderID"] = toUtf(task_data->ActiveTraderID);
+        data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
+        data["SequenceNo"] = task_data->SequenceNo;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
+        data["StatusMsg"] = toUtf(task_data->StatusMsg);
+        data["UserForceClose"] = task_data->UserForceClose;
+        data["ActiveUserID"] = toUtf(task_data->ActiveUserID);
+        data["BrokerOrderSeq"] = task_data->BrokerOrderSeq;
+        data["RelativeOrderSysID"] = toUtf(task_data->RelativeOrderSysID);
+        data["ZCETotalTradedVolume"] = task_data->ZCETotalTradedVolume;
+        data["IsSwapOrder"] = task_data->IsSwapOrder;
+        data["BranchID"] = toUtf(task_data->BranchID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    this->onRtnOrder(data);
 };
 
 void TdApi::processRtnTrade(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcTradeField *task_data = (CThostFtdcTradeField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["OrderRef"] = toUtf(task_data->OrderRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["TradeID"] = toUtf(task_data->TradeID);
-		data["Direction"] = task_data->Direction;
-		data["OrderSysID"] = toUtf(task_data->OrderSysID);
-		data["ParticipantID"] = toUtf(task_data->ParticipantID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["TradingRole"] = task_data->TradingRole;
-		data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
-		data["OffsetFlag"] = task_data->OffsetFlag;
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["Price"] = task_data->Price;
-		data["Volume"] = task_data->Volume;
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["TradeType"] = task_data->TradeType;
-		data["PriceSource"] = task_data->PriceSource;
-		data["TraderID"] = toUtf(task_data->TraderID);
-		data["OrderLocalID"] = toUtf(task_data->OrderLocalID);
-		data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["SequenceNo"] = task_data->SequenceNo;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["SettlementID"] = task_data->SettlementID;
-		data["BrokerOrderSeq"] = task_data->BrokerOrderSeq;
-		data["TradeSource"] = task_data->TradeSource;
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	this->onRtnTrade(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcTradeField *task_data = (CThostFtdcTradeField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["OrderRef"] = toUtf(task_data->OrderRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["TradeID"] = toUtf(task_data->TradeID);
+        data["Direction"] = task_data->Direction;
+        data["OrderSysID"] = toUtf(task_data->OrderSysID);
+        data["ParticipantID"] = toUtf(task_data->ParticipantID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["TradingRole"] = task_data->TradingRole;
+        data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
+        data["OffsetFlag"] = task_data->OffsetFlag;
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["Price"] = task_data->Price;
+        data["Volume"] = task_data->Volume;
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["TradeType"] = task_data->TradeType;
+        data["PriceSource"] = task_data->PriceSource;
+        data["TraderID"] = toUtf(task_data->TraderID);
+        data["OrderLocalID"] = toUtf(task_data->OrderLocalID);
+        data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["SequenceNo"] = task_data->SequenceNo;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["SettlementID"] = task_data->SettlementID;
+        data["BrokerOrderSeq"] = task_data->BrokerOrderSeq;
+        data["TradeSource"] = task_data->TradeSource;
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    this->onRtnTrade(data);
 };
 
 void TdApi::processErrRtnOrderInsert(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInputOrderField *task_data = (CThostFtdcInputOrderField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["OrderRef"] = toUtf(task_data->OrderRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["OrderPriceType"] = task_data->OrderPriceType;
-		data["Direction"] = task_data->Direction;
-		data["CombOffsetFlag"] = toUtf(task_data->CombOffsetFlag);
-		data["CombHedgeFlag"] = toUtf(task_data->CombHedgeFlag);
-		data["LimitPrice"] = task_data->LimitPrice;
-		data["VolumeTotalOriginal"] = task_data->VolumeTotalOriginal;
-		data["TimeCondition"] = task_data->TimeCondition;
-		data["GTDDate"] = toUtf(task_data->GTDDate);
-		data["VolumeCondition"] = task_data->VolumeCondition;
-		data["MinVolume"] = task_data->MinVolume;
-		data["ContingentCondition"] = task_data->ContingentCondition;
-		data["StopPrice"] = task_data->StopPrice;
-		data["ForceCloseReason"] = task_data->ForceCloseReason;
-		data["IsAutoSuspend"] = task_data->IsAutoSuspend;
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["RequestID"] = task_data->RequestID;
-		data["UserForceClose"] = task_data->UserForceClose;
-		data["IsSwapOrder"] = task_data->IsSwapOrder;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onErrRtnOrderInsert(data, error);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInputOrderField *task_data = (CThostFtdcInputOrderField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["OrderRef"] = toUtf(task_data->OrderRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["OrderPriceType"] = task_data->OrderPriceType;
+        data["Direction"] = task_data->Direction;
+        data["CombOffsetFlag"] = toUtf(task_data->CombOffsetFlag);
+        data["CombHedgeFlag"] = toUtf(task_data->CombHedgeFlag);
+        data["LimitPrice"] = task_data->LimitPrice;
+        data["VolumeTotalOriginal"] = task_data->VolumeTotalOriginal;
+        data["TimeCondition"] = task_data->TimeCondition;
+        data["GTDDate"] = toUtf(task_data->GTDDate);
+        data["VolumeCondition"] = task_data->VolumeCondition;
+        data["MinVolume"] = task_data->MinVolume;
+        data["ContingentCondition"] = task_data->ContingentCondition;
+        data["StopPrice"] = task_data->StopPrice;
+        data["ForceCloseReason"] = task_data->ForceCloseReason;
+        data["IsAutoSuspend"] = task_data->IsAutoSuspend;
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["RequestID"] = task_data->RequestID;
+        data["UserForceClose"] = task_data->UserForceClose;
+        data["IsSwapOrder"] = task_data->IsSwapOrder;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onErrRtnOrderInsert(data, error);
 };
 
 void TdApi::processErrRtnOrderAction(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcOrderActionField *task_data = (CThostFtdcOrderActionField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["OrderActionRef"] = task_data->OrderActionRef;
-		data["OrderRef"] = toUtf(task_data->OrderRef);
-		data["RequestID"] = task_data->RequestID;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["OrderSysID"] = toUtf(task_data->OrderSysID);
-		data["ActionFlag"] = task_data->ActionFlag;
-		data["LimitPrice"] = task_data->LimitPrice;
-		data["VolumeChange"] = task_data->VolumeChange;
-		data["ActionDate"] = toUtf(task_data->ActionDate);
-		data["ActionTime"] = toUtf(task_data->ActionTime);
-		data["TraderID"] = toUtf(task_data->TraderID);
-		data["InstallID"] = task_data->InstallID;
-		data["OrderLocalID"] = toUtf(task_data->OrderLocalID);
-		data["ActionLocalID"] = toUtf(task_data->ActionLocalID);
-		data["ParticipantID"] = toUtf(task_data->ParticipantID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["OrderActionStatus"] = task_data->OrderActionStatus;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["StatusMsg"] = toUtf(task_data->StatusMsg);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["BranchID"] = toUtf(task_data->BranchID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onErrRtnOrderAction(data, error);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcOrderActionField *task_data = (CThostFtdcOrderActionField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["OrderActionRef"] = task_data->OrderActionRef;
+        data["OrderRef"] = toUtf(task_data->OrderRef);
+        data["RequestID"] = task_data->RequestID;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["OrderSysID"] = toUtf(task_data->OrderSysID);
+        data["ActionFlag"] = task_data->ActionFlag;
+        data["LimitPrice"] = task_data->LimitPrice;
+        data["VolumeChange"] = task_data->VolumeChange;
+        data["ActionDate"] = toUtf(task_data->ActionDate);
+        data["ActionTime"] = toUtf(task_data->ActionTime);
+        data["TraderID"] = toUtf(task_data->TraderID);
+        data["InstallID"] = task_data->InstallID;
+        data["OrderLocalID"] = toUtf(task_data->OrderLocalID);
+        data["ActionLocalID"] = toUtf(task_data->ActionLocalID);
+        data["ParticipantID"] = toUtf(task_data->ParticipantID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["OrderActionStatus"] = task_data->OrderActionStatus;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["StatusMsg"] = toUtf(task_data->StatusMsg);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["BranchID"] = toUtf(task_data->BranchID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onErrRtnOrderAction(data, error);
 };
 
 void TdApi::processRtnInstrumentStatus(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInstrumentStatusField *task_data = (CThostFtdcInstrumentStatusField*)task->task_data;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
-		data["SettlementGroupID"] = toUtf(task_data->SettlementGroupID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["InstrumentStatus"] = task_data->InstrumentStatus;
-		data["TradingSegmentSN"] = task_data->TradingSegmentSN;
-		data["EnterTime"] = toUtf(task_data->EnterTime);
-		data["EnterReason"] = task_data->EnterReason;
-		delete task->task_data;
-	}
-	this->onRtnInstrumentStatus(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInstrumentStatusField *task_data = (CThostFtdcInstrumentStatusField*)task->task_data;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
+        data["SettlementGroupID"] = toUtf(task_data->SettlementGroupID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["InstrumentStatus"] = task_data->InstrumentStatus;
+        data["TradingSegmentSN"] = task_data->TradingSegmentSN;
+        data["EnterTime"] = toUtf(task_data->EnterTime);
+        data["EnterReason"] = task_data->EnterReason;
+        delete task->task_data;
+    }
+    this->onRtnInstrumentStatus(data);
 };
 
 void TdApi::processRtnBulletin(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcBulletinField *task_data = (CThostFtdcBulletinField*)task->task_data;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["BulletinID"] = task_data->BulletinID;
-		data["SequenceNo"] = task_data->SequenceNo;
-		data["NewsType"] = toUtf(task_data->NewsType);
-		data["NewsUrgency"] = task_data->NewsUrgency;
-		data["SendTime"] = toUtf(task_data->SendTime);
-		data["Abstract"] = toUtf(task_data->Abstract);
-		data["ComeFrom"] = toUtf(task_data->ComeFrom);
-		data["Content"] = toUtf(task_data->Content);
-		data["URLLink"] = toUtf(task_data->URLLink);
-		data["MarketID"] = toUtf(task_data->MarketID);
-		delete task->task_data;
-	}
-	this->onRtnBulletin(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcBulletinField *task_data = (CThostFtdcBulletinField*)task->task_data;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["BulletinID"] = task_data->BulletinID;
+        data["SequenceNo"] = task_data->SequenceNo;
+        data["NewsType"] = toUtf(task_data->NewsType);
+        data["NewsUrgency"] = task_data->NewsUrgency;
+        data["SendTime"] = toUtf(task_data->SendTime);
+        data["Abstract"] = toUtf(task_data->Abstract);
+        data["ComeFrom"] = toUtf(task_data->ComeFrom);
+        data["Content"] = toUtf(task_data->Content);
+        data["URLLink"] = toUtf(task_data->URLLink);
+        data["MarketID"] = toUtf(task_data->MarketID);
+        delete task->task_data;
+    }
+    this->onRtnBulletin(data);
 };
 
 void TdApi::processRtnTradingNotice(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcTradingNoticeInfoField *task_data = (CThostFtdcTradingNoticeInfoField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["SendTime"] = toUtf(task_data->SendTime);
-		data["FieldContent"] = toUtf(task_data->FieldContent);
-		data["SequenceSeries"] = task_data->SequenceSeries;
-		data["SequenceNo"] = task_data->SequenceNo;
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	this->onRtnTradingNotice(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcTradingNoticeInfoField *task_data = (CThostFtdcTradingNoticeInfoField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["SendTime"] = toUtf(task_data->SendTime);
+        data["FieldContent"] = toUtf(task_data->FieldContent);
+        data["SequenceSeries"] = task_data->SequenceSeries;
+        data["SequenceNo"] = task_data->SequenceNo;
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    this->onRtnTradingNotice(data);
 };
 
 void TdApi::processRtnErrorConditionalOrder(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcErrorConditionalOrderField *task_data = (CThostFtdcErrorConditionalOrderField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["OrderRef"] = toUtf(task_data->OrderRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["OrderPriceType"] = task_data->OrderPriceType;
-		data["Direction"] = task_data->Direction;
-		data["CombOffsetFlag"] = toUtf(task_data->CombOffsetFlag);
-		data["CombHedgeFlag"] = toUtf(task_data->CombHedgeFlag);
-		data["LimitPrice"] = task_data->LimitPrice;
-		data["VolumeTotalOriginal"] = task_data->VolumeTotalOriginal;
-		data["TimeCondition"] = task_data->TimeCondition;
-		data["GTDDate"] = toUtf(task_data->GTDDate);
-		data["VolumeCondition"] = task_data->VolumeCondition;
-		data["MinVolume"] = task_data->MinVolume;
-		data["ContingentCondition"] = task_data->ContingentCondition;
-		data["StopPrice"] = task_data->StopPrice;
-		data["ForceCloseReason"] = task_data->ForceCloseReason;
-		data["IsAutoSuspend"] = task_data->IsAutoSuspend;
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["RequestID"] = task_data->RequestID;
-		data["OrderLocalID"] = toUtf(task_data->OrderLocalID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ParticipantID"] = toUtf(task_data->ParticipantID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
-		data["TraderID"] = toUtf(task_data->TraderID);
-		data["InstallID"] = task_data->InstallID;
-		data["OrderSubmitStatus"] = task_data->OrderSubmitStatus;
-		data["NotifySequence"] = task_data->NotifySequence;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["SettlementID"] = task_data->SettlementID;
-		data["OrderSysID"] = toUtf(task_data->OrderSysID);
-		data["OrderSource"] = task_data->OrderSource;
-		data["OrderStatus"] = task_data->OrderStatus;
-		data["OrderType"] = task_data->OrderType;
-		data["VolumeTraded"] = task_data->VolumeTraded;
-		data["VolumeTotal"] = task_data->VolumeTotal;
-		data["InsertDate"] = toUtf(task_data->InsertDate);
-		data["InsertTime"] = toUtf(task_data->InsertTime);
-		data["ActiveTime"] = toUtf(task_data->ActiveTime);
-		data["SuspendTime"] = toUtf(task_data->SuspendTime);
-		data["UpdateTime"] = toUtf(task_data->UpdateTime);
-		data["CancelTime"] = toUtf(task_data->CancelTime);
-		data["ActiveTraderID"] = toUtf(task_data->ActiveTraderID);
-		data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
-		data["SequenceNo"] = task_data->SequenceNo;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
-		data["StatusMsg"] = toUtf(task_data->StatusMsg);
-		data["UserForceClose"] = task_data->UserForceClose;
-		data["ActiveUserID"] = toUtf(task_data->ActiveUserID);
-		data["BrokerOrderSeq"] = task_data->BrokerOrderSeq;
-		data["RelativeOrderSysID"] = toUtf(task_data->RelativeOrderSysID);
-		data["ZCETotalTradedVolume"] = task_data->ZCETotalTradedVolume;
-		data["ErrorID"] = task_data->ErrorID;
-		data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
-		data["IsSwapOrder"] = task_data->IsSwapOrder;
-		data["BranchID"] = toUtf(task_data->BranchID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	this->onRtnErrorConditionalOrder(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcErrorConditionalOrderField *task_data = (CThostFtdcErrorConditionalOrderField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["OrderRef"] = toUtf(task_data->OrderRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["OrderPriceType"] = task_data->OrderPriceType;
+        data["Direction"] = task_data->Direction;
+        data["CombOffsetFlag"] = toUtf(task_data->CombOffsetFlag);
+        data["CombHedgeFlag"] = toUtf(task_data->CombHedgeFlag);
+        data["LimitPrice"] = task_data->LimitPrice;
+        data["VolumeTotalOriginal"] = task_data->VolumeTotalOriginal;
+        data["TimeCondition"] = task_data->TimeCondition;
+        data["GTDDate"] = toUtf(task_data->GTDDate);
+        data["VolumeCondition"] = task_data->VolumeCondition;
+        data["MinVolume"] = task_data->MinVolume;
+        data["ContingentCondition"] = task_data->ContingentCondition;
+        data["StopPrice"] = task_data->StopPrice;
+        data["ForceCloseReason"] = task_data->ForceCloseReason;
+        data["IsAutoSuspend"] = task_data->IsAutoSuspend;
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["RequestID"] = task_data->RequestID;
+        data["OrderLocalID"] = toUtf(task_data->OrderLocalID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ParticipantID"] = toUtf(task_data->ParticipantID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
+        data["TraderID"] = toUtf(task_data->TraderID);
+        data["InstallID"] = task_data->InstallID;
+        data["OrderSubmitStatus"] = task_data->OrderSubmitStatus;
+        data["NotifySequence"] = task_data->NotifySequence;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["SettlementID"] = task_data->SettlementID;
+        data["OrderSysID"] = toUtf(task_data->OrderSysID);
+        data["OrderSource"] = task_data->OrderSource;
+        data["OrderStatus"] = task_data->OrderStatus;
+        data["OrderType"] = task_data->OrderType;
+        data["VolumeTraded"] = task_data->VolumeTraded;
+        data["VolumeTotal"] = task_data->VolumeTotal;
+        data["InsertDate"] = toUtf(task_data->InsertDate);
+        data["InsertTime"] = toUtf(task_data->InsertTime);
+        data["ActiveTime"] = toUtf(task_data->ActiveTime);
+        data["SuspendTime"] = toUtf(task_data->SuspendTime);
+        data["UpdateTime"] = toUtf(task_data->UpdateTime);
+        data["CancelTime"] = toUtf(task_data->CancelTime);
+        data["ActiveTraderID"] = toUtf(task_data->ActiveTraderID);
+        data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
+        data["SequenceNo"] = task_data->SequenceNo;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
+        data["StatusMsg"] = toUtf(task_data->StatusMsg);
+        data["UserForceClose"] = task_data->UserForceClose;
+        data["ActiveUserID"] = toUtf(task_data->ActiveUserID);
+        data["BrokerOrderSeq"] = task_data->BrokerOrderSeq;
+        data["RelativeOrderSysID"] = toUtf(task_data->RelativeOrderSysID);
+        data["ZCETotalTradedVolume"] = task_data->ZCETotalTradedVolume;
+        data["ErrorID"] = task_data->ErrorID;
+        data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
+        data["IsSwapOrder"] = task_data->IsSwapOrder;
+        data["BranchID"] = toUtf(task_data->BranchID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    this->onRtnErrorConditionalOrder(data);
 };
 
 void TdApi::processRtnExecOrder(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcExecOrderField *task_data = (CThostFtdcExecOrderField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["ExecOrderRef"] = toUtf(task_data->ExecOrderRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["Volume"] = task_data->Volume;
-		data["RequestID"] = task_data->RequestID;
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["OffsetFlag"] = task_data->OffsetFlag;
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["ActionType"] = task_data->ActionType;
-		data["PosiDirection"] = task_data->PosiDirection;
-		data["ReservePositionFlag"] = task_data->ReservePositionFlag;
-		data["CloseFlag"] = task_data->CloseFlag;
-		data["ExecOrderLocalID"] = toUtf(task_data->ExecOrderLocalID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ParticipantID"] = toUtf(task_data->ParticipantID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
-		data["TraderID"] = toUtf(task_data->TraderID);
-		data["InstallID"] = task_data->InstallID;
-		data["OrderSubmitStatus"] = task_data->OrderSubmitStatus;
-		data["NotifySequence"] = task_data->NotifySequence;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["SettlementID"] = task_data->SettlementID;
-		data["ExecOrderSysID"] = toUtf(task_data->ExecOrderSysID);
-		data["InsertDate"] = toUtf(task_data->InsertDate);
-		data["InsertTime"] = toUtf(task_data->InsertTime);
-		data["CancelTime"] = toUtf(task_data->CancelTime);
-		data["ExecResult"] = task_data->ExecResult;
-		data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
-		data["SequenceNo"] = task_data->SequenceNo;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
-		data["StatusMsg"] = toUtf(task_data->StatusMsg);
-		data["ActiveUserID"] = toUtf(task_data->ActiveUserID);
-		data["BrokerExecOrderSeq"] = task_data->BrokerExecOrderSeq;
-		data["BranchID"] = toUtf(task_data->BranchID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	this->onRtnExecOrder(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcExecOrderField *task_data = (CThostFtdcExecOrderField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["ExecOrderRef"] = toUtf(task_data->ExecOrderRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["Volume"] = task_data->Volume;
+        data["RequestID"] = task_data->RequestID;
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["OffsetFlag"] = task_data->OffsetFlag;
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["ActionType"] = task_data->ActionType;
+        data["PosiDirection"] = task_data->PosiDirection;
+        data["ReservePositionFlag"] = task_data->ReservePositionFlag;
+        data["CloseFlag"] = task_data->CloseFlag;
+        data["ExecOrderLocalID"] = toUtf(task_data->ExecOrderLocalID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ParticipantID"] = toUtf(task_data->ParticipantID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
+        data["TraderID"] = toUtf(task_data->TraderID);
+        data["InstallID"] = task_data->InstallID;
+        data["OrderSubmitStatus"] = task_data->OrderSubmitStatus;
+        data["NotifySequence"] = task_data->NotifySequence;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["SettlementID"] = task_data->SettlementID;
+        data["ExecOrderSysID"] = toUtf(task_data->ExecOrderSysID);
+        data["InsertDate"] = toUtf(task_data->InsertDate);
+        data["InsertTime"] = toUtf(task_data->InsertTime);
+        data["CancelTime"] = toUtf(task_data->CancelTime);
+        data["ExecResult"] = task_data->ExecResult;
+        data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
+        data["SequenceNo"] = task_data->SequenceNo;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
+        data["StatusMsg"] = toUtf(task_data->StatusMsg);
+        data["ActiveUserID"] = toUtf(task_data->ActiveUserID);
+        data["BrokerExecOrderSeq"] = task_data->BrokerExecOrderSeq;
+        data["BranchID"] = toUtf(task_data->BranchID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    this->onRtnExecOrder(data);
 };
 
 void TdApi::processErrRtnExecOrderInsert(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInputExecOrderField *task_data = (CThostFtdcInputExecOrderField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["ExecOrderRef"] = toUtf(task_data->ExecOrderRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["Volume"] = task_data->Volume;
-		data["RequestID"] = task_data->RequestID;
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["OffsetFlag"] = task_data->OffsetFlag;
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["ActionType"] = task_data->ActionType;
-		data["PosiDirection"] = task_data->PosiDirection;
-		data["ReservePositionFlag"] = task_data->ReservePositionFlag;
-		data["CloseFlag"] = task_data->CloseFlag;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onErrRtnExecOrderInsert(data, error);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInputExecOrderField *task_data = (CThostFtdcInputExecOrderField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["ExecOrderRef"] = toUtf(task_data->ExecOrderRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["Volume"] = task_data->Volume;
+        data["RequestID"] = task_data->RequestID;
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["OffsetFlag"] = task_data->OffsetFlag;
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["ActionType"] = task_data->ActionType;
+        data["PosiDirection"] = task_data->PosiDirection;
+        data["ReservePositionFlag"] = task_data->ReservePositionFlag;
+        data["CloseFlag"] = task_data->CloseFlag;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onErrRtnExecOrderInsert(data, error);
 };
 
 void TdApi::processErrRtnExecOrderAction(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcExecOrderActionField *task_data = (CThostFtdcExecOrderActionField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["ExecOrderActionRef"] = task_data->ExecOrderActionRef;
-		data["ExecOrderRef"] = toUtf(task_data->ExecOrderRef);
-		data["RequestID"] = task_data->RequestID;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ExecOrderSysID"] = toUtf(task_data->ExecOrderSysID);
-		data["ActionFlag"] = task_data->ActionFlag;
-		data["ActionDate"] = toUtf(task_data->ActionDate);
-		data["ActionTime"] = toUtf(task_data->ActionTime);
-		data["TraderID"] = toUtf(task_data->TraderID);
-		data["InstallID"] = task_data->InstallID;
-		data["ExecOrderLocalID"] = toUtf(task_data->ExecOrderLocalID);
-		data["ActionLocalID"] = toUtf(task_data->ActionLocalID);
-		data["ParticipantID"] = toUtf(task_data->ParticipantID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["OrderActionStatus"] = task_data->OrderActionStatus;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["ActionType"] = task_data->ActionType;
-		data["StatusMsg"] = toUtf(task_data->StatusMsg);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["BranchID"] = toUtf(task_data->BranchID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onErrRtnExecOrderAction(data, error);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcExecOrderActionField *task_data = (CThostFtdcExecOrderActionField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["ExecOrderActionRef"] = task_data->ExecOrderActionRef;
+        data["ExecOrderRef"] = toUtf(task_data->ExecOrderRef);
+        data["RequestID"] = task_data->RequestID;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ExecOrderSysID"] = toUtf(task_data->ExecOrderSysID);
+        data["ActionFlag"] = task_data->ActionFlag;
+        data["ActionDate"] = toUtf(task_data->ActionDate);
+        data["ActionTime"] = toUtf(task_data->ActionTime);
+        data["TraderID"] = toUtf(task_data->TraderID);
+        data["InstallID"] = task_data->InstallID;
+        data["ExecOrderLocalID"] = toUtf(task_data->ExecOrderLocalID);
+        data["ActionLocalID"] = toUtf(task_data->ActionLocalID);
+        data["ParticipantID"] = toUtf(task_data->ParticipantID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["OrderActionStatus"] = task_data->OrderActionStatus;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["ActionType"] = task_data->ActionType;
+        data["StatusMsg"] = toUtf(task_data->StatusMsg);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["BranchID"] = toUtf(task_data->BranchID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onErrRtnExecOrderAction(data, error);
 };
 
 void TdApi::processErrRtnForQuoteInsert(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInputForQuoteField *task_data = (CThostFtdcInputForQuoteField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["ForQuoteRef"] = toUtf(task_data->ForQuoteRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onErrRtnForQuoteInsert(data, error);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInputForQuoteField *task_data = (CThostFtdcInputForQuoteField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["ForQuoteRef"] = toUtf(task_data->ForQuoteRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onErrRtnForQuoteInsert(data, error);
 };
 
 void TdApi::processRtnQuote(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcQuoteField *task_data = (CThostFtdcQuoteField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["QuoteRef"] = toUtf(task_data->QuoteRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["AskPrice"] = task_data->AskPrice;
-		data["BidPrice"] = task_data->BidPrice;
-		data["AskVolume"] = task_data->AskVolume;
-		data["BidVolume"] = task_data->BidVolume;
-		data["RequestID"] = task_data->RequestID;
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["AskOffsetFlag"] = task_data->AskOffsetFlag;
-		data["BidOffsetFlag"] = task_data->BidOffsetFlag;
-		data["AskHedgeFlag"] = task_data->AskHedgeFlag;
-		data["BidHedgeFlag"] = task_data->BidHedgeFlag;
-		data["QuoteLocalID"] = toUtf(task_data->QuoteLocalID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ParticipantID"] = toUtf(task_data->ParticipantID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
-		data["TraderID"] = toUtf(task_data->TraderID);
-		data["InstallID"] = task_data->InstallID;
-		data["NotifySequence"] = task_data->NotifySequence;
-		data["OrderSubmitStatus"] = task_data->OrderSubmitStatus;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["SettlementID"] = task_data->SettlementID;
-		data["QuoteSysID"] = toUtf(task_data->QuoteSysID);
-		data["InsertDate"] = toUtf(task_data->InsertDate);
-		data["InsertTime"] = toUtf(task_data->InsertTime);
-		data["CancelTime"] = toUtf(task_data->CancelTime);
-		data["QuoteStatus"] = task_data->QuoteStatus;
-		data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
-		data["SequenceNo"] = task_data->SequenceNo;
-		data["AskOrderSysID"] = toUtf(task_data->AskOrderSysID);
-		data["BidOrderSysID"] = toUtf(task_data->BidOrderSysID);
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
-		data["StatusMsg"] = toUtf(task_data->StatusMsg);
-		data["ActiveUserID"] = toUtf(task_data->ActiveUserID);
-		data["BrokerQuoteSeq"] = task_data->BrokerQuoteSeq;
-		data["AskOrderRef"] = toUtf(task_data->AskOrderRef);
-		data["BidOrderRef"] = toUtf(task_data->BidOrderRef);
-		data["ForQuoteSysID"] = toUtf(task_data->ForQuoteSysID);
-		data["BranchID"] = toUtf(task_data->BranchID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	this->onRtnQuote(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcQuoteField *task_data = (CThostFtdcQuoteField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["QuoteRef"] = toUtf(task_data->QuoteRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["AskPrice"] = task_data->AskPrice;
+        data["BidPrice"] = task_data->BidPrice;
+        data["AskVolume"] = task_data->AskVolume;
+        data["BidVolume"] = task_data->BidVolume;
+        data["RequestID"] = task_data->RequestID;
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["AskOffsetFlag"] = task_data->AskOffsetFlag;
+        data["BidOffsetFlag"] = task_data->BidOffsetFlag;
+        data["AskHedgeFlag"] = task_data->AskHedgeFlag;
+        data["BidHedgeFlag"] = task_data->BidHedgeFlag;
+        data["QuoteLocalID"] = toUtf(task_data->QuoteLocalID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ParticipantID"] = toUtf(task_data->ParticipantID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
+        data["TraderID"] = toUtf(task_data->TraderID);
+        data["InstallID"] = task_data->InstallID;
+        data["NotifySequence"] = task_data->NotifySequence;
+        data["OrderSubmitStatus"] = task_data->OrderSubmitStatus;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["SettlementID"] = task_data->SettlementID;
+        data["QuoteSysID"] = toUtf(task_data->QuoteSysID);
+        data["InsertDate"] = toUtf(task_data->InsertDate);
+        data["InsertTime"] = toUtf(task_data->InsertTime);
+        data["CancelTime"] = toUtf(task_data->CancelTime);
+        data["QuoteStatus"] = task_data->QuoteStatus;
+        data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
+        data["SequenceNo"] = task_data->SequenceNo;
+        data["AskOrderSysID"] = toUtf(task_data->AskOrderSysID);
+        data["BidOrderSysID"] = toUtf(task_data->BidOrderSysID);
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
+        data["StatusMsg"] = toUtf(task_data->StatusMsg);
+        data["ActiveUserID"] = toUtf(task_data->ActiveUserID);
+        data["BrokerQuoteSeq"] = task_data->BrokerQuoteSeq;
+        data["AskOrderRef"] = toUtf(task_data->AskOrderRef);
+        data["BidOrderRef"] = toUtf(task_data->BidOrderRef);
+        data["ForQuoteSysID"] = toUtf(task_data->ForQuoteSysID);
+        data["BranchID"] = toUtf(task_data->BranchID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    this->onRtnQuote(data);
 };
 
 void TdApi::processErrRtnQuoteInsert(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInputQuoteField *task_data = (CThostFtdcInputQuoteField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["QuoteRef"] = toUtf(task_data->QuoteRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["AskPrice"] = task_data->AskPrice;
-		data["BidPrice"] = task_data->BidPrice;
-		data["AskVolume"] = task_data->AskVolume;
-		data["BidVolume"] = task_data->BidVolume;
-		data["RequestID"] = task_data->RequestID;
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["AskOffsetFlag"] = task_data->AskOffsetFlag;
-		data["BidOffsetFlag"] = task_data->BidOffsetFlag;
-		data["AskHedgeFlag"] = task_data->AskHedgeFlag;
-		data["BidHedgeFlag"] = task_data->BidHedgeFlag;
-		data["AskOrderRef"] = toUtf(task_data->AskOrderRef);
-		data["BidOrderRef"] = toUtf(task_data->BidOrderRef);
-		data["ForQuoteSysID"] = toUtf(task_data->ForQuoteSysID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onErrRtnQuoteInsert(data, error);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInputQuoteField *task_data = (CThostFtdcInputQuoteField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["QuoteRef"] = toUtf(task_data->QuoteRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["AskPrice"] = task_data->AskPrice;
+        data["BidPrice"] = task_data->BidPrice;
+        data["AskVolume"] = task_data->AskVolume;
+        data["BidVolume"] = task_data->BidVolume;
+        data["RequestID"] = task_data->RequestID;
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["AskOffsetFlag"] = task_data->AskOffsetFlag;
+        data["BidOffsetFlag"] = task_data->BidOffsetFlag;
+        data["AskHedgeFlag"] = task_data->AskHedgeFlag;
+        data["BidHedgeFlag"] = task_data->BidHedgeFlag;
+        data["AskOrderRef"] = toUtf(task_data->AskOrderRef);
+        data["BidOrderRef"] = toUtf(task_data->BidOrderRef);
+        data["ForQuoteSysID"] = toUtf(task_data->ForQuoteSysID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onErrRtnQuoteInsert(data, error);
 };
 
 void TdApi::processErrRtnQuoteAction(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcQuoteActionField *task_data = (CThostFtdcQuoteActionField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["QuoteActionRef"] = task_data->QuoteActionRef;
-		data["QuoteRef"] = toUtf(task_data->QuoteRef);
-		data["RequestID"] = task_data->RequestID;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["QuoteSysID"] = toUtf(task_data->QuoteSysID);
-		data["ActionFlag"] = task_data->ActionFlag;
-		data["ActionDate"] = toUtf(task_data->ActionDate);
-		data["ActionTime"] = toUtf(task_data->ActionTime);
-		data["TraderID"] = toUtf(task_data->TraderID);
-		data["InstallID"] = task_data->InstallID;
-		data["QuoteLocalID"] = toUtf(task_data->QuoteLocalID);
-		data["ActionLocalID"] = toUtf(task_data->ActionLocalID);
-		data["ParticipantID"] = toUtf(task_data->ParticipantID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["OrderActionStatus"] = task_data->OrderActionStatus;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["StatusMsg"] = toUtf(task_data->StatusMsg);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["BranchID"] = toUtf(task_data->BranchID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onErrRtnQuoteAction(data, error);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcQuoteActionField *task_data = (CThostFtdcQuoteActionField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["QuoteActionRef"] = task_data->QuoteActionRef;
+        data["QuoteRef"] = toUtf(task_data->QuoteRef);
+        data["RequestID"] = task_data->RequestID;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["QuoteSysID"] = toUtf(task_data->QuoteSysID);
+        data["ActionFlag"] = task_data->ActionFlag;
+        data["ActionDate"] = toUtf(task_data->ActionDate);
+        data["ActionTime"] = toUtf(task_data->ActionTime);
+        data["TraderID"] = toUtf(task_data->TraderID);
+        data["InstallID"] = task_data->InstallID;
+        data["QuoteLocalID"] = toUtf(task_data->QuoteLocalID);
+        data["ActionLocalID"] = toUtf(task_data->ActionLocalID);
+        data["ParticipantID"] = toUtf(task_data->ParticipantID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["OrderActionStatus"] = task_data->OrderActionStatus;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["StatusMsg"] = toUtf(task_data->StatusMsg);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["BranchID"] = toUtf(task_data->BranchID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onErrRtnQuoteAction(data, error);
 };
 
 void TdApi::processRtnForQuoteRsp(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcForQuoteRspField *task_data = (CThostFtdcForQuoteRspField*)task->task_data;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["ForQuoteSysID"] = toUtf(task_data->ForQuoteSysID);
-		data["ForQuoteTime"] = toUtf(task_data->ForQuoteTime);
-		data["ActionDay"] = toUtf(task_data->ActionDay);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		delete task->task_data;
-	}
-	this->onRtnForQuoteRsp(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcForQuoteRspField *task_data = (CThostFtdcForQuoteRspField*)task->task_data;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["ForQuoteSysID"] = toUtf(task_data->ForQuoteSysID);
+        data["ForQuoteTime"] = toUtf(task_data->ForQuoteTime);
+        data["ActionDay"] = toUtf(task_data->ActionDay);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        delete task->task_data;
+    }
+    this->onRtnForQuoteRsp(data);
 };
 
 void TdApi::processRtnCFMMCTradingAccountToken(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcCFMMCTradingAccountTokenField *task_data = (CThostFtdcCFMMCTradingAccountTokenField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["ParticipantID"] = toUtf(task_data->ParticipantID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["KeyID"] = task_data->KeyID;
-		data["Token"] = toUtf(task_data->Token);
-		delete task->task_data;
-	}
-	this->onRtnCFMMCTradingAccountToken(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcCFMMCTradingAccountTokenField *task_data = (CThostFtdcCFMMCTradingAccountTokenField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["ParticipantID"] = toUtf(task_data->ParticipantID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["KeyID"] = task_data->KeyID;
+        data["Token"] = toUtf(task_data->Token);
+        delete task->task_data;
+    }
+    this->onRtnCFMMCTradingAccountToken(data);
 };
 
 void TdApi::processErrRtnBatchOrderAction(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcBatchOrderActionField *task_data = (CThostFtdcBatchOrderActionField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["OrderActionRef"] = task_data->OrderActionRef;
-		data["RequestID"] = task_data->RequestID;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ActionDate"] = toUtf(task_data->ActionDate);
-		data["ActionTime"] = toUtf(task_data->ActionTime);
-		data["TraderID"] = toUtf(task_data->TraderID);
-		data["InstallID"] = task_data->InstallID;
-		data["ActionLocalID"] = toUtf(task_data->ActionLocalID);
-		data["ParticipantID"] = toUtf(task_data->ParticipantID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["OrderActionStatus"] = task_data->OrderActionStatus;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["StatusMsg"] = toUtf(task_data->StatusMsg);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onErrRtnBatchOrderAction(data, error);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcBatchOrderActionField *task_data = (CThostFtdcBatchOrderActionField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["OrderActionRef"] = task_data->OrderActionRef;
+        data["RequestID"] = task_data->RequestID;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ActionDate"] = toUtf(task_data->ActionDate);
+        data["ActionTime"] = toUtf(task_data->ActionTime);
+        data["TraderID"] = toUtf(task_data->TraderID);
+        data["InstallID"] = task_data->InstallID;
+        data["ActionLocalID"] = toUtf(task_data->ActionLocalID);
+        data["ParticipantID"] = toUtf(task_data->ParticipantID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["OrderActionStatus"] = task_data->OrderActionStatus;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["StatusMsg"] = toUtf(task_data->StatusMsg);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onErrRtnBatchOrderAction(data, error);
 };
 
 void TdApi::processRtnOptionSelfClose(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcOptionSelfCloseField *task_data = (CThostFtdcOptionSelfCloseField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["OptionSelfCloseRef"] = toUtf(task_data->OptionSelfCloseRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["Volume"] = task_data->Volume;
-		data["RequestID"] = task_data->RequestID;
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["OptSelfCloseFlag"] = task_data->OptSelfCloseFlag;
-		data["OptionSelfCloseLocalID"] = toUtf(task_data->OptionSelfCloseLocalID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ParticipantID"] = toUtf(task_data->ParticipantID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
-		data["TraderID"] = toUtf(task_data->TraderID);
-		data["InstallID"] = task_data->InstallID;
-		data["OrderSubmitStatus"] = task_data->OrderSubmitStatus;
-		data["NotifySequence"] = task_data->NotifySequence;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["SettlementID"] = task_data->SettlementID;
-		data["OptionSelfCloseSysID"] = toUtf(task_data->OptionSelfCloseSysID);
-		data["InsertDate"] = toUtf(task_data->InsertDate);
-		data["InsertTime"] = toUtf(task_data->InsertTime);
-		data["CancelTime"] = toUtf(task_data->CancelTime);
-		data["ExecResult"] = task_data->ExecResult;
-		data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
-		data["SequenceNo"] = task_data->SequenceNo;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
-		data["StatusMsg"] = toUtf(task_data->StatusMsg);
-		data["ActiveUserID"] = toUtf(task_data->ActiveUserID);
-		data["BrokerOptionSelfCloseSeq"] = task_data->BrokerOptionSelfCloseSeq;
-		data["BranchID"] = toUtf(task_data->BranchID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	this->onRtnOptionSelfClose(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcOptionSelfCloseField *task_data = (CThostFtdcOptionSelfCloseField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["OptionSelfCloseRef"] = toUtf(task_data->OptionSelfCloseRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["Volume"] = task_data->Volume;
+        data["RequestID"] = task_data->RequestID;
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["OptSelfCloseFlag"] = task_data->OptSelfCloseFlag;
+        data["OptionSelfCloseLocalID"] = toUtf(task_data->OptionSelfCloseLocalID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ParticipantID"] = toUtf(task_data->ParticipantID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
+        data["TraderID"] = toUtf(task_data->TraderID);
+        data["InstallID"] = task_data->InstallID;
+        data["OrderSubmitStatus"] = task_data->OrderSubmitStatus;
+        data["NotifySequence"] = task_data->NotifySequence;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["SettlementID"] = task_data->SettlementID;
+        data["OptionSelfCloseSysID"] = toUtf(task_data->OptionSelfCloseSysID);
+        data["InsertDate"] = toUtf(task_data->InsertDate);
+        data["InsertTime"] = toUtf(task_data->InsertTime);
+        data["CancelTime"] = toUtf(task_data->CancelTime);
+        data["ExecResult"] = task_data->ExecResult;
+        data["ClearingPartID"] = toUtf(task_data->ClearingPartID);
+        data["SequenceNo"] = task_data->SequenceNo;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
+        data["StatusMsg"] = toUtf(task_data->StatusMsg);
+        data["ActiveUserID"] = toUtf(task_data->ActiveUserID);
+        data["BrokerOptionSelfCloseSeq"] = task_data->BrokerOptionSelfCloseSeq;
+        data["BranchID"] = toUtf(task_data->BranchID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    this->onRtnOptionSelfClose(data);
 };
 
 void TdApi::processErrRtnOptionSelfCloseInsert(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInputOptionSelfCloseField *task_data = (CThostFtdcInputOptionSelfCloseField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["OptionSelfCloseRef"] = toUtf(task_data->OptionSelfCloseRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["Volume"] = task_data->Volume;
-		data["RequestID"] = task_data->RequestID;
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["OptSelfCloseFlag"] = task_data->OptSelfCloseFlag;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onErrRtnOptionSelfCloseInsert(data, error);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInputOptionSelfCloseField *task_data = (CThostFtdcInputOptionSelfCloseField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["OptionSelfCloseRef"] = toUtf(task_data->OptionSelfCloseRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["Volume"] = task_data->Volume;
+        data["RequestID"] = task_data->RequestID;
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["OptSelfCloseFlag"] = task_data->OptSelfCloseFlag;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onErrRtnOptionSelfCloseInsert(data, error);
 };
 
 void TdApi::processErrRtnOptionSelfCloseAction(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcOptionSelfCloseActionField *task_data = (CThostFtdcOptionSelfCloseActionField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["OptionSelfCloseActionRef"] = task_data->OptionSelfCloseActionRef;
-		data["OptionSelfCloseRef"] = toUtf(task_data->OptionSelfCloseRef);
-		data["RequestID"] = task_data->RequestID;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["OptionSelfCloseSysID"] = toUtf(task_data->OptionSelfCloseSysID);
-		data["ActionFlag"] = task_data->ActionFlag;
-		data["ActionDate"] = toUtf(task_data->ActionDate);
-		data["ActionTime"] = toUtf(task_data->ActionTime);
-		data["TraderID"] = toUtf(task_data->TraderID);
-		data["InstallID"] = task_data->InstallID;
-		data["OptionSelfCloseLocalID"] = toUtf(task_data->OptionSelfCloseLocalID);
-		data["ActionLocalID"] = toUtf(task_data->ActionLocalID);
-		data["ParticipantID"] = toUtf(task_data->ParticipantID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["OrderActionStatus"] = task_data->OrderActionStatus;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["StatusMsg"] = toUtf(task_data->StatusMsg);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["BranchID"] = toUtf(task_data->BranchID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onErrRtnOptionSelfCloseAction(data, error);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcOptionSelfCloseActionField *task_data = (CThostFtdcOptionSelfCloseActionField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["OptionSelfCloseActionRef"] = task_data->OptionSelfCloseActionRef;
+        data["OptionSelfCloseRef"] = toUtf(task_data->OptionSelfCloseRef);
+        data["RequestID"] = task_data->RequestID;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["OptionSelfCloseSysID"] = toUtf(task_data->OptionSelfCloseSysID);
+        data["ActionFlag"] = task_data->ActionFlag;
+        data["ActionDate"] = toUtf(task_data->ActionDate);
+        data["ActionTime"] = toUtf(task_data->ActionTime);
+        data["TraderID"] = toUtf(task_data->TraderID);
+        data["InstallID"] = task_data->InstallID;
+        data["OptionSelfCloseLocalID"] = toUtf(task_data->OptionSelfCloseLocalID);
+        data["ActionLocalID"] = toUtf(task_data->ActionLocalID);
+        data["ParticipantID"] = toUtf(task_data->ParticipantID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["OrderActionStatus"] = task_data->OrderActionStatus;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["StatusMsg"] = toUtf(task_data->StatusMsg);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["BranchID"] = toUtf(task_data->BranchID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onErrRtnOptionSelfCloseAction(data, error);
 };
 
 void TdApi::processRtnCombAction(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcCombActionField *task_data = (CThostFtdcCombActionField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["CombActionRef"] = toUtf(task_data->CombActionRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["Direction"] = task_data->Direction;
-		data["Volume"] = task_data->Volume;
-		data["CombDirection"] = task_data->CombDirection;
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["ActionLocalID"] = toUtf(task_data->ActionLocalID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ParticipantID"] = toUtf(task_data->ParticipantID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
-		data["TraderID"] = toUtf(task_data->TraderID);
-		data["InstallID"] = task_data->InstallID;
-		data["ActionStatus"] = task_data->ActionStatus;
-		data["NotifySequence"] = task_data->NotifySequence;
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["SettlementID"] = task_data->SettlementID;
-		data["SequenceNo"] = task_data->SequenceNo;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
-		data["StatusMsg"] = toUtf(task_data->StatusMsg);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		data["ComTradeID"] = toUtf(task_data->ComTradeID);
-		data["BranchID"] = toUtf(task_data->BranchID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	this->onRtnCombAction(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcCombActionField *task_data = (CThostFtdcCombActionField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["CombActionRef"] = toUtf(task_data->CombActionRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["Direction"] = task_data->Direction;
+        data["Volume"] = task_data->Volume;
+        data["CombDirection"] = task_data->CombDirection;
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["ActionLocalID"] = toUtf(task_data->ActionLocalID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ParticipantID"] = toUtf(task_data->ParticipantID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["ExchangeInstID"] = toUtf(task_data->ExchangeInstID);
+        data["TraderID"] = toUtf(task_data->TraderID);
+        data["InstallID"] = task_data->InstallID;
+        data["ActionStatus"] = task_data->ActionStatus;
+        data["NotifySequence"] = task_data->NotifySequence;
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["SettlementID"] = task_data->SettlementID;
+        data["SequenceNo"] = task_data->SequenceNo;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["UserProductInfo"] = toUtf(task_data->UserProductInfo);
+        data["StatusMsg"] = toUtf(task_data->StatusMsg);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        data["ComTradeID"] = toUtf(task_data->ComTradeID);
+        data["BranchID"] = toUtf(task_data->BranchID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    this->onRtnCombAction(data);
 };
 
 void TdApi::processErrRtnCombActionInsert(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcInputCombActionField *task_data = (CThostFtdcInputCombActionField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["CombActionRef"] = toUtf(task_data->CombActionRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["Direction"] = task_data->Direction;
-		data["Volume"] = task_data->Volume;
-		data["CombDirection"] = task_data->CombDirection;
-		data["HedgeFlag"] = task_data->HedgeFlag;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onErrRtnCombActionInsert(data, error);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcInputCombActionField *task_data = (CThostFtdcInputCombActionField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["CombActionRef"] = toUtf(task_data->CombActionRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["Direction"] = task_data->Direction;
+        data["Volume"] = task_data->Volume;
+        data["CombDirection"] = task_data->CombDirection;
+        data["HedgeFlag"] = task_data->HedgeFlag;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onErrRtnCombActionInsert(data, error);
 };
 
 void TdApi::processRspQryContractBank(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcContractBankField *task_data = (CThostFtdcContractBankField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBrchID"] = toUtf(task_data->BankBrchID);
-		data["BankName"] = toUtf(task_data->BankName);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryContractBank(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcContractBankField *task_data = (CThostFtdcContractBankField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBrchID"] = toUtf(task_data->BankBrchID);
+        data["BankName"] = toUtf(task_data->BankName);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryContractBank(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryParkedOrder(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcParkedOrderField *task_data = (CThostFtdcParkedOrderField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["OrderRef"] = toUtf(task_data->OrderRef);
-		data["UserID"] = toUtf(task_data->UserID);
-		data["OrderPriceType"] = task_data->OrderPriceType;
-		data["Direction"] = task_data->Direction;
-		data["CombOffsetFlag"] = toUtf(task_data->CombOffsetFlag);
-		data["CombHedgeFlag"] = toUtf(task_data->CombHedgeFlag);
-		data["LimitPrice"] = task_data->LimitPrice;
-		data["VolumeTotalOriginal"] = task_data->VolumeTotalOriginal;
-		data["TimeCondition"] = task_data->TimeCondition;
-		data["GTDDate"] = toUtf(task_data->GTDDate);
-		data["VolumeCondition"] = task_data->VolumeCondition;
-		data["MinVolume"] = task_data->MinVolume;
-		data["ContingentCondition"] = task_data->ContingentCondition;
-		data["StopPrice"] = task_data->StopPrice;
-		data["ForceCloseReason"] = task_data->ForceCloseReason;
-		data["IsAutoSuspend"] = task_data->IsAutoSuspend;
-		data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
-		data["RequestID"] = task_data->RequestID;
-		data["UserForceClose"] = task_data->UserForceClose;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["ParkedOrderID"] = toUtf(task_data->ParkedOrderID);
-		data["UserType"] = task_data->UserType;
-		data["Status"] = task_data->Status;
-		data["ErrorID"] = task_data->ErrorID;
-		data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
-		data["IsSwapOrder"] = task_data->IsSwapOrder;
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["ClientID"] = toUtf(task_data->ClientID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryParkedOrder(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcParkedOrderField *task_data = (CThostFtdcParkedOrderField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["OrderRef"] = toUtf(task_data->OrderRef);
+        data["UserID"] = toUtf(task_data->UserID);
+        data["OrderPriceType"] = task_data->OrderPriceType;
+        data["Direction"] = task_data->Direction;
+        data["CombOffsetFlag"] = toUtf(task_data->CombOffsetFlag);
+        data["CombHedgeFlag"] = toUtf(task_data->CombHedgeFlag);
+        data["LimitPrice"] = task_data->LimitPrice;
+        data["VolumeTotalOriginal"] = task_data->VolumeTotalOriginal;
+        data["TimeCondition"] = task_data->TimeCondition;
+        data["GTDDate"] = toUtf(task_data->GTDDate);
+        data["VolumeCondition"] = task_data->VolumeCondition;
+        data["MinVolume"] = task_data->MinVolume;
+        data["ContingentCondition"] = task_data->ContingentCondition;
+        data["StopPrice"] = task_data->StopPrice;
+        data["ForceCloseReason"] = task_data->ForceCloseReason;
+        data["IsAutoSuspend"] = task_data->IsAutoSuspend;
+        data["BusinessUnit"] = toUtf(task_data->BusinessUnit);
+        data["RequestID"] = task_data->RequestID;
+        data["UserForceClose"] = task_data->UserForceClose;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["ParkedOrderID"] = toUtf(task_data->ParkedOrderID);
+        data["UserType"] = task_data->UserType;
+        data["Status"] = task_data->Status;
+        data["ErrorID"] = task_data->ErrorID;
+        data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
+        data["IsSwapOrder"] = task_data->IsSwapOrder;
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["ClientID"] = toUtf(task_data->ClientID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryParkedOrder(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryParkedOrderAction(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcParkedOrderActionField *task_data = (CThostFtdcParkedOrderActionField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["OrderActionRef"] = task_data->OrderActionRef;
-		data["OrderRef"] = toUtf(task_data->OrderRef);
-		data["RequestID"] = task_data->RequestID;
-		data["FrontID"] = task_data->FrontID;
-		data["SessionID"] = task_data->SessionID;
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["OrderSysID"] = toUtf(task_data->OrderSysID);
-		data["ActionFlag"] = task_data->ActionFlag;
-		data["LimitPrice"] = task_data->LimitPrice;
-		data["VolumeChange"] = task_data->VolumeChange;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["ParkedOrderActionID"] = toUtf(task_data->ParkedOrderActionID);
-		data["UserType"] = task_data->UserType;
-		data["Status"] = task_data->Status;
-		data["ErrorID"] = task_data->ErrorID;
-		data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		data["IPAddress"] = toUtf(task_data->IPAddress);
-		data["MacAddress"] = toUtf(task_data->MacAddress);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryParkedOrderAction(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcParkedOrderActionField *task_data = (CThostFtdcParkedOrderActionField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["OrderActionRef"] = task_data->OrderActionRef;
+        data["OrderRef"] = toUtf(task_data->OrderRef);
+        data["RequestID"] = task_data->RequestID;
+        data["FrontID"] = task_data->FrontID;
+        data["SessionID"] = task_data->SessionID;
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["OrderSysID"] = toUtf(task_data->OrderSysID);
+        data["ActionFlag"] = task_data->ActionFlag;
+        data["LimitPrice"] = task_data->LimitPrice;
+        data["VolumeChange"] = task_data->VolumeChange;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["ParkedOrderActionID"] = toUtf(task_data->ParkedOrderActionID);
+        data["UserType"] = task_data->UserType;
+        data["Status"] = task_data->Status;
+        data["ErrorID"] = task_data->ErrorID;
+        data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        data["IPAddress"] = toUtf(task_data->IPAddress);
+        data["MacAddress"] = toUtf(task_data->MacAddress);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryParkedOrderAction(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryTradingNotice(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcTradingNoticeField *task_data = (CThostFtdcTradingNoticeField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorRange"] = task_data->InvestorRange;
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["SequenceSeries"] = task_data->SequenceSeries;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["SendTime"] = toUtf(task_data->SendTime);
-		data["SequenceNo"] = task_data->SequenceNo;
-		data["FieldContent"] = toUtf(task_data->FieldContent);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryTradingNotice(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcTradingNoticeField *task_data = (CThostFtdcTradingNoticeField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorRange"] = task_data->InvestorRange;
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["SequenceSeries"] = task_data->SequenceSeries;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["SendTime"] = toUtf(task_data->SendTime);
+        data["SequenceNo"] = task_data->SequenceNo;
+        data["FieldContent"] = toUtf(task_data->FieldContent);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryTradingNotice(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryBrokerTradingParams(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcBrokerTradingParamsField *task_data = (CThostFtdcBrokerTradingParamsField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["MarginPriceType"] = task_data->MarginPriceType;
-		data["Algorithm"] = task_data->Algorithm;
-		data["AvailIncludeCloseProfit"] = task_data->AvailIncludeCloseProfit;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["OptionRoyaltyPriceType"] = task_data->OptionRoyaltyPriceType;
-		data["AccountID"] = toUtf(task_data->AccountID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryBrokerTradingParams(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcBrokerTradingParamsField *task_data = (CThostFtdcBrokerTradingParamsField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["MarginPriceType"] = task_data->MarginPriceType;
+        data["Algorithm"] = task_data->Algorithm;
+        data["AvailIncludeCloseProfit"] = task_data->AvailIncludeCloseProfit;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["OptionRoyaltyPriceType"] = task_data->OptionRoyaltyPriceType;
+        data["AccountID"] = toUtf(task_data->AccountID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryBrokerTradingParams(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQryBrokerTradingAlgos(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcBrokerTradingAlgosField *task_data = (CThostFtdcBrokerTradingAlgosField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["ExchangeID"] = toUtf(task_data->ExchangeID);
-		data["InstrumentID"] = toUtf(task_data->InstrumentID);
-		data["HandlePositionAlgoID"] = task_data->HandlePositionAlgoID;
-		data["FindMarginRateAlgoID"] = task_data->FindMarginRateAlgoID;
-		data["HandleTradingAccountAlgoID"] = task_data->HandleTradingAccountAlgoID;
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQryBrokerTradingAlgos(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcBrokerTradingAlgosField *task_data = (CThostFtdcBrokerTradingAlgosField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["ExchangeID"] = toUtf(task_data->ExchangeID);
+        data["InstrumentID"] = toUtf(task_data->InstrumentID);
+        data["HandlePositionAlgoID"] = task_data->HandlePositionAlgoID;
+        data["FindMarginRateAlgoID"] = task_data->FindMarginRateAlgoID;
+        data["HandleTradingAccountAlgoID"] = task_data->HandleTradingAccountAlgoID;
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQryBrokerTradingAlgos(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQueryCFMMCTradingAccountToken(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcQueryCFMMCTradingAccountTokenField *task_data = (CThostFtdcQueryCFMMCTradingAccountTokenField*)task->task_data;
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["InvestorID"] = toUtf(task_data->InvestorID);
-		data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQueryCFMMCTradingAccountToken(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcQueryCFMMCTradingAccountTokenField *task_data = (CThostFtdcQueryCFMMCTradingAccountTokenField*)task->task_data;
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["InvestorID"] = toUtf(task_data->InvestorID);
+        data["InvestUnitID"] = toUtf(task_data->InvestUnitID);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQueryCFMMCTradingAccountToken(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRtnFromBankToFutureByBank(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcRspTransferField *task_data = (CThostFtdcRspTransferField*)task->task_data;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["CustType"] = task_data->CustType;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["InstallID"] = task_data->InstallID;
-		data["FutureSerial"] = task_data->FutureSerial;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["TradeAmount"] = task_data->TradeAmount;
-		data["FutureFetchAmount"] = task_data->FutureFetchAmount;
-		data["FeePayFlag"] = task_data->FeePayFlag;
-		data["CustFee"] = task_data->CustFee;
-		data["BrokerFee"] = task_data->BrokerFee;
-		data["Message"] = toUtf(task_data->Message);
-		data["Digest"] = toUtf(task_data->Digest);
-		data["BankAccType"] = task_data->BankAccType;
-		data["DeviceID"] = toUtf(task_data->DeviceID);
-		data["BankSecuAccType"] = task_data->BankSecuAccType;
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["OperNo"] = toUtf(task_data->OperNo);
-		data["RequestID"] = task_data->RequestID;
-		data["TID"] = task_data->TID;
-		data["TransferStatus"] = task_data->TransferStatus;
-		data["ErrorID"] = task_data->ErrorID;
-		data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	this->onRtnFromBankToFutureByBank(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcRspTransferField *task_data = (CThostFtdcRspTransferField*)task->task_data;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["CustType"] = task_data->CustType;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["InstallID"] = task_data->InstallID;
+        data["FutureSerial"] = task_data->FutureSerial;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["TradeAmount"] = task_data->TradeAmount;
+        data["FutureFetchAmount"] = task_data->FutureFetchAmount;
+        data["FeePayFlag"] = task_data->FeePayFlag;
+        data["CustFee"] = task_data->CustFee;
+        data["BrokerFee"] = task_data->BrokerFee;
+        data["Message"] = toUtf(task_data->Message);
+        data["Digest"] = toUtf(task_data->Digest);
+        data["BankAccType"] = task_data->BankAccType;
+        data["DeviceID"] = toUtf(task_data->DeviceID);
+        data["BankSecuAccType"] = task_data->BankSecuAccType;
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["OperNo"] = toUtf(task_data->OperNo);
+        data["RequestID"] = task_data->RequestID;
+        data["TID"] = task_data->TID;
+        data["TransferStatus"] = task_data->TransferStatus;
+        data["ErrorID"] = task_data->ErrorID;
+        data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    this->onRtnFromBankToFutureByBank(data);
 };
 
 void TdApi::processRtnFromFutureToBankByBank(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcRspTransferField *task_data = (CThostFtdcRspTransferField*)task->task_data;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["CustType"] = task_data->CustType;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["InstallID"] = task_data->InstallID;
-		data["FutureSerial"] = task_data->FutureSerial;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["TradeAmount"] = task_data->TradeAmount;
-		data["FutureFetchAmount"] = task_data->FutureFetchAmount;
-		data["FeePayFlag"] = task_data->FeePayFlag;
-		data["CustFee"] = task_data->CustFee;
-		data["BrokerFee"] = task_data->BrokerFee;
-		data["Message"] = toUtf(task_data->Message);
-		data["Digest"] = toUtf(task_data->Digest);
-		data["BankAccType"] = task_data->BankAccType;
-		data["DeviceID"] = toUtf(task_data->DeviceID);
-		data["BankSecuAccType"] = task_data->BankSecuAccType;
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["OperNo"] = toUtf(task_data->OperNo);
-		data["RequestID"] = task_data->RequestID;
-		data["TID"] = task_data->TID;
-		data["TransferStatus"] = task_data->TransferStatus;
-		data["ErrorID"] = task_data->ErrorID;
-		data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	this->onRtnFromFutureToBankByBank(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcRspTransferField *task_data = (CThostFtdcRspTransferField*)task->task_data;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["CustType"] = task_data->CustType;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["InstallID"] = task_data->InstallID;
+        data["FutureSerial"] = task_data->FutureSerial;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["TradeAmount"] = task_data->TradeAmount;
+        data["FutureFetchAmount"] = task_data->FutureFetchAmount;
+        data["FeePayFlag"] = task_data->FeePayFlag;
+        data["CustFee"] = task_data->CustFee;
+        data["BrokerFee"] = task_data->BrokerFee;
+        data["Message"] = toUtf(task_data->Message);
+        data["Digest"] = toUtf(task_data->Digest);
+        data["BankAccType"] = task_data->BankAccType;
+        data["DeviceID"] = toUtf(task_data->DeviceID);
+        data["BankSecuAccType"] = task_data->BankSecuAccType;
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["OperNo"] = toUtf(task_data->OperNo);
+        data["RequestID"] = task_data->RequestID;
+        data["TID"] = task_data->TID;
+        data["TransferStatus"] = task_data->TransferStatus;
+        data["ErrorID"] = task_data->ErrorID;
+        data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    this->onRtnFromFutureToBankByBank(data);
 };
 
 void TdApi::processRtnRepealFromBankToFutureByBank(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcRspRepealField *task_data = (CThostFtdcRspRepealField*)task->task_data;
-		data["RepealTimeInterval"] = task_data->RepealTimeInterval;
-		data["RepealedTimes"] = task_data->RepealedTimes;
-		data["BankRepealFlag"] = task_data->BankRepealFlag;
-		data["BrokerRepealFlag"] = task_data->BrokerRepealFlag;
-		data["PlateRepealSerial"] = task_data->PlateRepealSerial;
-		data["BankRepealSerial"] = toUtf(task_data->BankRepealSerial);
-		data["FutureRepealSerial"] = task_data->FutureRepealSerial;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["CustType"] = task_data->CustType;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["InstallID"] = task_data->InstallID;
-		data["FutureSerial"] = task_data->FutureSerial;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["TradeAmount"] = task_data->TradeAmount;
-		data["FutureFetchAmount"] = task_data->FutureFetchAmount;
-		data["FeePayFlag"] = task_data->FeePayFlag;
-		data["CustFee"] = task_data->CustFee;
-		data["BrokerFee"] = task_data->BrokerFee;
-		data["Message"] = toUtf(task_data->Message);
-		data["Digest"] = toUtf(task_data->Digest);
-		data["BankAccType"] = task_data->BankAccType;
-		data["DeviceID"] = toUtf(task_data->DeviceID);
-		data["BankSecuAccType"] = task_data->BankSecuAccType;
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["OperNo"] = toUtf(task_data->OperNo);
-		data["RequestID"] = task_data->RequestID;
-		data["TID"] = task_data->TID;
-		data["TransferStatus"] = task_data->TransferStatus;
-		data["ErrorID"] = task_data->ErrorID;
-		data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	this->onRtnRepealFromBankToFutureByBank(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcRspRepealField *task_data = (CThostFtdcRspRepealField*)task->task_data;
+        data["RepealTimeInterval"] = task_data->RepealTimeInterval;
+        data["RepealedTimes"] = task_data->RepealedTimes;
+        data["BankRepealFlag"] = task_data->BankRepealFlag;
+        data["BrokerRepealFlag"] = task_data->BrokerRepealFlag;
+        data["PlateRepealSerial"] = task_data->PlateRepealSerial;
+        data["BankRepealSerial"] = toUtf(task_data->BankRepealSerial);
+        data["FutureRepealSerial"] = task_data->FutureRepealSerial;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["CustType"] = task_data->CustType;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["InstallID"] = task_data->InstallID;
+        data["FutureSerial"] = task_data->FutureSerial;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["TradeAmount"] = task_data->TradeAmount;
+        data["FutureFetchAmount"] = task_data->FutureFetchAmount;
+        data["FeePayFlag"] = task_data->FeePayFlag;
+        data["CustFee"] = task_data->CustFee;
+        data["BrokerFee"] = task_data->BrokerFee;
+        data["Message"] = toUtf(task_data->Message);
+        data["Digest"] = toUtf(task_data->Digest);
+        data["BankAccType"] = task_data->BankAccType;
+        data["DeviceID"] = toUtf(task_data->DeviceID);
+        data["BankSecuAccType"] = task_data->BankSecuAccType;
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["OperNo"] = toUtf(task_data->OperNo);
+        data["RequestID"] = task_data->RequestID;
+        data["TID"] = task_data->TID;
+        data["TransferStatus"] = task_data->TransferStatus;
+        data["ErrorID"] = task_data->ErrorID;
+        data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    this->onRtnRepealFromBankToFutureByBank(data);
 };
 
 void TdApi::processRtnRepealFromFutureToBankByBank(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcRspRepealField *task_data = (CThostFtdcRspRepealField*)task->task_data;
-		data["RepealTimeInterval"] = task_data->RepealTimeInterval;
-		data["RepealedTimes"] = task_data->RepealedTimes;
-		data["BankRepealFlag"] = task_data->BankRepealFlag;
-		data["BrokerRepealFlag"] = task_data->BrokerRepealFlag;
-		data["PlateRepealSerial"] = task_data->PlateRepealSerial;
-		data["BankRepealSerial"] = toUtf(task_data->BankRepealSerial);
-		data["FutureRepealSerial"] = task_data->FutureRepealSerial;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["CustType"] = task_data->CustType;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["InstallID"] = task_data->InstallID;
-		data["FutureSerial"] = task_data->FutureSerial;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["TradeAmount"] = task_data->TradeAmount;
-		data["FutureFetchAmount"] = task_data->FutureFetchAmount;
-		data["FeePayFlag"] = task_data->FeePayFlag;
-		data["CustFee"] = task_data->CustFee;
-		data["BrokerFee"] = task_data->BrokerFee;
-		data["Message"] = toUtf(task_data->Message);
-		data["Digest"] = toUtf(task_data->Digest);
-		data["BankAccType"] = task_data->BankAccType;
-		data["DeviceID"] = toUtf(task_data->DeviceID);
-		data["BankSecuAccType"] = task_data->BankSecuAccType;
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["OperNo"] = toUtf(task_data->OperNo);
-		data["RequestID"] = task_data->RequestID;
-		data["TID"] = task_data->TID;
-		data["TransferStatus"] = task_data->TransferStatus;
-		data["ErrorID"] = task_data->ErrorID;
-		data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	this->onRtnRepealFromFutureToBankByBank(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcRspRepealField *task_data = (CThostFtdcRspRepealField*)task->task_data;
+        data["RepealTimeInterval"] = task_data->RepealTimeInterval;
+        data["RepealedTimes"] = task_data->RepealedTimes;
+        data["BankRepealFlag"] = task_data->BankRepealFlag;
+        data["BrokerRepealFlag"] = task_data->BrokerRepealFlag;
+        data["PlateRepealSerial"] = task_data->PlateRepealSerial;
+        data["BankRepealSerial"] = toUtf(task_data->BankRepealSerial);
+        data["FutureRepealSerial"] = task_data->FutureRepealSerial;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["CustType"] = task_data->CustType;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["InstallID"] = task_data->InstallID;
+        data["FutureSerial"] = task_data->FutureSerial;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["TradeAmount"] = task_data->TradeAmount;
+        data["FutureFetchAmount"] = task_data->FutureFetchAmount;
+        data["FeePayFlag"] = task_data->FeePayFlag;
+        data["CustFee"] = task_data->CustFee;
+        data["BrokerFee"] = task_data->BrokerFee;
+        data["Message"] = toUtf(task_data->Message);
+        data["Digest"] = toUtf(task_data->Digest);
+        data["BankAccType"] = task_data->BankAccType;
+        data["DeviceID"] = toUtf(task_data->DeviceID);
+        data["BankSecuAccType"] = task_data->BankSecuAccType;
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["OperNo"] = toUtf(task_data->OperNo);
+        data["RequestID"] = task_data->RequestID;
+        data["TID"] = task_data->TID;
+        data["TransferStatus"] = task_data->TransferStatus;
+        data["ErrorID"] = task_data->ErrorID;
+        data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    this->onRtnRepealFromFutureToBankByBank(data);
 };
 
 void TdApi::processRtnFromBankToFutureByFuture(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcRspTransferField *task_data = (CThostFtdcRspTransferField*)task->task_data;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["CustType"] = task_data->CustType;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["InstallID"] = task_data->InstallID;
-		data["FutureSerial"] = task_data->FutureSerial;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["TradeAmount"] = task_data->TradeAmount;
-		data["FutureFetchAmount"] = task_data->FutureFetchAmount;
-		data["FeePayFlag"] = task_data->FeePayFlag;
-		data["CustFee"] = task_data->CustFee;
-		data["BrokerFee"] = task_data->BrokerFee;
-		data["Message"] = toUtf(task_data->Message);
-		data["Digest"] = toUtf(task_data->Digest);
-		data["BankAccType"] = task_data->BankAccType;
-		data["DeviceID"] = toUtf(task_data->DeviceID);
-		data["BankSecuAccType"] = task_data->BankSecuAccType;
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["OperNo"] = toUtf(task_data->OperNo);
-		data["RequestID"] = task_data->RequestID;
-		data["TID"] = task_data->TID;
-		data["TransferStatus"] = task_data->TransferStatus;
-		data["ErrorID"] = task_data->ErrorID;
-		data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	this->onRtnFromBankToFutureByFuture(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcRspTransferField *task_data = (CThostFtdcRspTransferField*)task->task_data;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["CustType"] = task_data->CustType;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["InstallID"] = task_data->InstallID;
+        data["FutureSerial"] = task_data->FutureSerial;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["TradeAmount"] = task_data->TradeAmount;
+        data["FutureFetchAmount"] = task_data->FutureFetchAmount;
+        data["FeePayFlag"] = task_data->FeePayFlag;
+        data["CustFee"] = task_data->CustFee;
+        data["BrokerFee"] = task_data->BrokerFee;
+        data["Message"] = toUtf(task_data->Message);
+        data["Digest"] = toUtf(task_data->Digest);
+        data["BankAccType"] = task_data->BankAccType;
+        data["DeviceID"] = toUtf(task_data->DeviceID);
+        data["BankSecuAccType"] = task_data->BankSecuAccType;
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["OperNo"] = toUtf(task_data->OperNo);
+        data["RequestID"] = task_data->RequestID;
+        data["TID"] = task_data->TID;
+        data["TransferStatus"] = task_data->TransferStatus;
+        data["ErrorID"] = task_data->ErrorID;
+        data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    this->onRtnFromBankToFutureByFuture(data);
 };
 
 void TdApi::processRtnFromFutureToBankByFuture(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcRspTransferField *task_data = (CThostFtdcRspTransferField*)task->task_data;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["CustType"] = task_data->CustType;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["InstallID"] = task_data->InstallID;
-		data["FutureSerial"] = task_data->FutureSerial;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["TradeAmount"] = task_data->TradeAmount;
-		data["FutureFetchAmount"] = task_data->FutureFetchAmount;
-		data["FeePayFlag"] = task_data->FeePayFlag;
-		data["CustFee"] = task_data->CustFee;
-		data["BrokerFee"] = task_data->BrokerFee;
-		data["Message"] = toUtf(task_data->Message);
-		data["Digest"] = toUtf(task_data->Digest);
-		data["BankAccType"] = task_data->BankAccType;
-		data["DeviceID"] = toUtf(task_data->DeviceID);
-		data["BankSecuAccType"] = task_data->BankSecuAccType;
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["OperNo"] = toUtf(task_data->OperNo);
-		data["RequestID"] = task_data->RequestID;
-		data["TID"] = task_data->TID;
-		data["TransferStatus"] = task_data->TransferStatus;
-		data["ErrorID"] = task_data->ErrorID;
-		data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	this->onRtnFromFutureToBankByFuture(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcRspTransferField *task_data = (CThostFtdcRspTransferField*)task->task_data;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["CustType"] = task_data->CustType;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["InstallID"] = task_data->InstallID;
+        data["FutureSerial"] = task_data->FutureSerial;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["TradeAmount"] = task_data->TradeAmount;
+        data["FutureFetchAmount"] = task_data->FutureFetchAmount;
+        data["FeePayFlag"] = task_data->FeePayFlag;
+        data["CustFee"] = task_data->CustFee;
+        data["BrokerFee"] = task_data->BrokerFee;
+        data["Message"] = toUtf(task_data->Message);
+        data["Digest"] = toUtf(task_data->Digest);
+        data["BankAccType"] = task_data->BankAccType;
+        data["DeviceID"] = toUtf(task_data->DeviceID);
+        data["BankSecuAccType"] = task_data->BankSecuAccType;
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["OperNo"] = toUtf(task_data->OperNo);
+        data["RequestID"] = task_data->RequestID;
+        data["TID"] = task_data->TID;
+        data["TransferStatus"] = task_data->TransferStatus;
+        data["ErrorID"] = task_data->ErrorID;
+        data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    this->onRtnFromFutureToBankByFuture(data);
 };
 
 void TdApi::processRtnRepealFromBankToFutureByFutureManual(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcRspRepealField *task_data = (CThostFtdcRspRepealField*)task->task_data;
-		data["RepealTimeInterval"] = task_data->RepealTimeInterval;
-		data["RepealedTimes"] = task_data->RepealedTimes;
-		data["BankRepealFlag"] = task_data->BankRepealFlag;
-		data["BrokerRepealFlag"] = task_data->BrokerRepealFlag;
-		data["PlateRepealSerial"] = task_data->PlateRepealSerial;
-		data["BankRepealSerial"] = toUtf(task_data->BankRepealSerial);
-		data["FutureRepealSerial"] = task_data->FutureRepealSerial;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["CustType"] = task_data->CustType;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["InstallID"] = task_data->InstallID;
-		data["FutureSerial"] = task_data->FutureSerial;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["TradeAmount"] = task_data->TradeAmount;
-		data["FutureFetchAmount"] = task_data->FutureFetchAmount;
-		data["FeePayFlag"] = task_data->FeePayFlag;
-		data["CustFee"] = task_data->CustFee;
-		data["BrokerFee"] = task_data->BrokerFee;
-		data["Message"] = toUtf(task_data->Message);
-		data["Digest"] = toUtf(task_data->Digest);
-		data["BankAccType"] = task_data->BankAccType;
-		data["DeviceID"] = toUtf(task_data->DeviceID);
-		data["BankSecuAccType"] = task_data->BankSecuAccType;
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["OperNo"] = toUtf(task_data->OperNo);
-		data["RequestID"] = task_data->RequestID;
-		data["TID"] = task_data->TID;
-		data["TransferStatus"] = task_data->TransferStatus;
-		data["ErrorID"] = task_data->ErrorID;
-		data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	this->onRtnRepealFromBankToFutureByFutureManual(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcRspRepealField *task_data = (CThostFtdcRspRepealField*)task->task_data;
+        data["RepealTimeInterval"] = task_data->RepealTimeInterval;
+        data["RepealedTimes"] = task_data->RepealedTimes;
+        data["BankRepealFlag"] = task_data->BankRepealFlag;
+        data["BrokerRepealFlag"] = task_data->BrokerRepealFlag;
+        data["PlateRepealSerial"] = task_data->PlateRepealSerial;
+        data["BankRepealSerial"] = toUtf(task_data->BankRepealSerial);
+        data["FutureRepealSerial"] = task_data->FutureRepealSerial;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["CustType"] = task_data->CustType;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["InstallID"] = task_data->InstallID;
+        data["FutureSerial"] = task_data->FutureSerial;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["TradeAmount"] = task_data->TradeAmount;
+        data["FutureFetchAmount"] = task_data->FutureFetchAmount;
+        data["FeePayFlag"] = task_data->FeePayFlag;
+        data["CustFee"] = task_data->CustFee;
+        data["BrokerFee"] = task_data->BrokerFee;
+        data["Message"] = toUtf(task_data->Message);
+        data["Digest"] = toUtf(task_data->Digest);
+        data["BankAccType"] = task_data->BankAccType;
+        data["DeviceID"] = toUtf(task_data->DeviceID);
+        data["BankSecuAccType"] = task_data->BankSecuAccType;
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["OperNo"] = toUtf(task_data->OperNo);
+        data["RequestID"] = task_data->RequestID;
+        data["TID"] = task_data->TID;
+        data["TransferStatus"] = task_data->TransferStatus;
+        data["ErrorID"] = task_data->ErrorID;
+        data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    this->onRtnRepealFromBankToFutureByFutureManual(data);
 };
 
 void TdApi::processRtnRepealFromFutureToBankByFutureManual(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcRspRepealField *task_data = (CThostFtdcRspRepealField*)task->task_data;
-		data["RepealTimeInterval"] = task_data->RepealTimeInterval;
-		data["RepealedTimes"] = task_data->RepealedTimes;
-		data["BankRepealFlag"] = task_data->BankRepealFlag;
-		data["BrokerRepealFlag"] = task_data->BrokerRepealFlag;
-		data["PlateRepealSerial"] = task_data->PlateRepealSerial;
-		data["BankRepealSerial"] = toUtf(task_data->BankRepealSerial);
-		data["FutureRepealSerial"] = task_data->FutureRepealSerial;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["CustType"] = task_data->CustType;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["InstallID"] = task_data->InstallID;
-		data["FutureSerial"] = task_data->FutureSerial;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["TradeAmount"] = task_data->TradeAmount;
-		data["FutureFetchAmount"] = task_data->FutureFetchAmount;
-		data["FeePayFlag"] = task_data->FeePayFlag;
-		data["CustFee"] = task_data->CustFee;
-		data["BrokerFee"] = task_data->BrokerFee;
-		data["Message"] = toUtf(task_data->Message);
-		data["Digest"] = toUtf(task_data->Digest);
-		data["BankAccType"] = task_data->BankAccType;
-		data["DeviceID"] = toUtf(task_data->DeviceID);
-		data["BankSecuAccType"] = task_data->BankSecuAccType;
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["OperNo"] = toUtf(task_data->OperNo);
-		data["RequestID"] = task_data->RequestID;
-		data["TID"] = task_data->TID;
-		data["TransferStatus"] = task_data->TransferStatus;
-		data["ErrorID"] = task_data->ErrorID;
-		data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	this->onRtnRepealFromFutureToBankByFutureManual(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcRspRepealField *task_data = (CThostFtdcRspRepealField*)task->task_data;
+        data["RepealTimeInterval"] = task_data->RepealTimeInterval;
+        data["RepealedTimes"] = task_data->RepealedTimes;
+        data["BankRepealFlag"] = task_data->BankRepealFlag;
+        data["BrokerRepealFlag"] = task_data->BrokerRepealFlag;
+        data["PlateRepealSerial"] = task_data->PlateRepealSerial;
+        data["BankRepealSerial"] = toUtf(task_data->BankRepealSerial);
+        data["FutureRepealSerial"] = task_data->FutureRepealSerial;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["CustType"] = task_data->CustType;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["InstallID"] = task_data->InstallID;
+        data["FutureSerial"] = task_data->FutureSerial;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["TradeAmount"] = task_data->TradeAmount;
+        data["FutureFetchAmount"] = task_data->FutureFetchAmount;
+        data["FeePayFlag"] = task_data->FeePayFlag;
+        data["CustFee"] = task_data->CustFee;
+        data["BrokerFee"] = task_data->BrokerFee;
+        data["Message"] = toUtf(task_data->Message);
+        data["Digest"] = toUtf(task_data->Digest);
+        data["BankAccType"] = task_data->BankAccType;
+        data["DeviceID"] = toUtf(task_data->DeviceID);
+        data["BankSecuAccType"] = task_data->BankSecuAccType;
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["OperNo"] = toUtf(task_data->OperNo);
+        data["RequestID"] = task_data->RequestID;
+        data["TID"] = task_data->TID;
+        data["TransferStatus"] = task_data->TransferStatus;
+        data["ErrorID"] = task_data->ErrorID;
+        data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    this->onRtnRepealFromFutureToBankByFutureManual(data);
 };
 
 void TdApi::processRtnQueryBankBalanceByFuture(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcNotifyQueryAccountField *task_data = (CThostFtdcNotifyQueryAccountField*)task->task_data;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["CustType"] = task_data->CustType;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["FutureSerial"] = task_data->FutureSerial;
-		data["InstallID"] = task_data->InstallID;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["Digest"] = toUtf(task_data->Digest);
-		data["BankAccType"] = task_data->BankAccType;
-		data["DeviceID"] = toUtf(task_data->DeviceID);
-		data["BankSecuAccType"] = task_data->BankSecuAccType;
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["OperNo"] = toUtf(task_data->OperNo);
-		data["RequestID"] = task_data->RequestID;
-		data["TID"] = task_data->TID;
-		data["BankUseAmount"] = task_data->BankUseAmount;
-		data["BankFetchAmount"] = task_data->BankFetchAmount;
-		data["ErrorID"] = task_data->ErrorID;
-		data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	this->onRtnQueryBankBalanceByFuture(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcNotifyQueryAccountField *task_data = (CThostFtdcNotifyQueryAccountField*)task->task_data;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["CustType"] = task_data->CustType;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["FutureSerial"] = task_data->FutureSerial;
+        data["InstallID"] = task_data->InstallID;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["Digest"] = toUtf(task_data->Digest);
+        data["BankAccType"] = task_data->BankAccType;
+        data["DeviceID"] = toUtf(task_data->DeviceID);
+        data["BankSecuAccType"] = task_data->BankSecuAccType;
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["OperNo"] = toUtf(task_data->OperNo);
+        data["RequestID"] = task_data->RequestID;
+        data["TID"] = task_data->TID;
+        data["BankUseAmount"] = task_data->BankUseAmount;
+        data["BankFetchAmount"] = task_data->BankFetchAmount;
+        data["ErrorID"] = task_data->ErrorID;
+        data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    this->onRtnQueryBankBalanceByFuture(data);
 };
 
 void TdApi::processErrRtnBankToFutureByFuture(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcReqTransferField *task_data = (CThostFtdcReqTransferField*)task->task_data;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["CustType"] = task_data->CustType;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["InstallID"] = task_data->InstallID;
-		data["FutureSerial"] = task_data->FutureSerial;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["TradeAmount"] = task_data->TradeAmount;
-		data["FutureFetchAmount"] = task_data->FutureFetchAmount;
-		data["FeePayFlag"] = task_data->FeePayFlag;
-		data["CustFee"] = task_data->CustFee;
-		data["BrokerFee"] = task_data->BrokerFee;
-		data["Message"] = toUtf(task_data->Message);
-		data["Digest"] = toUtf(task_data->Digest);
-		data["BankAccType"] = task_data->BankAccType;
-		data["DeviceID"] = toUtf(task_data->DeviceID);
-		data["BankSecuAccType"] = task_data->BankSecuAccType;
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["OperNo"] = toUtf(task_data->OperNo);
-		data["RequestID"] = task_data->RequestID;
-		data["TID"] = task_data->TID;
-		data["TransferStatus"] = task_data->TransferStatus;
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onErrRtnBankToFutureByFuture(data, error);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcReqTransferField *task_data = (CThostFtdcReqTransferField*)task->task_data;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["CustType"] = task_data->CustType;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["InstallID"] = task_data->InstallID;
+        data["FutureSerial"] = task_data->FutureSerial;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["TradeAmount"] = task_data->TradeAmount;
+        data["FutureFetchAmount"] = task_data->FutureFetchAmount;
+        data["FeePayFlag"] = task_data->FeePayFlag;
+        data["CustFee"] = task_data->CustFee;
+        data["BrokerFee"] = task_data->BrokerFee;
+        data["Message"] = toUtf(task_data->Message);
+        data["Digest"] = toUtf(task_data->Digest);
+        data["BankAccType"] = task_data->BankAccType;
+        data["DeviceID"] = toUtf(task_data->DeviceID);
+        data["BankSecuAccType"] = task_data->BankSecuAccType;
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["OperNo"] = toUtf(task_data->OperNo);
+        data["RequestID"] = task_data->RequestID;
+        data["TID"] = task_data->TID;
+        data["TransferStatus"] = task_data->TransferStatus;
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onErrRtnBankToFutureByFuture(data, error);
 };
 
 void TdApi::processErrRtnFutureToBankByFuture(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcReqTransferField *task_data = (CThostFtdcReqTransferField*)task->task_data;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["CustType"] = task_data->CustType;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["InstallID"] = task_data->InstallID;
-		data["FutureSerial"] = task_data->FutureSerial;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["TradeAmount"] = task_data->TradeAmount;
-		data["FutureFetchAmount"] = task_data->FutureFetchAmount;
-		data["FeePayFlag"] = task_data->FeePayFlag;
-		data["CustFee"] = task_data->CustFee;
-		data["BrokerFee"] = task_data->BrokerFee;
-		data["Message"] = toUtf(task_data->Message);
-		data["Digest"] = toUtf(task_data->Digest);
-		data["BankAccType"] = task_data->BankAccType;
-		data["DeviceID"] = toUtf(task_data->DeviceID);
-		data["BankSecuAccType"] = task_data->BankSecuAccType;
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["OperNo"] = toUtf(task_data->OperNo);
-		data["RequestID"] = task_data->RequestID;
-		data["TID"] = task_data->TID;
-		data["TransferStatus"] = task_data->TransferStatus;
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onErrRtnFutureToBankByFuture(data, error);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcReqTransferField *task_data = (CThostFtdcReqTransferField*)task->task_data;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["CustType"] = task_data->CustType;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["InstallID"] = task_data->InstallID;
+        data["FutureSerial"] = task_data->FutureSerial;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["TradeAmount"] = task_data->TradeAmount;
+        data["FutureFetchAmount"] = task_data->FutureFetchAmount;
+        data["FeePayFlag"] = task_data->FeePayFlag;
+        data["CustFee"] = task_data->CustFee;
+        data["BrokerFee"] = task_data->BrokerFee;
+        data["Message"] = toUtf(task_data->Message);
+        data["Digest"] = toUtf(task_data->Digest);
+        data["BankAccType"] = task_data->BankAccType;
+        data["DeviceID"] = toUtf(task_data->DeviceID);
+        data["BankSecuAccType"] = task_data->BankSecuAccType;
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["OperNo"] = toUtf(task_data->OperNo);
+        data["RequestID"] = task_data->RequestID;
+        data["TID"] = task_data->TID;
+        data["TransferStatus"] = task_data->TransferStatus;
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onErrRtnFutureToBankByFuture(data, error);
 };
 
 void TdApi::processErrRtnRepealBankToFutureByFutureManual(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcReqRepealField *task_data = (CThostFtdcReqRepealField*)task->task_data;
-		data["RepealTimeInterval"] = task_data->RepealTimeInterval;
-		data["RepealedTimes"] = task_data->RepealedTimes;
-		data["BankRepealFlag"] = task_data->BankRepealFlag;
-		data["BrokerRepealFlag"] = task_data->BrokerRepealFlag;
-		data["PlateRepealSerial"] = task_data->PlateRepealSerial;
-		data["BankRepealSerial"] = toUtf(task_data->BankRepealSerial);
-		data["FutureRepealSerial"] = task_data->FutureRepealSerial;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["CustType"] = task_data->CustType;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["InstallID"] = task_data->InstallID;
-		data["FutureSerial"] = task_data->FutureSerial;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["TradeAmount"] = task_data->TradeAmount;
-		data["FutureFetchAmount"] = task_data->FutureFetchAmount;
-		data["FeePayFlag"] = task_data->FeePayFlag;
-		data["CustFee"] = task_data->CustFee;
-		data["BrokerFee"] = task_data->BrokerFee;
-		data["Message"] = toUtf(task_data->Message);
-		data["Digest"] = toUtf(task_data->Digest);
-		data["BankAccType"] = task_data->BankAccType;
-		data["DeviceID"] = toUtf(task_data->DeviceID);
-		data["BankSecuAccType"] = task_data->BankSecuAccType;
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["OperNo"] = toUtf(task_data->OperNo);
-		data["RequestID"] = task_data->RequestID;
-		data["TID"] = task_data->TID;
-		data["TransferStatus"] = task_data->TransferStatus;
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onErrRtnRepealBankToFutureByFutureManual(data, error);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcReqRepealField *task_data = (CThostFtdcReqRepealField*)task->task_data;
+        data["RepealTimeInterval"] = task_data->RepealTimeInterval;
+        data["RepealedTimes"] = task_data->RepealedTimes;
+        data["BankRepealFlag"] = task_data->BankRepealFlag;
+        data["BrokerRepealFlag"] = task_data->BrokerRepealFlag;
+        data["PlateRepealSerial"] = task_data->PlateRepealSerial;
+        data["BankRepealSerial"] = toUtf(task_data->BankRepealSerial);
+        data["FutureRepealSerial"] = task_data->FutureRepealSerial;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["CustType"] = task_data->CustType;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["InstallID"] = task_data->InstallID;
+        data["FutureSerial"] = task_data->FutureSerial;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["TradeAmount"] = task_data->TradeAmount;
+        data["FutureFetchAmount"] = task_data->FutureFetchAmount;
+        data["FeePayFlag"] = task_data->FeePayFlag;
+        data["CustFee"] = task_data->CustFee;
+        data["BrokerFee"] = task_data->BrokerFee;
+        data["Message"] = toUtf(task_data->Message);
+        data["Digest"] = toUtf(task_data->Digest);
+        data["BankAccType"] = task_data->BankAccType;
+        data["DeviceID"] = toUtf(task_data->DeviceID);
+        data["BankSecuAccType"] = task_data->BankSecuAccType;
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["OperNo"] = toUtf(task_data->OperNo);
+        data["RequestID"] = task_data->RequestID;
+        data["TID"] = task_data->TID;
+        data["TransferStatus"] = task_data->TransferStatus;
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onErrRtnRepealBankToFutureByFutureManual(data, error);
 };
 
 void TdApi::processErrRtnRepealFutureToBankByFutureManual(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcReqRepealField *task_data = (CThostFtdcReqRepealField*)task->task_data;
-		data["RepealTimeInterval"] = task_data->RepealTimeInterval;
-		data["RepealedTimes"] = task_data->RepealedTimes;
-		data["BankRepealFlag"] = task_data->BankRepealFlag;
-		data["BrokerRepealFlag"] = task_data->BrokerRepealFlag;
-		data["PlateRepealSerial"] = task_data->PlateRepealSerial;
-		data["BankRepealSerial"] = toUtf(task_data->BankRepealSerial);
-		data["FutureRepealSerial"] = task_data->FutureRepealSerial;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["CustType"] = task_data->CustType;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["InstallID"] = task_data->InstallID;
-		data["FutureSerial"] = task_data->FutureSerial;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["TradeAmount"] = task_data->TradeAmount;
-		data["FutureFetchAmount"] = task_data->FutureFetchAmount;
-		data["FeePayFlag"] = task_data->FeePayFlag;
-		data["CustFee"] = task_data->CustFee;
-		data["BrokerFee"] = task_data->BrokerFee;
-		data["Message"] = toUtf(task_data->Message);
-		data["Digest"] = toUtf(task_data->Digest);
-		data["BankAccType"] = task_data->BankAccType;
-		data["DeviceID"] = toUtf(task_data->DeviceID);
-		data["BankSecuAccType"] = task_data->BankSecuAccType;
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["OperNo"] = toUtf(task_data->OperNo);
-		data["RequestID"] = task_data->RequestID;
-		data["TID"] = task_data->TID;
-		data["TransferStatus"] = task_data->TransferStatus;
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onErrRtnRepealFutureToBankByFutureManual(data, error);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcReqRepealField *task_data = (CThostFtdcReqRepealField*)task->task_data;
+        data["RepealTimeInterval"] = task_data->RepealTimeInterval;
+        data["RepealedTimes"] = task_data->RepealedTimes;
+        data["BankRepealFlag"] = task_data->BankRepealFlag;
+        data["BrokerRepealFlag"] = task_data->BrokerRepealFlag;
+        data["PlateRepealSerial"] = task_data->PlateRepealSerial;
+        data["BankRepealSerial"] = toUtf(task_data->BankRepealSerial);
+        data["FutureRepealSerial"] = task_data->FutureRepealSerial;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["CustType"] = task_data->CustType;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["InstallID"] = task_data->InstallID;
+        data["FutureSerial"] = task_data->FutureSerial;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["TradeAmount"] = task_data->TradeAmount;
+        data["FutureFetchAmount"] = task_data->FutureFetchAmount;
+        data["FeePayFlag"] = task_data->FeePayFlag;
+        data["CustFee"] = task_data->CustFee;
+        data["BrokerFee"] = task_data->BrokerFee;
+        data["Message"] = toUtf(task_data->Message);
+        data["Digest"] = toUtf(task_data->Digest);
+        data["BankAccType"] = task_data->BankAccType;
+        data["DeviceID"] = toUtf(task_data->DeviceID);
+        data["BankSecuAccType"] = task_data->BankSecuAccType;
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["OperNo"] = toUtf(task_data->OperNo);
+        data["RequestID"] = task_data->RequestID;
+        data["TID"] = task_data->TID;
+        data["TransferStatus"] = task_data->TransferStatus;
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onErrRtnRepealFutureToBankByFutureManual(data, error);
 };
 
 void TdApi::processErrRtnQueryBankBalanceByFuture(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcReqQueryAccountField *task_data = (CThostFtdcReqQueryAccountField*)task->task_data;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["CustType"] = task_data->CustType;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["FutureSerial"] = task_data->FutureSerial;
-		data["InstallID"] = task_data->InstallID;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["Digest"] = toUtf(task_data->Digest);
-		data["BankAccType"] = task_data->BankAccType;
-		data["DeviceID"] = toUtf(task_data->DeviceID);
-		data["BankSecuAccType"] = task_data->BankSecuAccType;
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["OperNo"] = toUtf(task_data->OperNo);
-		data["RequestID"] = task_data->RequestID;
-		data["TID"] = task_data->TID;
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onErrRtnQueryBankBalanceByFuture(data, error);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcReqQueryAccountField *task_data = (CThostFtdcReqQueryAccountField*)task->task_data;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["CustType"] = task_data->CustType;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["FutureSerial"] = task_data->FutureSerial;
+        data["InstallID"] = task_data->InstallID;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["Digest"] = toUtf(task_data->Digest);
+        data["BankAccType"] = task_data->BankAccType;
+        data["DeviceID"] = toUtf(task_data->DeviceID);
+        data["BankSecuAccType"] = task_data->BankSecuAccType;
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["OperNo"] = toUtf(task_data->OperNo);
+        data["RequestID"] = task_data->RequestID;
+        data["TID"] = task_data->TID;
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onErrRtnQueryBankBalanceByFuture(data, error);
 };
 
 void TdApi::processRtnRepealFromBankToFutureByFuture(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcRspRepealField *task_data = (CThostFtdcRspRepealField*)task->task_data;
-		data["RepealTimeInterval"] = task_data->RepealTimeInterval;
-		data["RepealedTimes"] = task_data->RepealedTimes;
-		data["BankRepealFlag"] = task_data->BankRepealFlag;
-		data["BrokerRepealFlag"] = task_data->BrokerRepealFlag;
-		data["PlateRepealSerial"] = task_data->PlateRepealSerial;
-		data["BankRepealSerial"] = toUtf(task_data->BankRepealSerial);
-		data["FutureRepealSerial"] = task_data->FutureRepealSerial;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["CustType"] = task_data->CustType;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["InstallID"] = task_data->InstallID;
-		data["FutureSerial"] = task_data->FutureSerial;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["TradeAmount"] = task_data->TradeAmount;
-		data["FutureFetchAmount"] = task_data->FutureFetchAmount;
-		data["FeePayFlag"] = task_data->FeePayFlag;
-		data["CustFee"] = task_data->CustFee;
-		data["BrokerFee"] = task_data->BrokerFee;
-		data["Message"] = toUtf(task_data->Message);
-		data["Digest"] = toUtf(task_data->Digest);
-		data["BankAccType"] = task_data->BankAccType;
-		data["DeviceID"] = toUtf(task_data->DeviceID);
-		data["BankSecuAccType"] = task_data->BankSecuAccType;
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["OperNo"] = toUtf(task_data->OperNo);
-		data["RequestID"] = task_data->RequestID;
-		data["TID"] = task_data->TID;
-		data["TransferStatus"] = task_data->TransferStatus;
-		data["ErrorID"] = task_data->ErrorID;
-		data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	this->onRtnRepealFromBankToFutureByFuture(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcRspRepealField *task_data = (CThostFtdcRspRepealField*)task->task_data;
+        data["RepealTimeInterval"] = task_data->RepealTimeInterval;
+        data["RepealedTimes"] = task_data->RepealedTimes;
+        data["BankRepealFlag"] = task_data->BankRepealFlag;
+        data["BrokerRepealFlag"] = task_data->BrokerRepealFlag;
+        data["PlateRepealSerial"] = task_data->PlateRepealSerial;
+        data["BankRepealSerial"] = toUtf(task_data->BankRepealSerial);
+        data["FutureRepealSerial"] = task_data->FutureRepealSerial;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["CustType"] = task_data->CustType;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["InstallID"] = task_data->InstallID;
+        data["FutureSerial"] = task_data->FutureSerial;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["TradeAmount"] = task_data->TradeAmount;
+        data["FutureFetchAmount"] = task_data->FutureFetchAmount;
+        data["FeePayFlag"] = task_data->FeePayFlag;
+        data["CustFee"] = task_data->CustFee;
+        data["BrokerFee"] = task_data->BrokerFee;
+        data["Message"] = toUtf(task_data->Message);
+        data["Digest"] = toUtf(task_data->Digest);
+        data["BankAccType"] = task_data->BankAccType;
+        data["DeviceID"] = toUtf(task_data->DeviceID);
+        data["BankSecuAccType"] = task_data->BankSecuAccType;
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["OperNo"] = toUtf(task_data->OperNo);
+        data["RequestID"] = task_data->RequestID;
+        data["TID"] = task_data->TID;
+        data["TransferStatus"] = task_data->TransferStatus;
+        data["ErrorID"] = task_data->ErrorID;
+        data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    this->onRtnRepealFromBankToFutureByFuture(data);
 };
 
 void TdApi::processRtnRepealFromFutureToBankByFuture(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcRspRepealField *task_data = (CThostFtdcRspRepealField*)task->task_data;
-		data["RepealTimeInterval"] = task_data->RepealTimeInterval;
-		data["RepealedTimes"] = task_data->RepealedTimes;
-		data["BankRepealFlag"] = task_data->BankRepealFlag;
-		data["BrokerRepealFlag"] = task_data->BrokerRepealFlag;
-		data["PlateRepealSerial"] = task_data->PlateRepealSerial;
-		data["BankRepealSerial"] = toUtf(task_data->BankRepealSerial);
-		data["FutureRepealSerial"] = task_data->FutureRepealSerial;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["CustType"] = task_data->CustType;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["InstallID"] = task_data->InstallID;
-		data["FutureSerial"] = task_data->FutureSerial;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["TradeAmount"] = task_data->TradeAmount;
-		data["FutureFetchAmount"] = task_data->FutureFetchAmount;
-		data["FeePayFlag"] = task_data->FeePayFlag;
-		data["CustFee"] = task_data->CustFee;
-		data["BrokerFee"] = task_data->BrokerFee;
-		data["Message"] = toUtf(task_data->Message);
-		data["Digest"] = toUtf(task_data->Digest);
-		data["BankAccType"] = task_data->BankAccType;
-		data["DeviceID"] = toUtf(task_data->DeviceID);
-		data["BankSecuAccType"] = task_data->BankSecuAccType;
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["OperNo"] = toUtf(task_data->OperNo);
-		data["RequestID"] = task_data->RequestID;
-		data["TID"] = task_data->TID;
-		data["TransferStatus"] = task_data->TransferStatus;
-		data["ErrorID"] = task_data->ErrorID;
-		data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	this->onRtnRepealFromFutureToBankByFuture(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcRspRepealField *task_data = (CThostFtdcRspRepealField*)task->task_data;
+        data["RepealTimeInterval"] = task_data->RepealTimeInterval;
+        data["RepealedTimes"] = task_data->RepealedTimes;
+        data["BankRepealFlag"] = task_data->BankRepealFlag;
+        data["BrokerRepealFlag"] = task_data->BrokerRepealFlag;
+        data["PlateRepealSerial"] = task_data->PlateRepealSerial;
+        data["BankRepealSerial"] = toUtf(task_data->BankRepealSerial);
+        data["FutureRepealSerial"] = task_data->FutureRepealSerial;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["CustType"] = task_data->CustType;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["InstallID"] = task_data->InstallID;
+        data["FutureSerial"] = task_data->FutureSerial;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["TradeAmount"] = task_data->TradeAmount;
+        data["FutureFetchAmount"] = task_data->FutureFetchAmount;
+        data["FeePayFlag"] = task_data->FeePayFlag;
+        data["CustFee"] = task_data->CustFee;
+        data["BrokerFee"] = task_data->BrokerFee;
+        data["Message"] = toUtf(task_data->Message);
+        data["Digest"] = toUtf(task_data->Digest);
+        data["BankAccType"] = task_data->BankAccType;
+        data["DeviceID"] = toUtf(task_data->DeviceID);
+        data["BankSecuAccType"] = task_data->BankSecuAccType;
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["OperNo"] = toUtf(task_data->OperNo);
+        data["RequestID"] = task_data->RequestID;
+        data["TID"] = task_data->TID;
+        data["TransferStatus"] = task_data->TransferStatus;
+        data["ErrorID"] = task_data->ErrorID;
+        data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    this->onRtnRepealFromFutureToBankByFuture(data);
 };
 
 void TdApi::processRspFromBankToFutureByFuture(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcReqTransferField *task_data = (CThostFtdcReqTransferField*)task->task_data;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["CustType"] = task_data->CustType;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["InstallID"] = task_data->InstallID;
-		data["FutureSerial"] = task_data->FutureSerial;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["TradeAmount"] = task_data->TradeAmount;
-		data["FutureFetchAmount"] = task_data->FutureFetchAmount;
-		data["FeePayFlag"] = task_data->FeePayFlag;
-		data["CustFee"] = task_data->CustFee;
-		data["BrokerFee"] = task_data->BrokerFee;
-		data["Message"] = toUtf(task_data->Message);
-		data["Digest"] = toUtf(task_data->Digest);
-		data["BankAccType"] = task_data->BankAccType;
-		data["DeviceID"] = toUtf(task_data->DeviceID);
-		data["BankSecuAccType"] = task_data->BankSecuAccType;
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["OperNo"] = toUtf(task_data->OperNo);
-		data["RequestID"] = task_data->RequestID;
-		data["TID"] = task_data->TID;
-		data["TransferStatus"] = task_data->TransferStatus;
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspFromBankToFutureByFuture(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcReqTransferField *task_data = (CThostFtdcReqTransferField*)task->task_data;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["CustType"] = task_data->CustType;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["InstallID"] = task_data->InstallID;
+        data["FutureSerial"] = task_data->FutureSerial;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["TradeAmount"] = task_data->TradeAmount;
+        data["FutureFetchAmount"] = task_data->FutureFetchAmount;
+        data["FeePayFlag"] = task_data->FeePayFlag;
+        data["CustFee"] = task_data->CustFee;
+        data["BrokerFee"] = task_data->BrokerFee;
+        data["Message"] = toUtf(task_data->Message);
+        data["Digest"] = toUtf(task_data->Digest);
+        data["BankAccType"] = task_data->BankAccType;
+        data["DeviceID"] = toUtf(task_data->DeviceID);
+        data["BankSecuAccType"] = task_data->BankSecuAccType;
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["OperNo"] = toUtf(task_data->OperNo);
+        data["RequestID"] = task_data->RequestID;
+        data["TID"] = task_data->TID;
+        data["TransferStatus"] = task_data->TransferStatus;
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspFromBankToFutureByFuture(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspFromFutureToBankByFuture(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcReqTransferField *task_data = (CThostFtdcReqTransferField*)task->task_data;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["CustType"] = task_data->CustType;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["InstallID"] = task_data->InstallID;
-		data["FutureSerial"] = task_data->FutureSerial;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["TradeAmount"] = task_data->TradeAmount;
-		data["FutureFetchAmount"] = task_data->FutureFetchAmount;
-		data["FeePayFlag"] = task_data->FeePayFlag;
-		data["CustFee"] = task_data->CustFee;
-		data["BrokerFee"] = task_data->BrokerFee;
-		data["Message"] = toUtf(task_data->Message);
-		data["Digest"] = toUtf(task_data->Digest);
-		data["BankAccType"] = task_data->BankAccType;
-		data["DeviceID"] = toUtf(task_data->DeviceID);
-		data["BankSecuAccType"] = task_data->BankSecuAccType;
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["OperNo"] = toUtf(task_data->OperNo);
-		data["RequestID"] = task_data->RequestID;
-		data["TID"] = task_data->TID;
-		data["TransferStatus"] = task_data->TransferStatus;
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspFromFutureToBankByFuture(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcReqTransferField *task_data = (CThostFtdcReqTransferField*)task->task_data;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["CustType"] = task_data->CustType;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["InstallID"] = task_data->InstallID;
+        data["FutureSerial"] = task_data->FutureSerial;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["TradeAmount"] = task_data->TradeAmount;
+        data["FutureFetchAmount"] = task_data->FutureFetchAmount;
+        data["FeePayFlag"] = task_data->FeePayFlag;
+        data["CustFee"] = task_data->CustFee;
+        data["BrokerFee"] = task_data->BrokerFee;
+        data["Message"] = toUtf(task_data->Message);
+        data["Digest"] = toUtf(task_data->Digest);
+        data["BankAccType"] = task_data->BankAccType;
+        data["DeviceID"] = toUtf(task_data->DeviceID);
+        data["BankSecuAccType"] = task_data->BankSecuAccType;
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["OperNo"] = toUtf(task_data->OperNo);
+        data["RequestID"] = task_data->RequestID;
+        data["TID"] = task_data->TID;
+        data["TransferStatus"] = task_data->TransferStatus;
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspFromFutureToBankByFuture(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRspQueryBankAccountMoneyByFuture(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcReqQueryAccountField *task_data = (CThostFtdcReqQueryAccountField*)task->task_data;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["CustType"] = task_data->CustType;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["FutureSerial"] = task_data->FutureSerial;
-		data["InstallID"] = task_data->InstallID;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["Digest"] = toUtf(task_data->Digest);
-		data["BankAccType"] = task_data->BankAccType;
-		data["DeviceID"] = toUtf(task_data->DeviceID);
-		data["BankSecuAccType"] = task_data->BankSecuAccType;
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["OperNo"] = toUtf(task_data->OperNo);
-		data["RequestID"] = task_data->RequestID;
-		data["TID"] = task_data->TID;
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	dict error;
-	if (task->task_error)
-	{
-		CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
-		error["ErrorID"] = task_error->ErrorID;
-		error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
-		delete task->task_error;
-	}
-	this->onRspQueryBankAccountMoneyByFuture(data, error, task->task_id, task->task_last);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcReqQueryAccountField *task_data = (CThostFtdcReqQueryAccountField*)task->task_data;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["CustType"] = task_data->CustType;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["FutureSerial"] = task_data->FutureSerial;
+        data["InstallID"] = task_data->InstallID;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["Digest"] = toUtf(task_data->Digest);
+        data["BankAccType"] = task_data->BankAccType;
+        data["DeviceID"] = toUtf(task_data->DeviceID);
+        data["BankSecuAccType"] = task_data->BankSecuAccType;
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["OperNo"] = toUtf(task_data->OperNo);
+        data["RequestID"] = task_data->RequestID;
+        data["TID"] = task_data->TID;
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    dict error;
+    if (task->task_error)
+    {
+        CThostFtdcRspInfoField *task_error = (CThostFtdcRspInfoField*)task->task_error;
+        error["ErrorID"] = task_error->ErrorID;
+        error["ErrorMsg"] = toUtf(task_error->ErrorMsg);
+        delete task->task_error;
+    }
+    this->onRspQueryBankAccountMoneyByFuture(data, error, task->task_id, task->task_last);
 };
 
 void TdApi::processRtnOpenAccountByBank(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcOpenAccountField *task_data = (CThostFtdcOpenAccountField*)task->task_data;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["Gender"] = task_data->Gender;
-		data["CountryCode"] = toUtf(task_data->CountryCode);
-		data["CustType"] = task_data->CustType;
-		data["Address"] = toUtf(task_data->Address);
-		data["ZipCode"] = toUtf(task_data->ZipCode);
-		data["Telephone"] = toUtf(task_data->Telephone);
-		data["MobilePhone"] = toUtf(task_data->MobilePhone);
-		data["Fax"] = toUtf(task_data->Fax);
-		data["EMail"] = toUtf(task_data->EMail);
-		data["MoneyAccountStatus"] = task_data->MoneyAccountStatus;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["InstallID"] = task_data->InstallID;
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["CashExchangeCode"] = task_data->CashExchangeCode;
-		data["Digest"] = toUtf(task_data->Digest);
-		data["BankAccType"] = task_data->BankAccType;
-		data["DeviceID"] = toUtf(task_data->DeviceID);
-		data["BankSecuAccType"] = task_data->BankSecuAccType;
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["OperNo"] = toUtf(task_data->OperNo);
-		data["TID"] = task_data->TID;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["ErrorID"] = task_data->ErrorID;
-		data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	this->onRtnOpenAccountByBank(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcOpenAccountField *task_data = (CThostFtdcOpenAccountField*)task->task_data;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["Gender"] = task_data->Gender;
+        data["CountryCode"] = toUtf(task_data->CountryCode);
+        data["CustType"] = task_data->CustType;
+        data["Address"] = toUtf(task_data->Address);
+        data["ZipCode"] = toUtf(task_data->ZipCode);
+        data["Telephone"] = toUtf(task_data->Telephone);
+        data["MobilePhone"] = toUtf(task_data->MobilePhone);
+        data["Fax"] = toUtf(task_data->Fax);
+        data["EMail"] = toUtf(task_data->EMail);
+        data["MoneyAccountStatus"] = task_data->MoneyAccountStatus;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["InstallID"] = task_data->InstallID;
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["CashExchangeCode"] = task_data->CashExchangeCode;
+        data["Digest"] = toUtf(task_data->Digest);
+        data["BankAccType"] = task_data->BankAccType;
+        data["DeviceID"] = toUtf(task_data->DeviceID);
+        data["BankSecuAccType"] = task_data->BankSecuAccType;
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["OperNo"] = toUtf(task_data->OperNo);
+        data["TID"] = task_data->TID;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["ErrorID"] = task_data->ErrorID;
+        data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    this->onRtnOpenAccountByBank(data);
 };
 
 void TdApi::processRtnCancelAccountByBank(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcCancelAccountField *task_data = (CThostFtdcCancelAccountField*)task->task_data;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["Gender"] = task_data->Gender;
-		data["CountryCode"] = toUtf(task_data->CountryCode);
-		data["CustType"] = task_data->CustType;
-		data["Address"] = toUtf(task_data->Address);
-		data["ZipCode"] = toUtf(task_data->ZipCode);
-		data["Telephone"] = toUtf(task_data->Telephone);
-		data["MobilePhone"] = toUtf(task_data->MobilePhone);
-		data["Fax"] = toUtf(task_data->Fax);
-		data["EMail"] = toUtf(task_data->EMail);
-		data["MoneyAccountStatus"] = task_data->MoneyAccountStatus;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["InstallID"] = task_data->InstallID;
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["CashExchangeCode"] = task_data->CashExchangeCode;
-		data["Digest"] = toUtf(task_data->Digest);
-		data["BankAccType"] = task_data->BankAccType;
-		data["DeviceID"] = toUtf(task_data->DeviceID);
-		data["BankSecuAccType"] = task_data->BankSecuAccType;
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["OperNo"] = toUtf(task_data->OperNo);
-		data["TID"] = task_data->TID;
-		data["UserID"] = toUtf(task_data->UserID);
-		data["ErrorID"] = task_data->ErrorID;
-		data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	this->onRtnCancelAccountByBank(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcCancelAccountField *task_data = (CThostFtdcCancelAccountField*)task->task_data;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["Gender"] = task_data->Gender;
+        data["CountryCode"] = toUtf(task_data->CountryCode);
+        data["CustType"] = task_data->CustType;
+        data["Address"] = toUtf(task_data->Address);
+        data["ZipCode"] = toUtf(task_data->ZipCode);
+        data["Telephone"] = toUtf(task_data->Telephone);
+        data["MobilePhone"] = toUtf(task_data->MobilePhone);
+        data["Fax"] = toUtf(task_data->Fax);
+        data["EMail"] = toUtf(task_data->EMail);
+        data["MoneyAccountStatus"] = task_data->MoneyAccountStatus;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["InstallID"] = task_data->InstallID;
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["CashExchangeCode"] = task_data->CashExchangeCode;
+        data["Digest"] = toUtf(task_data->Digest);
+        data["BankAccType"] = task_data->BankAccType;
+        data["DeviceID"] = toUtf(task_data->DeviceID);
+        data["BankSecuAccType"] = task_data->BankSecuAccType;
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankSecuAcc"] = toUtf(task_data->BankSecuAcc);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["OperNo"] = toUtf(task_data->OperNo);
+        data["TID"] = task_data->TID;
+        data["UserID"] = toUtf(task_data->UserID);
+        data["ErrorID"] = task_data->ErrorID;
+        data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    this->onRtnCancelAccountByBank(data);
 };
 
 void TdApi::processRtnChangeAccountByBank(Task *task)
 {
-	gil_scoped_acquire acquire;
-	dict data;
-	if (task->task_data)
-	{
-		CThostFtdcChangeAccountField *task_data = (CThostFtdcChangeAccountField*)task->task_data;
-		data["TradeCode"] = toUtf(task_data->TradeCode);
-		data["BankID"] = toUtf(task_data->BankID);
-		data["BankBranchID"] = toUtf(task_data->BankBranchID);
-		data["BrokerID"] = toUtf(task_data->BrokerID);
-		data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
-		data["TradeDate"] = toUtf(task_data->TradeDate);
-		data["TradeTime"] = toUtf(task_data->TradeTime);
-		data["BankSerial"] = toUtf(task_data->BankSerial);
-		data["TradingDay"] = toUtf(task_data->TradingDay);
-		data["PlateSerial"] = task_data->PlateSerial;
-		data["LastFragment"] = task_data->LastFragment;
-		data["SessionID"] = task_data->SessionID;
-		data["CustomerName"] = toUtf(task_data->CustomerName);
-		data["IdCardType"] = task_data->IdCardType;
-		data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
-		data["Gender"] = task_data->Gender;
-		data["CountryCode"] = toUtf(task_data->CountryCode);
-		data["CustType"] = task_data->CustType;
-		data["Address"] = toUtf(task_data->Address);
-		data["ZipCode"] = toUtf(task_data->ZipCode);
-		data["Telephone"] = toUtf(task_data->Telephone);
-		data["MobilePhone"] = toUtf(task_data->MobilePhone);
-		data["Fax"] = toUtf(task_data->Fax);
-		data["EMail"] = toUtf(task_data->EMail);
-		data["MoneyAccountStatus"] = task_data->MoneyAccountStatus;
-		data["BankAccount"] = toUtf(task_data->BankAccount);
-		data["BankPassWord"] = toUtf(task_data->BankPassWord);
-		data["NewBankAccount"] = toUtf(task_data->NewBankAccount);
-		data["NewBankPassWord"] = toUtf(task_data->NewBankPassWord);
-		data["AccountID"] = toUtf(task_data->AccountID);
-		data["Password"] = toUtf(task_data->Password);
-		data["BankAccType"] = task_data->BankAccType;
-		data["InstallID"] = task_data->InstallID;
-		data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
-		data["CurrencyID"] = toUtf(task_data->CurrencyID);
-		data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
-		data["BankPwdFlag"] = task_data->BankPwdFlag;
-		data["SecuPwdFlag"] = task_data->SecuPwdFlag;
-		data["TID"] = task_data->TID;
-		data["Digest"] = toUtf(task_data->Digest);
-		data["ErrorID"] = task_data->ErrorID;
-		data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
-		data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
-		delete task->task_data;
-	}
-	this->onRtnChangeAccountByBank(data);
+    gil_scoped_acquire acquire;
+    dict data;
+    if (task->task_data)
+    {
+        CThostFtdcChangeAccountField *task_data = (CThostFtdcChangeAccountField*)task->task_data;
+        data["TradeCode"] = toUtf(task_data->TradeCode);
+        data["BankID"] = toUtf(task_data->BankID);
+        data["BankBranchID"] = toUtf(task_data->BankBranchID);
+        data["BrokerID"] = toUtf(task_data->BrokerID);
+        data["BrokerBranchID"] = toUtf(task_data->BrokerBranchID);
+        data["TradeDate"] = toUtf(task_data->TradeDate);
+        data["TradeTime"] = toUtf(task_data->TradeTime);
+        data["BankSerial"] = toUtf(task_data->BankSerial);
+        data["TradingDay"] = toUtf(task_data->TradingDay);
+        data["PlateSerial"] = task_data->PlateSerial;
+        data["LastFragment"] = task_data->LastFragment;
+        data["SessionID"] = task_data->SessionID;
+        data["CustomerName"] = toUtf(task_data->CustomerName);
+        data["IdCardType"] = task_data->IdCardType;
+        data["IdentifiedCardNo"] = toUtf(task_data->IdentifiedCardNo);
+        data["Gender"] = task_data->Gender;
+        data["CountryCode"] = toUtf(task_data->CountryCode);
+        data["CustType"] = task_data->CustType;
+        data["Address"] = toUtf(task_data->Address);
+        data["ZipCode"] = toUtf(task_data->ZipCode);
+        data["Telephone"] = toUtf(task_data->Telephone);
+        data["MobilePhone"] = toUtf(task_data->MobilePhone);
+        data["Fax"] = toUtf(task_data->Fax);
+        data["EMail"] = toUtf(task_data->EMail);
+        data["MoneyAccountStatus"] = task_data->MoneyAccountStatus;
+        data["BankAccount"] = toUtf(task_data->BankAccount);
+        data["BankPassWord"] = toUtf(task_data->BankPassWord);
+        data["NewBankAccount"] = toUtf(task_data->NewBankAccount);
+        data["NewBankPassWord"] = toUtf(task_data->NewBankPassWord);
+        data["AccountID"] = toUtf(task_data->AccountID);
+        data["Password"] = toUtf(task_data->Password);
+        data["BankAccType"] = task_data->BankAccType;
+        data["InstallID"] = task_data->InstallID;
+        data["VerifyCertNoFlag"] = task_data->VerifyCertNoFlag;
+        data["CurrencyID"] = toUtf(task_data->CurrencyID);
+        data["BrokerIDByBank"] = toUtf(task_data->BrokerIDByBank);
+        data["BankPwdFlag"] = task_data->BankPwdFlag;
+        data["SecuPwdFlag"] = task_data->SecuPwdFlag;
+        data["TID"] = task_data->TID;
+        data["Digest"] = toUtf(task_data->Digest);
+        data["ErrorID"] = task_data->ErrorID;
+        data["ErrorMsg"] = toUtf(task_data->ErrorMsg);
+        data["LongCustomerName"] = toUtf(task_data->LongCustomerName);
+        delete task->task_data;
+    }
+    this->onRtnChangeAccountByBank(data);
 };
+
 
 
 ///-------------------------------------------------------------------------------------
@@ -7941,7 +7942,7 @@ void TdApi::subscribePublicTopic(int nType)
 	this->api->SubscribePublicTopic((THOST_TE_RESUME_TYPE)nType);
 };
 
-int TdApi::reqAuthenticate(dict req, int reqid)
+int TdApi::reqAuthenticate(const dict &req, int reqid)
 {
 	CThostFtdcReqAuthenticateField myreq = CThostFtdcReqAuthenticateField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -7953,7 +7954,7 @@ int TdApi::reqAuthenticate(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqUserLogin(dict req, int reqid)
+int TdApi::reqUserLogin(const dict &req, int reqid)
 {
 	CThostFtdcReqUserLoginField myreq = CThostFtdcReqUserLoginField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -7972,7 +7973,7 @@ int TdApi::reqUserLogin(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqUserLogout(dict req, int reqid)
+int TdApi::reqUserLogout(const dict &req, int reqid)
 {
 	CThostFtdcUserLogoutField myreq = CThostFtdcUserLogoutField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -7982,7 +7983,7 @@ int TdApi::reqUserLogout(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqUserPasswordUpdate(dict req, int reqid)
+int TdApi::reqUserPasswordUpdate(const dict &req, int reqid)
 {
 	CThostFtdcUserPasswordUpdateField myreq = CThostFtdcUserPasswordUpdateField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -7994,7 +7995,7 @@ int TdApi::reqUserPasswordUpdate(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqTradingAccountPasswordUpdate(dict req, int reqid)
+int TdApi::reqTradingAccountPasswordUpdate(const dict &req, int reqid)
 {
 	CThostFtdcTradingAccountPasswordUpdateField myreq = CThostFtdcTradingAccountPasswordUpdateField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8007,7 +8008,7 @@ int TdApi::reqTradingAccountPasswordUpdate(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqUserLogin2(dict req, int reqid)
+int TdApi::reqUserLogin2(const dict &req, int reqid)
 {
 	CThostFtdcReqUserLoginField myreq = CThostFtdcReqUserLoginField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8026,7 +8027,7 @@ int TdApi::reqUserLogin2(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqUserPasswordUpdate2(dict req, int reqid)
+int TdApi::reqUserPasswordUpdate2(const dict &req, int reqid)
 {
 	CThostFtdcUserPasswordUpdateField myreq = CThostFtdcUserPasswordUpdateField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8038,7 +8039,7 @@ int TdApi::reqUserPasswordUpdate2(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqOrderInsert(dict req, int reqid)
+int TdApi::reqOrderInsert(const dict &req, int reqid)
 {
 	CThostFtdcInputOrderField myreq = CThostFtdcInputOrderField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8076,7 +8077,7 @@ int TdApi::reqOrderInsert(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqParkedOrderInsert(dict req, int reqid)
+int TdApi::reqParkedOrderInsert(const dict &req, int reqid)
 {
 	CThostFtdcParkedOrderField myreq = CThostFtdcParkedOrderField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8119,7 +8120,7 @@ int TdApi::reqParkedOrderInsert(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqParkedOrderAction(dict req, int reqid)
+int TdApi::reqParkedOrderAction(const dict &req, int reqid)
 {
 	CThostFtdcParkedOrderActionField myreq = CThostFtdcParkedOrderActionField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8149,7 +8150,7 @@ int TdApi::reqParkedOrderAction(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqOrderAction(dict req, int reqid)
+int TdApi::reqOrderAction(const dict &req, int reqid)
 {
 	CThostFtdcInputOrderActionField myreq = CThostFtdcInputOrderActionField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8174,7 +8175,7 @@ int TdApi::reqOrderAction(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQueryMaxOrderVolume(dict req, int reqid)
+int TdApi::reqQueryMaxOrderVolume(const dict &req, int reqid)
 {
 	CThostFtdcQueryMaxOrderVolumeField myreq = CThostFtdcQueryMaxOrderVolumeField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8191,7 +8192,7 @@ int TdApi::reqQueryMaxOrderVolume(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqSettlementInfoConfirm(dict req, int reqid)
+int TdApi::reqSettlementInfoConfirm(const dict &req, int reqid)
 {
 	CThostFtdcSettlementInfoConfirmField myreq = CThostFtdcSettlementInfoConfirmField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8206,7 +8207,7 @@ int TdApi::reqSettlementInfoConfirm(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqRemoveParkedOrder(dict req, int reqid)
+int TdApi::reqRemoveParkedOrder(const dict &req, int reqid)
 {
 	CThostFtdcRemoveParkedOrderField myreq = CThostFtdcRemoveParkedOrderField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8218,7 +8219,7 @@ int TdApi::reqRemoveParkedOrder(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqRemoveParkedOrderAction(dict req, int reqid)
+int TdApi::reqRemoveParkedOrderAction(const dict &req, int reqid)
 {
 	CThostFtdcRemoveParkedOrderActionField myreq = CThostFtdcRemoveParkedOrderActionField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8230,7 +8231,7 @@ int TdApi::reqRemoveParkedOrderAction(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqExecOrderInsert(dict req, int reqid)
+int TdApi::reqExecOrderInsert(const dict &req, int reqid)
 {
 	CThostFtdcInputExecOrderField myreq = CThostFtdcInputExecOrderField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8259,7 +8260,7 @@ int TdApi::reqExecOrderInsert(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqExecOrderAction(dict req, int reqid)
+int TdApi::reqExecOrderAction(const dict &req, int reqid)
 {
 	CThostFtdcInputExecOrderActionField myreq = CThostFtdcInputExecOrderActionField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8282,7 +8283,7 @@ int TdApi::reqExecOrderAction(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqForQuoteInsert(dict req, int reqid)
+int TdApi::reqForQuoteInsert(const dict &req, int reqid)
 {
 	CThostFtdcInputForQuoteField myreq = CThostFtdcInputForQuoteField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8299,7 +8300,7 @@ int TdApi::reqForQuoteInsert(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQuoteInsert(dict req, int reqid)
+int TdApi::reqQuoteInsert(const dict &req, int reqid)
 {
 	CThostFtdcInputQuoteField myreq = CThostFtdcInputQuoteField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8330,7 +8331,7 @@ int TdApi::reqQuoteInsert(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQuoteAction(dict req, int reqid)
+int TdApi::reqQuoteAction(const dict &req, int reqid)
 {
 	CThostFtdcInputQuoteActionField myreq = CThostFtdcInputQuoteActionField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8354,7 +8355,7 @@ int TdApi::reqQuoteAction(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqBatchOrderAction(dict req, int reqid)
+int TdApi::reqBatchOrderAction(const dict &req, int reqid)
 {
 	CThostFtdcInputBatchOrderActionField myreq = CThostFtdcInputBatchOrderActionField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8373,7 +8374,7 @@ int TdApi::reqBatchOrderAction(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqOptionSelfCloseInsert(dict req, int reqid)
+int TdApi::reqOptionSelfCloseInsert(const dict &req, int reqid)
 {
 	CThostFtdcInputOptionSelfCloseField myreq = CThostFtdcInputOptionSelfCloseField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8398,7 +8399,7 @@ int TdApi::reqOptionSelfCloseInsert(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqOptionSelfCloseAction(dict req, int reqid)
+int TdApi::reqOptionSelfCloseAction(const dict &req, int reqid)
 {
 	CThostFtdcInputOptionSelfCloseActionField myreq = CThostFtdcInputOptionSelfCloseActionField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8421,7 +8422,7 @@ int TdApi::reqOptionSelfCloseAction(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqCombActionInsert(dict req, int reqid)
+int TdApi::reqCombActionInsert(const dict &req, int reqid)
 {
 	CThostFtdcInputCombActionField myreq = CThostFtdcInputCombActionField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8442,7 +8443,7 @@ int TdApi::reqCombActionInsert(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryOrder(dict req, int reqid)
+int TdApi::reqQryOrder(const dict &req, int reqid)
 {
 	CThostFtdcQryOrderField myreq = CThostFtdcQryOrderField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8458,7 +8459,7 @@ int TdApi::reqQryOrder(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryTrade(dict req, int reqid)
+int TdApi::reqQryTrade(const dict &req, int reqid)
 {
 	CThostFtdcQryTradeField myreq = CThostFtdcQryTradeField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8474,7 +8475,7 @@ int TdApi::reqQryTrade(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryInvestorPosition(dict req, int reqid)
+int TdApi::reqQryInvestorPosition(const dict &req, int reqid)
 {
 	CThostFtdcQryInvestorPositionField myreq = CThostFtdcQryInvestorPositionField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8487,7 +8488,7 @@ int TdApi::reqQryInvestorPosition(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryTradingAccount(dict req, int reqid)
+int TdApi::reqQryTradingAccount(const dict &req, int reqid)
 {
 	CThostFtdcQryTradingAccountField myreq = CThostFtdcQryTradingAccountField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8500,7 +8501,7 @@ int TdApi::reqQryTradingAccount(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryInvestor(dict req, int reqid)
+int TdApi::reqQryInvestor(const dict &req, int reqid)
 {
 	CThostFtdcQryInvestorField myreq = CThostFtdcQryInvestorField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8510,7 +8511,7 @@ int TdApi::reqQryInvestor(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryTradingCode(dict req, int reqid)
+int TdApi::reqQryTradingCode(const dict &req, int reqid)
 {
 	CThostFtdcQryTradingCodeField myreq = CThostFtdcQryTradingCodeField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8524,7 +8525,7 @@ int TdApi::reqQryTradingCode(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryInstrumentMarginRate(dict req, int reqid)
+int TdApi::reqQryInstrumentMarginRate(const dict &req, int reqid)
 {
 	CThostFtdcQryInstrumentMarginRateField myreq = CThostFtdcQryInstrumentMarginRateField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8538,7 +8539,7 @@ int TdApi::reqQryInstrumentMarginRate(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryInstrumentCommissionRate(dict req, int reqid)
+int TdApi::reqQryInstrumentCommissionRate(const dict &req, int reqid)
 {
 	CThostFtdcQryInstrumentCommissionRateField myreq = CThostFtdcQryInstrumentCommissionRateField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8551,7 +8552,7 @@ int TdApi::reqQryInstrumentCommissionRate(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryExchange(dict req, int reqid)
+int TdApi::reqQryExchange(const dict &req, int reqid)
 {
 	CThostFtdcQryExchangeField myreq = CThostFtdcQryExchangeField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8560,7 +8561,7 @@ int TdApi::reqQryExchange(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryProduct(dict req, int reqid)
+int TdApi::reqQryProduct(const dict &req, int reqid)
 {
 	CThostFtdcQryProductField myreq = CThostFtdcQryProductField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8571,7 +8572,7 @@ int TdApi::reqQryProduct(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryInstrument(dict req, int reqid)
+int TdApi::reqQryInstrument(const dict &req, int reqid)
 {
 	CThostFtdcQryInstrumentField myreq = CThostFtdcQryInstrumentField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8583,7 +8584,7 @@ int TdApi::reqQryInstrument(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryDepthMarketData(dict req, int reqid)
+int TdApi::reqQryDepthMarketData(const dict &req, int reqid)
 {
 	CThostFtdcQryDepthMarketDataField myreq = CThostFtdcQryDepthMarketDataField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8593,7 +8594,7 @@ int TdApi::reqQryDepthMarketData(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQrySettlementInfo(dict req, int reqid)
+int TdApi::reqQrySettlementInfo(const dict &req, int reqid)
 {
 	CThostFtdcQrySettlementInfoField myreq = CThostFtdcQrySettlementInfoField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8606,7 +8607,7 @@ int TdApi::reqQrySettlementInfo(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryTransferBank(dict req, int reqid)
+int TdApi::reqQryTransferBank(const dict &req, int reqid)
 {
 	CThostFtdcQryTransferBankField myreq = CThostFtdcQryTransferBankField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8616,7 +8617,7 @@ int TdApi::reqQryTransferBank(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryInvestorPositionDetail(dict req, int reqid)
+int TdApi::reqQryInvestorPositionDetail(const dict &req, int reqid)
 {
 	CThostFtdcQryInvestorPositionDetailField myreq = CThostFtdcQryInvestorPositionDetailField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8629,7 +8630,7 @@ int TdApi::reqQryInvestorPositionDetail(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryNotice(dict req, int reqid)
+int TdApi::reqQryNotice(const dict &req, int reqid)
 {
 	CThostFtdcQryNoticeField myreq = CThostFtdcQryNoticeField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8638,7 +8639,7 @@ int TdApi::reqQryNotice(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQrySettlementInfoConfirm(dict req, int reqid)
+int TdApi::reqQrySettlementInfoConfirm(const dict &req, int reqid)
 {
 	CThostFtdcQrySettlementInfoConfirmField myreq = CThostFtdcQrySettlementInfoConfirmField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8650,7 +8651,7 @@ int TdApi::reqQrySettlementInfoConfirm(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryInvestorPositionCombineDetail(dict req, int reqid)
+int TdApi::reqQryInvestorPositionCombineDetail(const dict &req, int reqid)
 {
 	CThostFtdcQryInvestorPositionCombineDetailField myreq = CThostFtdcQryInvestorPositionCombineDetailField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8663,7 +8664,7 @@ int TdApi::reqQryInvestorPositionCombineDetail(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryCFMMCTradingAccountKey(dict req, int reqid)
+int TdApi::reqQryCFMMCTradingAccountKey(const dict &req, int reqid)
 {
 	CThostFtdcQryCFMMCTradingAccountKeyField myreq = CThostFtdcQryCFMMCTradingAccountKeyField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8673,7 +8674,7 @@ int TdApi::reqQryCFMMCTradingAccountKey(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryEWarrantOffset(dict req, int reqid)
+int TdApi::reqQryEWarrantOffset(const dict &req, int reqid)
 {
 	CThostFtdcQryEWarrantOffsetField myreq = CThostFtdcQryEWarrantOffsetField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8686,7 +8687,7 @@ int TdApi::reqQryEWarrantOffset(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryInvestorProductGroupMargin(dict req, int reqid)
+int TdApi::reqQryInvestorProductGroupMargin(const dict &req, int reqid)
 {
 	CThostFtdcQryInvestorProductGroupMarginField myreq = CThostFtdcQryInvestorProductGroupMarginField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8700,7 +8701,7 @@ int TdApi::reqQryInvestorProductGroupMargin(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryExchangeMarginRate(dict req, int reqid)
+int TdApi::reqQryExchangeMarginRate(const dict &req, int reqid)
 {
 	CThostFtdcQryExchangeMarginRateField myreq = CThostFtdcQryExchangeMarginRateField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8712,7 +8713,7 @@ int TdApi::reqQryExchangeMarginRate(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryExchangeMarginRateAdjust(dict req, int reqid)
+int TdApi::reqQryExchangeMarginRateAdjust(const dict &req, int reqid)
 {
 	CThostFtdcQryExchangeMarginRateAdjustField myreq = CThostFtdcQryExchangeMarginRateAdjustField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8723,7 +8724,7 @@ int TdApi::reqQryExchangeMarginRateAdjust(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryExchangeRate(dict req, int reqid)
+int TdApi::reqQryExchangeRate(const dict &req, int reqid)
 {
 	CThostFtdcQryExchangeRateField myreq = CThostFtdcQryExchangeRateField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8734,7 +8735,7 @@ int TdApi::reqQryExchangeRate(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQrySecAgentACIDMap(dict req, int reqid)
+int TdApi::reqQrySecAgentACIDMap(const dict &req, int reqid)
 {
 	CThostFtdcQrySecAgentACIDMapField myreq = CThostFtdcQrySecAgentACIDMapField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8746,7 +8747,7 @@ int TdApi::reqQrySecAgentACIDMap(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryProductExchRate(dict req, int reqid)
+int TdApi::reqQryProductExchRate(const dict &req, int reqid)
 {
 	CThostFtdcQryProductExchRateField myreq = CThostFtdcQryProductExchRateField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8756,7 +8757,7 @@ int TdApi::reqQryProductExchRate(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryProductGroup(dict req, int reqid)
+int TdApi::reqQryProductGroup(const dict &req, int reqid)
 {
 	CThostFtdcQryProductGroupField myreq = CThostFtdcQryProductGroupField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8766,7 +8767,7 @@ int TdApi::reqQryProductGroup(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryMMInstrumentCommissionRate(dict req, int reqid)
+int TdApi::reqQryMMInstrumentCommissionRate(const dict &req, int reqid)
 {
 	CThostFtdcQryMMInstrumentCommissionRateField myreq = CThostFtdcQryMMInstrumentCommissionRateField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8777,7 +8778,7 @@ int TdApi::reqQryMMInstrumentCommissionRate(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryMMOptionInstrCommRate(dict req, int reqid)
+int TdApi::reqQryMMOptionInstrCommRate(const dict &req, int reqid)
 {
 	CThostFtdcQryMMOptionInstrCommRateField myreq = CThostFtdcQryMMOptionInstrCommRateField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8788,7 +8789,7 @@ int TdApi::reqQryMMOptionInstrCommRate(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryInstrumentOrderCommRate(dict req, int reqid)
+int TdApi::reqQryInstrumentOrderCommRate(const dict &req, int reqid)
 {
 	CThostFtdcQryInstrumentOrderCommRateField myreq = CThostFtdcQryInstrumentOrderCommRateField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8799,7 +8800,7 @@ int TdApi::reqQryInstrumentOrderCommRate(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryOptionInstrTradeCost(dict req, int reqid)
+int TdApi::reqQryOptionInstrTradeCost(const dict &req, int reqid)
 {
 	CThostFtdcQryOptionInstrTradeCostField myreq = CThostFtdcQryOptionInstrTradeCostField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8815,7 +8816,7 @@ int TdApi::reqQryOptionInstrTradeCost(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryOptionInstrCommRate(dict req, int reqid)
+int TdApi::reqQryOptionInstrCommRate(const dict &req, int reqid)
 {
 	CThostFtdcQryOptionInstrCommRateField myreq = CThostFtdcQryOptionInstrCommRateField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8828,7 +8829,7 @@ int TdApi::reqQryOptionInstrCommRate(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryExecOrder(dict req, int reqid)
+int TdApi::reqQryExecOrder(const dict &req, int reqid)
 {
 	CThostFtdcQryExecOrderField myreq = CThostFtdcQryExecOrderField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8843,7 +8844,7 @@ int TdApi::reqQryExecOrder(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryForQuote(dict req, int reqid)
+int TdApi::reqQryForQuote(const dict &req, int reqid)
 {
 	CThostFtdcQryForQuoteField myreq = CThostFtdcQryForQuoteField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8858,7 +8859,7 @@ int TdApi::reqQryForQuote(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryQuote(dict req, int reqid)
+int TdApi::reqQryQuote(const dict &req, int reqid)
 {
 	CThostFtdcQryQuoteField myreq = CThostFtdcQryQuoteField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8874,7 +8875,7 @@ int TdApi::reqQryQuote(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryOptionSelfClose(dict req, int reqid)
+int TdApi::reqQryOptionSelfClose(const dict &req, int reqid)
 {
 	CThostFtdcQryOptionSelfCloseField myreq = CThostFtdcQryOptionSelfCloseField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8889,7 +8890,7 @@ int TdApi::reqQryOptionSelfClose(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryInvestUnit(dict req, int reqid)
+int TdApi::reqQryInvestUnit(const dict &req, int reqid)
 {
 	CThostFtdcQryInvestUnitField myreq = CThostFtdcQryInvestUnitField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8900,7 +8901,7 @@ int TdApi::reqQryInvestUnit(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryCombInstrumentGuard(dict req, int reqid)
+int TdApi::reqQryCombInstrumentGuard(const dict &req, int reqid)
 {
 	CThostFtdcQryCombInstrumentGuardField myreq = CThostFtdcQryCombInstrumentGuardField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8911,7 +8912,7 @@ int TdApi::reqQryCombInstrumentGuard(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryCombAction(dict req, int reqid)
+int TdApi::reqQryCombAction(const dict &req, int reqid)
 {
 	CThostFtdcQryCombActionField myreq = CThostFtdcQryCombActionField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8924,7 +8925,7 @@ int TdApi::reqQryCombAction(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryTransferSerial(dict req, int reqid)
+int TdApi::reqQryTransferSerial(const dict &req, int reqid)
 {
 	CThostFtdcQryTransferSerialField myreq = CThostFtdcQryTransferSerialField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8936,7 +8937,7 @@ int TdApi::reqQryTransferSerial(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryAccountregister(dict req, int reqid)
+int TdApi::reqQryAccountregister(const dict &req, int reqid)
 {
 	CThostFtdcQryAccountregisterField myreq = CThostFtdcQryAccountregisterField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8949,7 +8950,7 @@ int TdApi::reqQryAccountregister(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryContractBank(dict req, int reqid)
+int TdApi::reqQryContractBank(const dict &req, int reqid)
 {
 	CThostFtdcQryContractBankField myreq = CThostFtdcQryContractBankField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8960,7 +8961,7 @@ int TdApi::reqQryContractBank(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryParkedOrder(dict req, int reqid)
+int TdApi::reqQryParkedOrder(const dict &req, int reqid)
 {
 	CThostFtdcQryParkedOrderField myreq = CThostFtdcQryParkedOrderField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8973,7 +8974,7 @@ int TdApi::reqQryParkedOrder(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryParkedOrderAction(dict req, int reqid)
+int TdApi::reqQryParkedOrderAction(const dict &req, int reqid)
 {
 	CThostFtdcQryParkedOrderActionField myreq = CThostFtdcQryParkedOrderActionField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8986,7 +8987,7 @@ int TdApi::reqQryParkedOrderAction(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryTradingNotice(dict req, int reqid)
+int TdApi::reqQryTradingNotice(const dict &req, int reqid)
 {
 	CThostFtdcQryTradingNoticeField myreq = CThostFtdcQryTradingNoticeField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -8997,7 +8998,7 @@ int TdApi::reqQryTradingNotice(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryBrokerTradingParams(dict req, int reqid)
+int TdApi::reqQryBrokerTradingParams(const dict &req, int reqid)
 {
 	CThostFtdcQryBrokerTradingParamsField myreq = CThostFtdcQryBrokerTradingParamsField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -9009,7 +9010,7 @@ int TdApi::reqQryBrokerTradingParams(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQryBrokerTradingAlgos(dict req, int reqid)
+int TdApi::reqQryBrokerTradingAlgos(const dict &req, int reqid)
 {
 	CThostFtdcQryBrokerTradingAlgosField myreq = CThostFtdcQryBrokerTradingAlgosField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -9020,7 +9021,7 @@ int TdApi::reqQryBrokerTradingAlgos(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQueryCFMMCTradingAccountToken(dict req, int reqid)
+int TdApi::reqQueryCFMMCTradingAccountToken(const dict &req, int reqid)
 {
 	CThostFtdcQueryCFMMCTradingAccountTokenField myreq = CThostFtdcQueryCFMMCTradingAccountTokenField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -9031,7 +9032,7 @@ int TdApi::reqQueryCFMMCTradingAccountToken(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqFromBankToFutureByFuture(dict req, int reqid)
+int TdApi::reqFromBankToFutureByFuture(const dict &req, int reqid)
 {
 	CThostFtdcReqTransferField myreq = CThostFtdcReqTransferField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -9083,7 +9084,7 @@ int TdApi::reqFromBankToFutureByFuture(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqFromFutureToBankByFuture(dict req, int reqid)
+int TdApi::reqFromFutureToBankByFuture(const dict &req, int reqid)
 {
 	CThostFtdcReqTransferField myreq = CThostFtdcReqTransferField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -9135,7 +9136,7 @@ int TdApi::reqFromFutureToBankByFuture(dict req, int reqid)
 	return i;
 };
 
-int TdApi::reqQueryBankAccountMoneyByFuture(dict req, int reqid)
+int TdApi::reqQueryBankAccountMoneyByFuture(const dict &req, int reqid)
 {
 	CThostFtdcReqQueryAccountField myreq = CThostFtdcReqQueryAccountField();
 	memset(&myreq, 0, sizeof(myreq));
@@ -9194,7 +9195,7 @@ public:
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onFrontConnected);
+			PYBIND11_OVERLOAD(void, TdApi, onFrontConnected);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9206,7 +9207,7 @@ public:
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onFrontDisconnected, reqid);
+			PYBIND11_OVERLOAD(void, TdApi, onFrontDisconnected, reqid);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9218,7 +9219,7 @@ public:
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onHeartBeatWarning, reqid);
+			PYBIND11_OVERLOAD(void, TdApi, onHeartBeatWarning, reqid);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9226,11 +9227,11 @@ public:
 		}
 	};
 
-	void onRspAuthenticate(dict data, dict error, int reqid, bool last) override
+	void onRspAuthenticate(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspAuthenticate, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspAuthenticate, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9238,11 +9239,11 @@ public:
 		}
 	};
 
-	void onRspUserLogin(dict data, dict error, int reqid, bool last) override
+	void onRspUserLogin(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspUserLogin, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspUserLogin, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9250,11 +9251,11 @@ public:
 		}
 	};
 
-	void onRspUserLogout(dict data, dict error, int reqid, bool last) override
+	void onRspUserLogout(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspUserLogout, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspUserLogout, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9262,11 +9263,11 @@ public:
 		}
 	};
 
-	void onRspUserPasswordUpdate(dict data, dict error, int reqid, bool last) override
+	void onRspUserPasswordUpdate(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspUserPasswordUpdate, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspUserPasswordUpdate, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9274,11 +9275,11 @@ public:
 		}
 	};
 
-	void onRspTradingAccountPasswordUpdate(dict data, dict error, int reqid, bool last) override
+	void onRspTradingAccountPasswordUpdate(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspTradingAccountPasswordUpdate, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspTradingAccountPasswordUpdate, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9286,11 +9287,11 @@ public:
 		}
 	};
 
-	void onRspOrderInsert(dict data, dict error, int reqid, bool last) override
+	void onRspOrderInsert(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspOrderInsert, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspOrderInsert, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9298,11 +9299,11 @@ public:
 		}
 	};
 
-	void onRspParkedOrderInsert(dict data, dict error, int reqid, bool last) override
+	void onRspParkedOrderInsert(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspParkedOrderInsert, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspParkedOrderInsert, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9310,11 +9311,11 @@ public:
 		}
 	};
 
-	void onRspParkedOrderAction(dict data, dict error, int reqid, bool last) override
+	void onRspParkedOrderAction(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspParkedOrderAction, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspParkedOrderAction, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9322,11 +9323,11 @@ public:
 		}
 	};
 
-	void onRspOrderAction(dict data, dict error, int reqid, bool last) override
+	void onRspOrderAction(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspOrderAction, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspOrderAction, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9334,11 +9335,11 @@ public:
 		}
 	};
 
-	void onRspQueryMaxOrderVolume(dict data, dict error, int reqid, bool last) override
+	void onRspQueryMaxOrderVolume(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQueryMaxOrderVolume, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQueryMaxOrderVolume, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9346,11 +9347,11 @@ public:
 		}
 	};
 
-	void onRspSettlementInfoConfirm(dict data, dict error, int reqid, bool last) override
+	void onRspSettlementInfoConfirm(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspSettlementInfoConfirm, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspSettlementInfoConfirm, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9358,11 +9359,11 @@ public:
 		}
 	};
 
-	void onRspRemoveParkedOrder(dict data, dict error, int reqid, bool last) override
+	void onRspRemoveParkedOrder(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspRemoveParkedOrder, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspRemoveParkedOrder, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9370,11 +9371,11 @@ public:
 		}
 	};
 
-	void onRspRemoveParkedOrderAction(dict data, dict error, int reqid, bool last) override
+	void onRspRemoveParkedOrderAction(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspRemoveParkedOrderAction, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspRemoveParkedOrderAction, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9382,11 +9383,11 @@ public:
 		}
 	};
 
-	void onRspExecOrderInsert(dict data, dict error, int reqid, bool last) override
+	void onRspExecOrderInsert(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspExecOrderInsert, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspExecOrderInsert, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9394,11 +9395,11 @@ public:
 		}
 	};
 
-	void onRspExecOrderAction(dict data, dict error, int reqid, bool last) override
+	void onRspExecOrderAction(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspExecOrderAction, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspExecOrderAction, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9406,11 +9407,11 @@ public:
 		}
 	};
 
-	void onRspForQuoteInsert(dict data, dict error, int reqid, bool last) override
+	void onRspForQuoteInsert(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspForQuoteInsert, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspForQuoteInsert, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9418,11 +9419,11 @@ public:
 		}
 	};
 
-	void onRspQuoteInsert(dict data, dict error, int reqid, bool last) override
+	void onRspQuoteInsert(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQuoteInsert, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQuoteInsert, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9430,11 +9431,11 @@ public:
 		}
 	};
 
-	void onRspQuoteAction(dict data, dict error, int reqid, bool last) override
+	void onRspQuoteAction(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQuoteAction, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQuoteAction, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9442,11 +9443,11 @@ public:
 		}
 	};
 
-	void onRspBatchOrderAction(dict data, dict error, int reqid, bool last) override
+	void onRspBatchOrderAction(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspBatchOrderAction, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspBatchOrderAction, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9454,11 +9455,11 @@ public:
 		}
 	};
 
-	void onRspOptionSelfCloseInsert(dict data, dict error, int reqid, bool last) override
+	void onRspOptionSelfCloseInsert(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspOptionSelfCloseInsert, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspOptionSelfCloseInsert, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9466,11 +9467,11 @@ public:
 		}
 	};
 
-	void onRspOptionSelfCloseAction(dict data, dict error, int reqid, bool last) override
+	void onRspOptionSelfCloseAction(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspOptionSelfCloseAction, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspOptionSelfCloseAction, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9478,11 +9479,11 @@ public:
 		}
 	};
 
-	void onRspCombActionInsert(dict data, dict error, int reqid, bool last) override
+	void onRspCombActionInsert(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspCombActionInsert, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspCombActionInsert, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9490,11 +9491,11 @@ public:
 		}
 	};
 
-	void onRspQryOrder(dict data, dict error, int reqid, bool last) override
+	void onRspQryOrder(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryOrder, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryOrder, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9502,11 +9503,11 @@ public:
 		}
 	};
 
-	void onRspQryTrade(dict data, dict error, int reqid, bool last) override
+	void onRspQryTrade(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryTrade, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryTrade, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9514,11 +9515,11 @@ public:
 		}
 	};
 
-	void onRspQryInvestorPosition(dict data, dict error, int reqid, bool last) override
+	void onRspQryInvestorPosition(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryInvestorPosition, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryInvestorPosition, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9526,11 +9527,11 @@ public:
 		}
 	};
 
-	void onRspQryTradingAccount(dict data, dict error, int reqid, bool last) override
+	void onRspQryTradingAccount(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryTradingAccount, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryTradingAccount, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9538,11 +9539,11 @@ public:
 		}
 	};
 
-	void onRspQryInvestor(dict data, dict error, int reqid, bool last) override
+	void onRspQryInvestor(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryInvestor, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryInvestor, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9550,11 +9551,11 @@ public:
 		}
 	};
 
-	void onRspQryTradingCode(dict data, dict error, int reqid, bool last) override
+	void onRspQryTradingCode(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryTradingCode, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryTradingCode, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9562,11 +9563,11 @@ public:
 		}
 	};
 
-	void onRspQryInstrumentMarginRate(dict data, dict error, int reqid, bool last) override
+	void onRspQryInstrumentMarginRate(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryInstrumentMarginRate, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryInstrumentMarginRate, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9574,11 +9575,11 @@ public:
 		}
 	};
 
-	void onRspQryInstrumentCommissionRate(dict data, dict error, int reqid, bool last) override
+	void onRspQryInstrumentCommissionRate(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryInstrumentCommissionRate, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryInstrumentCommissionRate, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9586,11 +9587,11 @@ public:
 		}
 	};
 
-	void onRspQryExchange(dict data, dict error, int reqid, bool last) override
+	void onRspQryExchange(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryExchange, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryExchange, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9598,11 +9599,11 @@ public:
 		}
 	};
 
-	void onRspQryProduct(dict data, dict error, int reqid, bool last) override
+	void onRspQryProduct(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryProduct, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryProduct, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9610,11 +9611,11 @@ public:
 		}
 	};
 
-	void onRspQryInstrument(dict data, dict error, int reqid, bool last) override
+	void onRspQryInstrument(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryInstrument, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryInstrument, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9622,11 +9623,11 @@ public:
 		}
 	};
 
-	void onRspQryDepthMarketData(dict data, dict error, int reqid, bool last) override
+	void onRspQryDepthMarketData(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryDepthMarketData, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryDepthMarketData, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9634,11 +9635,11 @@ public:
 		}
 	};
 
-	void onRspQrySettlementInfo(dict data, dict error, int reqid, bool last) override
+	void onRspQrySettlementInfo(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQrySettlementInfo, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQrySettlementInfo, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9646,11 +9647,11 @@ public:
 		}
 	};
 
-	void onRspQryTransferBank(dict data, dict error, int reqid, bool last) override
+	void onRspQryTransferBank(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryTransferBank, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryTransferBank, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9658,11 +9659,11 @@ public:
 		}
 	};
 
-	void onRspQryInvestorPositionDetail(dict data, dict error, int reqid, bool last) override
+	void onRspQryInvestorPositionDetail(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryInvestorPositionDetail, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryInvestorPositionDetail, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9670,11 +9671,11 @@ public:
 		}
 	};
 
-	void onRspQryNotice(dict data, dict error, int reqid, bool last) override
+	void onRspQryNotice(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryNotice, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryNotice, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9682,11 +9683,11 @@ public:
 		}
 	};
 
-	void onRspQrySettlementInfoConfirm(dict data, dict error, int reqid, bool last) override
+	void onRspQrySettlementInfoConfirm(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQrySettlementInfoConfirm, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQrySettlementInfoConfirm, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9694,11 +9695,11 @@ public:
 		}
 	};
 
-	void onRspQryInvestorPositionCombineDetail(dict data, dict error, int reqid, bool last) override
+	void onRspQryInvestorPositionCombineDetail(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryInvestorPositionCombineDetail, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryInvestorPositionCombineDetail, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9706,11 +9707,11 @@ public:
 		}
 	};
 
-	void onRspQryCFMMCTradingAccountKey(dict data, dict error, int reqid, bool last) override
+	void onRspQryCFMMCTradingAccountKey(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryCFMMCTradingAccountKey, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryCFMMCTradingAccountKey, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9718,11 +9719,11 @@ public:
 		}
 	};
 
-	void onRspQryEWarrantOffset(dict data, dict error, int reqid, bool last) override
+	void onRspQryEWarrantOffset(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryEWarrantOffset, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryEWarrantOffset, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9730,11 +9731,11 @@ public:
 		}
 	};
 
-	void onRspQryInvestorProductGroupMargin(dict data, dict error, int reqid, bool last) override
+	void onRspQryInvestorProductGroupMargin(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryInvestorProductGroupMargin, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryInvestorProductGroupMargin, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9742,11 +9743,11 @@ public:
 		}
 	};
 
-	void onRspQryExchangeMarginRate(dict data, dict error, int reqid, bool last) override
+	void onRspQryExchangeMarginRate(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryExchangeMarginRate, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryExchangeMarginRate, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9754,11 +9755,11 @@ public:
 		}
 	};
 
-	void onRspQryExchangeMarginRateAdjust(dict data, dict error, int reqid, bool last) override
+	void onRspQryExchangeMarginRateAdjust(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryExchangeMarginRateAdjust, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryExchangeMarginRateAdjust, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9766,11 +9767,11 @@ public:
 		}
 	};
 
-	void onRspQryExchangeRate(dict data, dict error, int reqid, bool last) override
+	void onRspQryExchangeRate(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryExchangeRate, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryExchangeRate, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9778,11 +9779,11 @@ public:
 		}
 	};
 
-	void onRspQrySecAgentACIDMap(dict data, dict error, int reqid, bool last) override
+	void onRspQrySecAgentACIDMap(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQrySecAgentACIDMap, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQrySecAgentACIDMap, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9790,11 +9791,11 @@ public:
 		}
 	};
 
-	void onRspQryProductExchRate(dict data, dict error, int reqid, bool last) override
+	void onRspQryProductExchRate(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryProductExchRate, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryProductExchRate, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9802,11 +9803,11 @@ public:
 		}
 	};
 
-	void onRspQryProductGroup(dict data, dict error, int reqid, bool last) override
+	void onRspQryProductGroup(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryProductGroup, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryProductGroup, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9814,11 +9815,11 @@ public:
 		}
 	};
 
-	void onRspQryMMInstrumentCommissionRate(dict data, dict error, int reqid, bool last) override
+	void onRspQryMMInstrumentCommissionRate(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryMMInstrumentCommissionRate, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryMMInstrumentCommissionRate, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9826,11 +9827,11 @@ public:
 		}
 	};
 
-	void onRspQryMMOptionInstrCommRate(dict data, dict error, int reqid, bool last) override
+	void onRspQryMMOptionInstrCommRate(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryMMOptionInstrCommRate, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryMMOptionInstrCommRate, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9838,11 +9839,11 @@ public:
 		}
 	};
 
-	void onRspQryInstrumentOrderCommRate(dict data, dict error, int reqid, bool last) override
+	void onRspQryInstrumentOrderCommRate(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryInstrumentOrderCommRate, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryInstrumentOrderCommRate, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9850,11 +9851,11 @@ public:
 		}
 	};
 
-	void onRspQryOptionInstrTradeCost(dict data, dict error, int reqid, bool last) override
+	void onRspQryOptionInstrTradeCost(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryOptionInstrTradeCost, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryOptionInstrTradeCost, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9862,11 +9863,11 @@ public:
 		}
 	};
 
-	void onRspQryOptionInstrCommRate(dict data, dict error, int reqid, bool last) override
+	void onRspQryOptionInstrCommRate(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryOptionInstrCommRate, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryOptionInstrCommRate, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9874,11 +9875,11 @@ public:
 		}
 	};
 
-	void onRspQryExecOrder(dict data, dict error, int reqid, bool last) override
+	void onRspQryExecOrder(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryExecOrder, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryExecOrder, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9886,11 +9887,11 @@ public:
 		}
 	};
 
-	void onRspQryForQuote(dict data, dict error, int reqid, bool last) override
+	void onRspQryForQuote(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryForQuote, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryForQuote, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9898,11 +9899,11 @@ public:
 		}
 	};
 
-	void onRspQryQuote(dict data, dict error, int reqid, bool last) override
+	void onRspQryQuote(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryQuote, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryQuote, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9910,11 +9911,11 @@ public:
 		}
 	};
 
-	void onRspQryOptionSelfClose(dict data, dict error, int reqid, bool last) override
+	void onRspQryOptionSelfClose(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryOptionSelfClose, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryOptionSelfClose, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9922,11 +9923,11 @@ public:
 		}
 	};
 
-	void onRspQryInvestUnit(dict data, dict error, int reqid, bool last) override
+	void onRspQryInvestUnit(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryInvestUnit, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryInvestUnit, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9934,11 +9935,11 @@ public:
 		}
 	};
 
-	void onRspQryCombInstrumentGuard(dict data, dict error, int reqid, bool last) override
+	void onRspQryCombInstrumentGuard(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryCombInstrumentGuard, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryCombInstrumentGuard, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9946,11 +9947,11 @@ public:
 		}
 	};
 
-	void onRspQryCombAction(dict data, dict error, int reqid, bool last) override
+	void onRspQryCombAction(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryCombAction, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryCombAction, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9958,11 +9959,11 @@ public:
 		}
 	};
 
-	void onRspQryTransferSerial(dict data, dict error, int reqid, bool last) override
+	void onRspQryTransferSerial(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryTransferSerial, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryTransferSerial, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9970,11 +9971,11 @@ public:
 		}
 	};
 
-	void onRspQryAccountregister(dict data, dict error, int reqid, bool last) override
+	void onRspQryAccountregister(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryAccountregister, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryAccountregister, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9982,11 +9983,11 @@ public:
 		}
 	};
 
-	void onRspError(dict error, int reqid, bool last) override
+	void onRspError(const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspError, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspError, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -9994,11 +9995,11 @@ public:
 		}
 	};
 
-	void onRtnOrder(dict data) override
+	void onRtnOrder(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnOrder, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnOrder, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10006,11 +10007,11 @@ public:
 		}
 	};
 
-	void onRtnTrade(dict data) override
+	void onRtnTrade(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnTrade, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnTrade, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10018,11 +10019,11 @@ public:
 		}
 	};
 
-	void onErrRtnOrderInsert(dict data, dict error) override
+	void onErrRtnOrderInsert(const dict &data, const dict &error) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onErrRtnOrderInsert, data, error);
+			PYBIND11_OVERLOAD(void, TdApi, onErrRtnOrderInsert, data, error);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10030,11 +10031,11 @@ public:
 		}
 	};
 
-	void onErrRtnOrderAction(dict data, dict error) override
+	void onErrRtnOrderAction(const dict &data, const dict &error) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onErrRtnOrderAction, data, error);
+			PYBIND11_OVERLOAD(void, TdApi, onErrRtnOrderAction, data, error);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10042,11 +10043,11 @@ public:
 		}
 	};
 
-	void onRtnInstrumentStatus(dict data) override
+	void onRtnInstrumentStatus(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnInstrumentStatus, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnInstrumentStatus, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10054,11 +10055,11 @@ public:
 		}
 	};
 
-	void onRtnBulletin(dict data) override
+	void onRtnBulletin(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnBulletin, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnBulletin, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10066,11 +10067,11 @@ public:
 		}
 	};
 
-	void onRtnTradingNotice(dict data) override
+	void onRtnTradingNotice(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnTradingNotice, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnTradingNotice, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10078,11 +10079,11 @@ public:
 		}
 	};
 
-	void onRtnErrorConditionalOrder(dict data) override
+	void onRtnErrorConditionalOrder(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnErrorConditionalOrder, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnErrorConditionalOrder, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10090,11 +10091,11 @@ public:
 		}
 	};
 
-	void onRtnExecOrder(dict data) override
+	void onRtnExecOrder(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnExecOrder, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnExecOrder, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10102,11 +10103,11 @@ public:
 		}
 	};
 
-	void onErrRtnExecOrderInsert(dict data, dict error) override
+	void onErrRtnExecOrderInsert(const dict &data, const dict &error) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onErrRtnExecOrderInsert, data, error);
+			PYBIND11_OVERLOAD(void, TdApi, onErrRtnExecOrderInsert, data, error);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10114,11 +10115,11 @@ public:
 		}
 	};
 
-	void onErrRtnExecOrderAction(dict data, dict error) override
+	void onErrRtnExecOrderAction(const dict &data, const dict &error) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onErrRtnExecOrderAction, data, error);
+			PYBIND11_OVERLOAD(void, TdApi, onErrRtnExecOrderAction, data, error);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10126,11 +10127,11 @@ public:
 		}
 	};
 
-	void onErrRtnForQuoteInsert(dict data, dict error) override
+	void onErrRtnForQuoteInsert(const dict &data, const dict &error) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onErrRtnForQuoteInsert, data, error);
+			PYBIND11_OVERLOAD(void, TdApi, onErrRtnForQuoteInsert, data, error);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10138,11 +10139,11 @@ public:
 		}
 	};
 
-	void onRtnQuote(dict data) override
+	void onRtnQuote(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnQuote, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnQuote, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10150,11 +10151,11 @@ public:
 		}
 	};
 
-	void onErrRtnQuoteInsert(dict data, dict error) override
+	void onErrRtnQuoteInsert(const dict &data, const dict &error) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onErrRtnQuoteInsert, data, error);
+			PYBIND11_OVERLOAD(void, TdApi, onErrRtnQuoteInsert, data, error);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10162,11 +10163,11 @@ public:
 		}
 	};
 
-	void onErrRtnQuoteAction(dict data, dict error) override
+	void onErrRtnQuoteAction(const dict &data, const dict &error) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onErrRtnQuoteAction, data, error);
+			PYBIND11_OVERLOAD(void, TdApi, onErrRtnQuoteAction, data, error);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10174,11 +10175,11 @@ public:
 		}
 	};
 
-	void onRtnForQuoteRsp(dict data) override
+	void onRtnForQuoteRsp(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnForQuoteRsp, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnForQuoteRsp, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10186,11 +10187,11 @@ public:
 		}
 	};
 
-	void onRtnCFMMCTradingAccountToken(dict data) override
+	void onRtnCFMMCTradingAccountToken(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnCFMMCTradingAccountToken, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnCFMMCTradingAccountToken, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10198,11 +10199,11 @@ public:
 		}
 	};
 
-	void onErrRtnBatchOrderAction(dict data, dict error) override
+	void onErrRtnBatchOrderAction(const dict &data, const dict &error) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onErrRtnBatchOrderAction, data, error);
+			PYBIND11_OVERLOAD(void, TdApi, onErrRtnBatchOrderAction, data, error);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10210,11 +10211,11 @@ public:
 		}
 	};
 
-	void onRtnOptionSelfClose(dict data) override
+	void onRtnOptionSelfClose(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnOptionSelfClose, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnOptionSelfClose, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10222,11 +10223,11 @@ public:
 		}
 	};
 
-	void onErrRtnOptionSelfCloseInsert(dict data, dict error) override
+	void onErrRtnOptionSelfCloseInsert(const dict &data, const dict &error) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onErrRtnOptionSelfCloseInsert, data, error);
+			PYBIND11_OVERLOAD(void, TdApi, onErrRtnOptionSelfCloseInsert, data, error);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10234,11 +10235,11 @@ public:
 		}
 	};
 
-	void onErrRtnOptionSelfCloseAction(dict data, dict error) override
+	void onErrRtnOptionSelfCloseAction(const dict &data, const dict &error) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onErrRtnOptionSelfCloseAction, data, error);
+			PYBIND11_OVERLOAD(void, TdApi, onErrRtnOptionSelfCloseAction, data, error);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10246,11 +10247,11 @@ public:
 		}
 	};
 
-	void onRtnCombAction(dict data) override
+	void onRtnCombAction(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnCombAction, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnCombAction, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10258,11 +10259,11 @@ public:
 		}
 	};
 
-	void onErrRtnCombActionInsert(dict data, dict error) override
+	void onErrRtnCombActionInsert(const dict &data, const dict &error) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onErrRtnCombActionInsert, data, error);
+			PYBIND11_OVERLOAD(void, TdApi, onErrRtnCombActionInsert, data, error);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10270,11 +10271,11 @@ public:
 		}
 	};
 
-	void onRspQryContractBank(dict data, dict error, int reqid, bool last) override
+	void onRspQryContractBank(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryContractBank, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryContractBank, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10282,11 +10283,11 @@ public:
 		}
 	};
 
-	void onRspQryParkedOrder(dict data, dict error, int reqid, bool last) override
+	void onRspQryParkedOrder(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryParkedOrder, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryParkedOrder, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10294,11 +10295,11 @@ public:
 		}
 	};
 
-	void onRspQryParkedOrderAction(dict data, dict error, int reqid, bool last) override
+	void onRspQryParkedOrderAction(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryParkedOrderAction, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryParkedOrderAction, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10306,11 +10307,11 @@ public:
 		}
 	};
 
-	void onRspQryTradingNotice(dict data, dict error, int reqid, bool last) override
+	void onRspQryTradingNotice(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryTradingNotice, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryTradingNotice, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10318,11 +10319,11 @@ public:
 		}
 	};
 
-	void onRspQryBrokerTradingParams(dict data, dict error, int reqid, bool last) override
+	void onRspQryBrokerTradingParams(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryBrokerTradingParams, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryBrokerTradingParams, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10330,11 +10331,11 @@ public:
 		}
 	};
 
-	void onRspQryBrokerTradingAlgos(dict data, dict error, int reqid, bool last) override
+	void onRspQryBrokerTradingAlgos(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQryBrokerTradingAlgos, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQryBrokerTradingAlgos, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10342,11 +10343,11 @@ public:
 		}
 	};
 
-	void onRspQueryCFMMCTradingAccountToken(dict data, dict error, int reqid, bool last) override
+	void onRspQueryCFMMCTradingAccountToken(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQueryCFMMCTradingAccountToken, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQueryCFMMCTradingAccountToken, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10354,11 +10355,11 @@ public:
 		}
 	};
 
-	void onRtnFromBankToFutureByBank(dict data) override
+	void onRtnFromBankToFutureByBank(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnFromBankToFutureByBank, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnFromBankToFutureByBank, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10366,11 +10367,11 @@ public:
 		}
 	};
 
-	void onRtnFromFutureToBankByBank(dict data) override
+	void onRtnFromFutureToBankByBank(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnFromFutureToBankByBank, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnFromFutureToBankByBank, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10378,11 +10379,11 @@ public:
 		}
 	};
 
-	void onRtnRepealFromBankToFutureByBank(dict data) override
+	void onRtnRepealFromBankToFutureByBank(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnRepealFromBankToFutureByBank, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnRepealFromBankToFutureByBank, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10390,11 +10391,11 @@ public:
 		}
 	};
 
-	void onRtnRepealFromFutureToBankByBank(dict data) override
+	void onRtnRepealFromFutureToBankByBank(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnRepealFromFutureToBankByBank, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnRepealFromFutureToBankByBank, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10402,11 +10403,11 @@ public:
 		}
 	};
 
-	void onRtnFromBankToFutureByFuture(dict data) override
+	void onRtnFromBankToFutureByFuture(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnFromBankToFutureByFuture, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnFromBankToFutureByFuture, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10414,11 +10415,11 @@ public:
 		}
 	};
 
-	void onRtnFromFutureToBankByFuture(dict data) override
+	void onRtnFromFutureToBankByFuture(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnFromFutureToBankByFuture, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnFromFutureToBankByFuture, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10426,11 +10427,11 @@ public:
 		}
 	};
 
-	void onRtnRepealFromBankToFutureByFutureManual(dict data) override
+	void onRtnRepealFromBankToFutureByFutureManual(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnRepealFromBankToFutureByFutureManual, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnRepealFromBankToFutureByFutureManual, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10438,11 +10439,11 @@ public:
 		}
 	};
 
-	void onRtnRepealFromFutureToBankByFutureManual(dict data) override
+	void onRtnRepealFromFutureToBankByFutureManual(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnRepealFromFutureToBankByFutureManual, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnRepealFromFutureToBankByFutureManual, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10450,11 +10451,11 @@ public:
 		}
 	};
 
-	void onRtnQueryBankBalanceByFuture(dict data) override
+	void onRtnQueryBankBalanceByFuture(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnQueryBankBalanceByFuture, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnQueryBankBalanceByFuture, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10462,11 +10463,11 @@ public:
 		}
 	};
 
-	void onErrRtnBankToFutureByFuture(dict data, dict error) override
+	void onErrRtnBankToFutureByFuture(const dict &data, const dict &error) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onErrRtnBankToFutureByFuture, data, error);
+			PYBIND11_OVERLOAD(void, TdApi, onErrRtnBankToFutureByFuture, data, error);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10474,11 +10475,11 @@ public:
 		}
 	};
 
-	void onErrRtnFutureToBankByFuture(dict data, dict error) override
+	void onErrRtnFutureToBankByFuture(const dict &data, const dict &error) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onErrRtnFutureToBankByFuture, data, error);
+			PYBIND11_OVERLOAD(void, TdApi, onErrRtnFutureToBankByFuture, data, error);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10486,11 +10487,11 @@ public:
 		}
 	};
 
-	void onErrRtnRepealBankToFutureByFutureManual(dict data, dict error) override
+	void onErrRtnRepealBankToFutureByFutureManual(const dict &data, const dict &error) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onErrRtnRepealBankToFutureByFutureManual, data, error);
+			PYBIND11_OVERLOAD(void, TdApi, onErrRtnRepealBankToFutureByFutureManual, data, error);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10498,11 +10499,11 @@ public:
 		}
 	};
 
-	void onErrRtnRepealFutureToBankByFutureManual(dict data, dict error) override
+	void onErrRtnRepealFutureToBankByFutureManual(const dict &data, const dict &error) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onErrRtnRepealFutureToBankByFutureManual, data, error);
+			PYBIND11_OVERLOAD(void, TdApi, onErrRtnRepealFutureToBankByFutureManual, data, error);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10510,11 +10511,11 @@ public:
 		}
 	};
 
-	void onErrRtnQueryBankBalanceByFuture(dict data, dict error) override
+	void onErrRtnQueryBankBalanceByFuture(const dict &data, const dict &error) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onErrRtnQueryBankBalanceByFuture, data, error);
+			PYBIND11_OVERLOAD(void, TdApi, onErrRtnQueryBankBalanceByFuture, data, error);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10522,11 +10523,11 @@ public:
 		}
 	};
 
-	void onRtnRepealFromBankToFutureByFuture(dict data) override
+	void onRtnRepealFromBankToFutureByFuture(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnRepealFromBankToFutureByFuture, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnRepealFromBankToFutureByFuture, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10534,11 +10535,11 @@ public:
 		}
 	};
 
-	void onRtnRepealFromFutureToBankByFuture(dict data) override
+	void onRtnRepealFromFutureToBankByFuture(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnRepealFromFutureToBankByFuture, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnRepealFromFutureToBankByFuture, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10546,11 +10547,11 @@ public:
 		}
 	};
 
-	void onRspFromBankToFutureByFuture(dict data, dict error, int reqid, bool last) override
+	void onRspFromBankToFutureByFuture(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspFromBankToFutureByFuture, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspFromBankToFutureByFuture, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10558,11 +10559,11 @@ public:
 		}
 	};
 
-	void onRspFromFutureToBankByFuture(dict data, dict error, int reqid, bool last) override
+	void onRspFromFutureToBankByFuture(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspFromFutureToBankByFuture, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspFromFutureToBankByFuture, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10570,11 +10571,11 @@ public:
 		}
 	};
 
-	void onRspQueryBankAccountMoneyByFuture(dict data, dict error, int reqid, bool last) override
+	void onRspQueryBankAccountMoneyByFuture(const dict &data, const dict &error, int reqid, bool last) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRspQueryBankAccountMoneyByFuture, data, error, reqid, last);
+			PYBIND11_OVERLOAD(void, TdApi, onRspQueryBankAccountMoneyByFuture, data, error, reqid, last);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10582,11 +10583,11 @@ public:
 		}
 	};
 
-	void onRtnOpenAccountByBank(dict data) override
+	void onRtnOpenAccountByBank(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnOpenAccountByBank, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnOpenAccountByBank, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10594,11 +10595,11 @@ public:
 		}
 	};
 
-	void onRtnCancelAccountByBank(dict data) override
+	void onRtnCancelAccountByBank(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnCancelAccountByBank, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnCancelAccountByBank, data);
 		}
 		catch (const error_already_set &e)
 		{
@@ -10606,11 +10607,11 @@ public:
 		}
 	};
 
-	void onRtnChangeAccountByBank(dict data) override
+	void onRtnChangeAccountByBank(const dict &data) override
 	{
 		try
 		{
-			PYBIND11_OVERLOAD_PURE(void, TdApi, onRtnChangeAccountByBank, data);
+			PYBIND11_OVERLOAD(void, TdApi, onRtnChangeAccountByBank, data);
 		}
 		catch (const error_already_set &e)
 		{

--- a/vnpy/api/ctp/vnctp/vnctptd/vnctptd.h
+++ b/vnpy/api/ctp/vnctp/vnctptd/vnctptd.h
@@ -534,243 +534,244 @@ public:
 
 	void processTask();
 
-	void processFrontConnected(Task *task);
+    void processFrontConnected(Task *task);
 
-	void processFrontDisconnected(Task *task);
+    void processFrontDisconnected(Task *task);
 
-	void processHeartBeatWarning(Task *task);
+    void processHeartBeatWarning(Task *task);
 
-	void processRspAuthenticate(Task *task);
+    void processRspAuthenticate(Task *task);
 
-	void processRspUserLogin(Task *task);
+    void processRspUserLogin(Task *task);
 
-	void processRspUserLogout(Task *task);
+    void processRspUserLogout(Task *task);
 
-	void processRspUserPasswordUpdate(Task *task);
+    void processRspUserPasswordUpdate(Task *task);
 
-	void processRspTradingAccountPasswordUpdate(Task *task);
+    void processRspTradingAccountPasswordUpdate(Task *task);
 
-	void processRspOrderInsert(Task *task);
+    void processRspOrderInsert(Task *task);
 
-	void processRspParkedOrderInsert(Task *task);
+    void processRspParkedOrderInsert(Task *task);
 
-	void processRspParkedOrderAction(Task *task);
+    void processRspParkedOrderAction(Task *task);
 
-	void processRspOrderAction(Task *task);
+    void processRspOrderAction(Task *task);
 
-	void processRspQueryMaxOrderVolume(Task *task);
+    void processRspQueryMaxOrderVolume(Task *task);
 
-	void processRspSettlementInfoConfirm(Task *task);
+    void processRspSettlementInfoConfirm(Task *task);
 
-	void processRspRemoveParkedOrder(Task *task);
+    void processRspRemoveParkedOrder(Task *task);
 
-	void processRspRemoveParkedOrderAction(Task *task);
+    void processRspRemoveParkedOrderAction(Task *task);
 
-	void processRspExecOrderInsert(Task *task);
+    void processRspExecOrderInsert(Task *task);
 
-	void processRspExecOrderAction(Task *task);
+    void processRspExecOrderAction(Task *task);
 
-	void processRspForQuoteInsert(Task *task);
+    void processRspForQuoteInsert(Task *task);
 
-	void processRspQuoteInsert(Task *task);
+    void processRspQuoteInsert(Task *task);
 
-	void processRspQuoteAction(Task *task);
+    void processRspQuoteAction(Task *task);
 
-	void processRspBatchOrderAction(Task *task);
+    void processRspBatchOrderAction(Task *task);
 
-	void processRspOptionSelfCloseInsert(Task *task);
+    void processRspOptionSelfCloseInsert(Task *task);
 
-	void processRspOptionSelfCloseAction(Task *task);
+    void processRspOptionSelfCloseAction(Task *task);
 
-	void processRspCombActionInsert(Task *task);
+    void processRspCombActionInsert(Task *task);
 
-	void processRspQryOrder(Task *task);
+    void processRspQryOrder(Task *task);
 
-	void processRspQryTrade(Task *task);
+    void processRspQryTrade(Task *task);
 
-	void processRspQryInvestorPosition(Task *task);
+    void processRspQryInvestorPosition(Task *task);
 
-	void processRspQryTradingAccount(Task *task);
+    void processRspQryTradingAccount(Task *task);
 
-	void processRspQryInvestor(Task *task);
+    void processRspQryInvestor(Task *task);
 
-	void processRspQryTradingCode(Task *task);
+    void processRspQryTradingCode(Task *task);
 
-	void processRspQryInstrumentMarginRate(Task *task);
+    void processRspQryInstrumentMarginRate(Task *task);
 
-	void processRspQryInstrumentCommissionRate(Task *task);
+    void processRspQryInstrumentCommissionRate(Task *task);
 
-	void processRspQryExchange(Task *task);
+    void processRspQryExchange(Task *task);
 
-	void processRspQryProduct(Task *task);
+    void processRspQryProduct(Task *task);
 
-	void processRspQryInstrument(Task *task);
+    void processRspQryInstrument(Task *task);
 
-	void processRspQryDepthMarketData(Task *task);
+    void processRspQryDepthMarketData(Task *task);
 
-	void processRspQrySettlementInfo(Task *task);
+    void processRspQrySettlementInfo(Task *task);
 
-	void processRspQryTransferBank(Task *task);
+    void processRspQryTransferBank(Task *task);
 
-	void processRspQryInvestorPositionDetail(Task *task);
+    void processRspQryInvestorPositionDetail(Task *task);
 
-	void processRspQryNotice(Task *task);
+    void processRspQryNotice(Task *task);
 
-	void processRspQrySettlementInfoConfirm(Task *task);
+    void processRspQrySettlementInfoConfirm(Task *task);
 
-	void processRspQryInvestorPositionCombineDetail(Task *task);
+    void processRspQryInvestorPositionCombineDetail(Task *task);
 
-	void processRspQryCFMMCTradingAccountKey(Task *task);
+    void processRspQryCFMMCTradingAccountKey(Task *task);
 
-	void processRspQryEWarrantOffset(Task *task);
+    void processRspQryEWarrantOffset(Task *task);
 
-	void processRspQryInvestorProductGroupMargin(Task *task);
+    void processRspQryInvestorProductGroupMargin(Task *task);
 
-	void processRspQryExchangeMarginRate(Task *task);
+    void processRspQryExchangeMarginRate(Task *task);
 
-	void processRspQryExchangeMarginRateAdjust(Task *task);
+    void processRspQryExchangeMarginRateAdjust(Task *task);
 
-	void processRspQryExchangeRate(Task *task);
+    void processRspQryExchangeRate(Task *task);
 
-	void processRspQrySecAgentACIDMap(Task *task);
+    void processRspQrySecAgentACIDMap(Task *task);
 
-	void processRspQryProductExchRate(Task *task);
+    void processRspQryProductExchRate(Task *task);
 
-	void processRspQryProductGroup(Task *task);
+    void processRspQryProductGroup(Task *task);
 
-	void processRspQryMMInstrumentCommissionRate(Task *task);
+    void processRspQryMMInstrumentCommissionRate(Task *task);
 
-	void processRspQryMMOptionInstrCommRate(Task *task);
+    void processRspQryMMOptionInstrCommRate(Task *task);
 
-	void processRspQryInstrumentOrderCommRate(Task *task);
+    void processRspQryInstrumentOrderCommRate(Task *task);
 
-	void processRspQryOptionInstrTradeCost(Task *task);
+    void processRspQryOptionInstrTradeCost(Task *task);
 
-	void processRspQryOptionInstrCommRate(Task *task);
+    void processRspQryOptionInstrCommRate(Task *task);
 
-	void processRspQryExecOrder(Task *task);
+    void processRspQryExecOrder(Task *task);
 
-	void processRspQryForQuote(Task *task);
+    void processRspQryForQuote(Task *task);
 
-	void processRspQryQuote(Task *task);
+    void processRspQryQuote(Task *task);
 
-	void processRspQryOptionSelfClose(Task *task);
+    void processRspQryOptionSelfClose(Task *task);
 
-	void processRspQryInvestUnit(Task *task);
+    void processRspQryInvestUnit(Task *task);
 
-	void processRspQryCombInstrumentGuard(Task *task);
+    void processRspQryCombInstrumentGuard(Task *task);
 
-	void processRspQryCombAction(Task *task);
+    void processRspQryCombAction(Task *task);
 
-	void processRspQryTransferSerial(Task *task);
+    void processRspQryTransferSerial(Task *task);
 
-	void processRspQryAccountregister(Task *task);
+    void processRspQryAccountregister(Task *task);
 
-	void processRspError(Task *task);
+    void processRspError(Task *task);
 
-	void processRtnOrder(Task *task);
+    void processRtnOrder(Task *task);
 
-	void processRtnTrade(Task *task);
+    void processRtnTrade(Task *task);
 
-	void processErrRtnOrderInsert(Task *task);
+    void processErrRtnOrderInsert(Task *task);
 
-	void processErrRtnOrderAction(Task *task);
+    void processErrRtnOrderAction(Task *task);
 
-	void processRtnInstrumentStatus(Task *task);
+    void processRtnInstrumentStatus(Task *task);
 
-	void processRtnBulletin(Task *task);
+    void processRtnBulletin(Task *task);
 
-	void processRtnTradingNotice(Task *task);
+    void processRtnTradingNotice(Task *task);
 
-	void processRtnErrorConditionalOrder(Task *task);
+    void processRtnErrorConditionalOrder(Task *task);
 
-	void processRtnExecOrder(Task *task);
+    void processRtnExecOrder(Task *task);
 
-	void processErrRtnExecOrderInsert(Task *task);
+    void processErrRtnExecOrderInsert(Task *task);
 
-	void processErrRtnExecOrderAction(Task *task);
+    void processErrRtnExecOrderAction(Task *task);
 
-	void processErrRtnForQuoteInsert(Task *task);
+    void processErrRtnForQuoteInsert(Task *task);
 
-	void processRtnQuote(Task *task);
+    void processRtnQuote(Task *task);
 
-	void processErrRtnQuoteInsert(Task *task);
+    void processErrRtnQuoteInsert(Task *task);
 
-	void processErrRtnQuoteAction(Task *task);
+    void processErrRtnQuoteAction(Task *task);
 
-	void processRtnForQuoteRsp(Task *task);
+    void processRtnForQuoteRsp(Task *task);
 
-	void processRtnCFMMCTradingAccountToken(Task *task);
+    void processRtnCFMMCTradingAccountToken(Task *task);
 
-	void processErrRtnBatchOrderAction(Task *task);
+    void processErrRtnBatchOrderAction(Task *task);
 
-	void processRtnOptionSelfClose(Task *task);
+    void processRtnOptionSelfClose(Task *task);
 
-	void processErrRtnOptionSelfCloseInsert(Task *task);
+    void processErrRtnOptionSelfCloseInsert(Task *task);
 
-	void processErrRtnOptionSelfCloseAction(Task *task);
+    void processErrRtnOptionSelfCloseAction(Task *task);
 
-	void processRtnCombAction(Task *task);
+    void processRtnCombAction(Task *task);
 
-	void processErrRtnCombActionInsert(Task *task);
+    void processErrRtnCombActionInsert(Task *task);
 
-	void processRspQryContractBank(Task *task);
+    void processRspQryContractBank(Task *task);
 
-	void processRspQryParkedOrder(Task *task);
+    void processRspQryParkedOrder(Task *task);
 
-	void processRspQryParkedOrderAction(Task *task);
+    void processRspQryParkedOrderAction(Task *task);
 
-	void processRspQryTradingNotice(Task *task);
+    void processRspQryTradingNotice(Task *task);
 
-	void processRspQryBrokerTradingParams(Task *task);
+    void processRspQryBrokerTradingParams(Task *task);
 
-	void processRspQryBrokerTradingAlgos(Task *task);
+    void processRspQryBrokerTradingAlgos(Task *task);
 
-	void processRspQueryCFMMCTradingAccountToken(Task *task);
+    void processRspQueryCFMMCTradingAccountToken(Task *task);
 
-	void processRtnFromBankToFutureByBank(Task *task);
+    void processRtnFromBankToFutureByBank(Task *task);
 
-	void processRtnFromFutureToBankByBank(Task *task);
+    void processRtnFromFutureToBankByBank(Task *task);
 
-	void processRtnRepealFromBankToFutureByBank(Task *task);
+    void processRtnRepealFromBankToFutureByBank(Task *task);
 
-	void processRtnRepealFromFutureToBankByBank(Task *task);
+    void processRtnRepealFromFutureToBankByBank(Task *task);
 
-	void processRtnFromBankToFutureByFuture(Task *task);
+    void processRtnFromBankToFutureByFuture(Task *task);
 
-	void processRtnFromFutureToBankByFuture(Task *task);
+    void processRtnFromFutureToBankByFuture(Task *task);
 
-	void processRtnRepealFromBankToFutureByFutureManual(Task *task);
+    void processRtnRepealFromBankToFutureByFutureManual(Task *task);
 
-	void processRtnRepealFromFutureToBankByFutureManual(Task *task);
+    void processRtnRepealFromFutureToBankByFutureManual(Task *task);
 
-	void processRtnQueryBankBalanceByFuture(Task *task);
+    void processRtnQueryBankBalanceByFuture(Task *task);
 
-	void processErrRtnBankToFutureByFuture(Task *task);
+    void processErrRtnBankToFutureByFuture(Task *task);
 
-	void processErrRtnFutureToBankByFuture(Task *task);
+    void processErrRtnFutureToBankByFuture(Task *task);
 
-	void processErrRtnRepealBankToFutureByFutureManual(Task *task);
+    void processErrRtnRepealBankToFutureByFutureManual(Task *task);
 
-	void processErrRtnRepealFutureToBankByFutureManual(Task *task);
+    void processErrRtnRepealFutureToBankByFutureManual(Task *task);
 
-	void processErrRtnQueryBankBalanceByFuture(Task *task);
+    void processErrRtnQueryBankBalanceByFuture(Task *task);
 
-	void processRtnRepealFromBankToFutureByFuture(Task *task);
+    void processRtnRepealFromBankToFutureByFuture(Task *task);
 
-	void processRtnRepealFromFutureToBankByFuture(Task *task);
+    void processRtnRepealFromFutureToBankByFuture(Task *task);
 
-	void processRspFromBankToFutureByFuture(Task *task);
+    void processRspFromBankToFutureByFuture(Task *task);
 
-	void processRspFromFutureToBankByFuture(Task *task);
+    void processRspFromFutureToBankByFuture(Task *task);
 
-	void processRspQueryBankAccountMoneyByFuture(Task *task);
+    void processRspQueryBankAccountMoneyByFuture(Task *task);
 
-	void processRtnOpenAccountByBank(Task *task);
+    void processRtnOpenAccountByBank(Task *task);
 
-	void processRtnCancelAccountByBank(Task *task);
+    void processRtnCancelAccountByBank(Task *task);
 
-	void processRtnChangeAccountByBank(Task *task);
+    void processRtnChangeAccountByBank(Task *task);
+
 
 
 	//-------------------------------------------------------------------------------------
@@ -780,244 +781,245 @@ public:
 	//last：是否为最后返回
 	//i：整数
 	//-------------------------------------------------------------------------------------
+    virtual void onFrontConnected() {};
 
-	virtual void onFrontConnected() {};
+    virtual void onFrontDisconnected(int reqid) {};
 
-	virtual void onFrontDisconnected(int reqid) {};
+    virtual void onHeartBeatWarning(int reqid) {};
 
-	virtual void onHeartBeatWarning(int reqid) {};
+    virtual void onRspAuthenticate(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspAuthenticate(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspUserLogin(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspUserLogin(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspUserLogout(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspUserLogout(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspUserPasswordUpdate(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspUserPasswordUpdate(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspTradingAccountPasswordUpdate(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspTradingAccountPasswordUpdate(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspOrderInsert(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspOrderInsert(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspParkedOrderInsert(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspParkedOrderInsert(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspParkedOrderAction(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspParkedOrderAction(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspOrderAction(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspOrderAction(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQueryMaxOrderVolume(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQueryMaxOrderVolume(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspSettlementInfoConfirm(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspSettlementInfoConfirm(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspRemoveParkedOrder(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspRemoveParkedOrder(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspRemoveParkedOrderAction(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspRemoveParkedOrderAction(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspExecOrderInsert(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspExecOrderInsert(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspExecOrderAction(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspExecOrderAction(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspForQuoteInsert(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspForQuoteInsert(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQuoteInsert(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQuoteInsert(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQuoteAction(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQuoteAction(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspBatchOrderAction(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspBatchOrderAction(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspOptionSelfCloseInsert(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspOptionSelfCloseInsert(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspOptionSelfCloseAction(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspOptionSelfCloseAction(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspCombActionInsert(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspCombActionInsert(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryOrder(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryOrder(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryTrade(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryTrade(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryInvestorPosition(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryInvestorPosition(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryTradingAccount(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryTradingAccount(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryInvestor(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryInvestor(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryTradingCode(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryTradingCode(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryInstrumentMarginRate(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryInstrumentMarginRate(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryInstrumentCommissionRate(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryInstrumentCommissionRate(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryExchange(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryExchange(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryProduct(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryProduct(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryInstrument(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryInstrument(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryDepthMarketData(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryDepthMarketData(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQrySettlementInfo(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQrySettlementInfo(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryTransferBank(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryTransferBank(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryInvestorPositionDetail(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryInvestorPositionDetail(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryNotice(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryNotice(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQrySettlementInfoConfirm(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQrySettlementInfoConfirm(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryInvestorPositionCombineDetail(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryInvestorPositionCombineDetail(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryCFMMCTradingAccountKey(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryCFMMCTradingAccountKey(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryEWarrantOffset(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryEWarrantOffset(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryInvestorProductGroupMargin(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryInvestorProductGroupMargin(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryExchangeMarginRate(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryExchangeMarginRate(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryExchangeMarginRateAdjust(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryExchangeMarginRateAdjust(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryExchangeRate(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryExchangeRate(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQrySecAgentACIDMap(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQrySecAgentACIDMap(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryProductExchRate(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryProductExchRate(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryProductGroup(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryProductGroup(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryMMInstrumentCommissionRate(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryMMInstrumentCommissionRate(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryMMOptionInstrCommRate(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryMMOptionInstrCommRate(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryInstrumentOrderCommRate(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryInstrumentOrderCommRate(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryOptionInstrTradeCost(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryOptionInstrTradeCost(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryOptionInstrCommRate(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryOptionInstrCommRate(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryExecOrder(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryExecOrder(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryForQuote(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryForQuote(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryQuote(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryQuote(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryOptionSelfClose(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryOptionSelfClose(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryInvestUnit(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryInvestUnit(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryCombInstrumentGuard(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryCombInstrumentGuard(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryCombAction(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryCombAction(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryTransferSerial(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryTransferSerial(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryAccountregister(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryAccountregister(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspError(const dict &error, int reqid, bool last) {};
 
-	virtual void onRspError(dict error, int reqid, bool last) {};
+    virtual void onRtnOrder(const dict &data) {};
 
-	virtual void onRtnOrder(dict data) {};
+    virtual void onRtnTrade(const dict &data) {};
 
-	virtual void onRtnTrade(dict data) {};
+    virtual void onErrRtnOrderInsert(const dict &data, const dict &error) {};
 
-	virtual void onErrRtnOrderInsert(dict data, dict error) {};
+    virtual void onErrRtnOrderAction(const dict &data, const dict &error) {};
 
-	virtual void onErrRtnOrderAction(dict data, dict error) {};
+    virtual void onRtnInstrumentStatus(const dict &data) {};
 
-	virtual void onRtnInstrumentStatus(dict data) {};
+    virtual void onRtnBulletin(const dict &data) {};
 
-	virtual void onRtnBulletin(dict data) {};
+    virtual void onRtnTradingNotice(const dict &data) {};
 
-	virtual void onRtnTradingNotice(dict data) {};
+    virtual void onRtnErrorConditionalOrder(const dict &data) {};
 
-	virtual void onRtnErrorConditionalOrder(dict data) {};
+    virtual void onRtnExecOrder(const dict &data) {};
 
-	virtual void onRtnExecOrder(dict data) {};
+    virtual void onErrRtnExecOrderInsert(const dict &data, const dict &error) {};
 
-	virtual void onErrRtnExecOrderInsert(dict data, dict error) {};
+    virtual void onErrRtnExecOrderAction(const dict &data, const dict &error) {};
 
-	virtual void onErrRtnExecOrderAction(dict data, dict error) {};
+    virtual void onErrRtnForQuoteInsert(const dict &data, const dict &error) {};
 
-	virtual void onErrRtnForQuoteInsert(dict data, dict error) {};
+    virtual void onRtnQuote(const dict &data) {};
 
-	virtual void onRtnQuote(dict data) {};
+    virtual void onErrRtnQuoteInsert(const dict &data, const dict &error) {};
 
-	virtual void onErrRtnQuoteInsert(dict data, dict error) {};
+    virtual void onErrRtnQuoteAction(const dict &data, const dict &error) {};
 
-	virtual void onErrRtnQuoteAction(dict data, dict error) {};
+    virtual void onRtnForQuoteRsp(const dict &data) {};
 
-	virtual void onRtnForQuoteRsp(dict data) {};
+    virtual void onRtnCFMMCTradingAccountToken(const dict &data) {};
 
-	virtual void onRtnCFMMCTradingAccountToken(dict data) {};
+    virtual void onErrRtnBatchOrderAction(const dict &data, const dict &error) {};
 
-	virtual void onErrRtnBatchOrderAction(dict data, dict error) {};
+    virtual void onRtnOptionSelfClose(const dict &data) {};
 
-	virtual void onRtnOptionSelfClose(dict data) {};
+    virtual void onErrRtnOptionSelfCloseInsert(const dict &data, const dict &error) {};
 
-	virtual void onErrRtnOptionSelfCloseInsert(dict data, dict error) {};
+    virtual void onErrRtnOptionSelfCloseAction(const dict &data, const dict &error) {};
 
-	virtual void onErrRtnOptionSelfCloseAction(dict data, dict error) {};
+    virtual void onRtnCombAction(const dict &data) {};
 
-	virtual void onRtnCombAction(dict data) {};
+    virtual void onErrRtnCombActionInsert(const dict &data, const dict &error) {};
 
-	virtual void onErrRtnCombActionInsert(dict data, dict error) {};
+    virtual void onRspQryContractBank(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryContractBank(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryParkedOrder(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryParkedOrder(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryParkedOrderAction(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryParkedOrderAction(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryTradingNotice(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryTradingNotice(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryBrokerTradingParams(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryBrokerTradingParams(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQryBrokerTradingAlgos(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQryBrokerTradingAlgos(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQueryCFMMCTradingAccountToken(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQueryCFMMCTradingAccountToken(dict data, dict error, int reqid, bool last) {};
+    virtual void onRtnFromBankToFutureByBank(const dict &data) {};
 
-	virtual void onRtnFromBankToFutureByBank(dict data) {};
+    virtual void onRtnFromFutureToBankByBank(const dict &data) {};
 
-	virtual void onRtnFromFutureToBankByBank(dict data) {};
+    virtual void onRtnRepealFromBankToFutureByBank(const dict &data) {};
 
-	virtual void onRtnRepealFromBankToFutureByBank(dict data) {};
+    virtual void onRtnRepealFromFutureToBankByBank(const dict &data) {};
 
-	virtual void onRtnRepealFromFutureToBankByBank(dict data) {};
+    virtual void onRtnFromBankToFutureByFuture(const dict &data) {};
 
-	virtual void onRtnFromBankToFutureByFuture(dict data) {};
+    virtual void onRtnFromFutureToBankByFuture(const dict &data) {};
 
-	virtual void onRtnFromFutureToBankByFuture(dict data) {};
+    virtual void onRtnRepealFromBankToFutureByFutureManual(const dict &data) {};
 
-	virtual void onRtnRepealFromBankToFutureByFutureManual(dict data) {};
+    virtual void onRtnRepealFromFutureToBankByFutureManual(const dict &data) {};
 
-	virtual void onRtnRepealFromFutureToBankByFutureManual(dict data) {};
+    virtual void onRtnQueryBankBalanceByFuture(const dict &data) {};
 
-	virtual void onRtnQueryBankBalanceByFuture(dict data) {};
+    virtual void onErrRtnBankToFutureByFuture(const dict &data, const dict &error) {};
 
-	virtual void onErrRtnBankToFutureByFuture(dict data, dict error) {};
+    virtual void onErrRtnFutureToBankByFuture(const dict &data, const dict &error) {};
 
-	virtual void onErrRtnFutureToBankByFuture(dict data, dict error) {};
+    virtual void onErrRtnRepealBankToFutureByFutureManual(const dict &data, const dict &error) {};
 
-	virtual void onErrRtnRepealBankToFutureByFutureManual(dict data, dict error) {};
+    virtual void onErrRtnRepealFutureToBankByFutureManual(const dict &data, const dict &error) {};
 
-	virtual void onErrRtnRepealFutureToBankByFutureManual(dict data, dict error) {};
+    virtual void onErrRtnQueryBankBalanceByFuture(const dict &data, const dict &error) {};
 
-	virtual void onErrRtnQueryBankBalanceByFuture(dict data, dict error) {};
+    virtual void onRtnRepealFromBankToFutureByFuture(const dict &data) {};
 
-	virtual void onRtnRepealFromBankToFutureByFuture(dict data) {};
+    virtual void onRtnRepealFromFutureToBankByFuture(const dict &data) {};
 
-	virtual void onRtnRepealFromFutureToBankByFuture(dict data) {};
+    virtual void onRspFromBankToFutureByFuture(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspFromBankToFutureByFuture(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspFromFutureToBankByFuture(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspFromFutureToBankByFuture(dict data, dict error, int reqid, bool last) {};
+    virtual void onRspQueryBankAccountMoneyByFuture(const dict &data, const dict &error, int reqid, bool last) {};
 
-	virtual void onRspQueryBankAccountMoneyByFuture(dict data, dict error, int reqid, bool last) {};
+    virtual void onRtnOpenAccountByBank(const dict &data) {};
 
-	virtual void onRtnOpenAccountByBank(dict data) {};
+    virtual void onRtnCancelAccountByBank(const dict &data) {};
 
-	virtual void onRtnCancelAccountByBank(dict data) {};
+    virtual void onRtnChangeAccountByBank(const dict &data) {};
 
-	virtual void onRtnChangeAccountByBank(dict data) {};
+
 
 	//-------------------------------------------------------------------------------------
 	//req:主动函数的请求字典
@@ -1041,153 +1043,153 @@ public:
 
 	void subscribePublicTopic(int nType);
 
-	int reqAuthenticate(dict req, int reqid);
+	int reqAuthenticate(const dict &req, int reqid);
 
-	int reqUserLogin(dict req, int reqid);
+	int reqUserLogin(const dict &req, int reqid);
 
-	int reqUserLogout(dict req, int reqid);
+	int reqUserLogout(const dict &req, int reqid);
 
-	int reqUserPasswordUpdate(dict req, int reqid);
+	int reqUserPasswordUpdate(const dict &req, int reqid);
 
-	int reqTradingAccountPasswordUpdate(dict req, int reqid);
+	int reqTradingAccountPasswordUpdate(const dict &req, int reqid);
 
-	int reqUserLogin2(dict req, int reqid);
+	int reqUserLogin2(const dict &req, int reqid);
 
-	int reqUserPasswordUpdate2(dict req, int reqid);
+	int reqUserPasswordUpdate2(const dict &req, int reqid);
 
-	int reqOrderInsert(dict req, int reqid);
+	int reqOrderInsert(const dict &req, int reqid);
 
-	int reqParkedOrderInsert(dict req, int reqid);
+	int reqParkedOrderInsert(const dict &req, int reqid);
 
-	int reqParkedOrderAction(dict req, int reqid);
+	int reqParkedOrderAction(const dict &req, int reqid);
 
-	int reqOrderAction(dict req, int reqid);
+	int reqOrderAction(const dict &req, int reqid);
 
-	int reqQueryMaxOrderVolume(dict req, int reqid);
+	int reqQueryMaxOrderVolume(const dict &req, int reqid);
 
-	int reqSettlementInfoConfirm(dict req, int reqid);
+	int reqSettlementInfoConfirm(const dict &req, int reqid);
 
-	int reqRemoveParkedOrder(dict req, int reqid);
+	int reqRemoveParkedOrder(const dict &req, int reqid);
 
-	int reqRemoveParkedOrderAction(dict req, int reqid);
+	int reqRemoveParkedOrderAction(const dict &req, int reqid);
 
-	int reqExecOrderInsert(dict req, int reqid);
+	int reqExecOrderInsert(const dict &req, int reqid);
 
-	int reqExecOrderAction(dict req, int reqid);
+	int reqExecOrderAction(const dict &req, int reqid);
 
-	int reqForQuoteInsert(dict req, int reqid);
+	int reqForQuoteInsert(const dict &req, int reqid);
 
-	int reqQuoteInsert(dict req, int reqid);
+	int reqQuoteInsert(const dict &req, int reqid);
 
-	int reqQuoteAction(dict req, int reqid);
+	int reqQuoteAction(const dict &req, int reqid);
 
-	int reqBatchOrderAction(dict req, int reqid);
+	int reqBatchOrderAction(const dict &req, int reqid);
 
-	int reqOptionSelfCloseInsert(dict req, int reqid);
+	int reqOptionSelfCloseInsert(const dict &req, int reqid);
 
-	int reqOptionSelfCloseAction(dict req, int reqid);
+	int reqOptionSelfCloseAction(const dict &req, int reqid);
 
-	int reqCombActionInsert(dict req, int reqid);
+	int reqCombActionInsert(const dict &req, int reqid);
 
-	int reqQryOrder(dict req, int reqid);
+	int reqQryOrder(const dict &req, int reqid);
 
-	int reqQryTrade(dict req, int reqid);
+	int reqQryTrade(const dict &req, int reqid);
 
-	int reqQryInvestorPosition(dict req, int reqid);
+	int reqQryInvestorPosition(const dict &req, int reqid);
 
-	int reqQryTradingAccount(dict req, int reqid);
+	int reqQryTradingAccount(const dict &req, int reqid);
 
-	int reqQryInvestor(dict req, int reqid);
+	int reqQryInvestor(const dict &req, int reqid);
 
-	int reqQryTradingCode(dict req, int reqid);
+	int reqQryTradingCode(const dict &req, int reqid);
 
-	int reqQryInstrumentMarginRate(dict req, int reqid);
+	int reqQryInstrumentMarginRate(const dict &req, int reqid);
 
-	int reqQryInstrumentCommissionRate(dict req, int reqid);
+	int reqQryInstrumentCommissionRate(const dict &req, int reqid);
 
-	int reqQryExchange(dict req, int reqid);
+	int reqQryExchange(const dict &req, int reqid);
 
-	int reqQryProduct(dict req, int reqid);
+	int reqQryProduct(const dict &req, int reqid);
 
-	int reqQryInstrument(dict req, int reqid);
+	int reqQryInstrument(const dict &req, int reqid);
 
-	int reqQryDepthMarketData(dict req, int reqid);
+	int reqQryDepthMarketData(const dict &req, int reqid);
 
-	int reqQrySettlementInfo(dict req, int reqid);
+	int reqQrySettlementInfo(const dict &req, int reqid);
 
-	int reqQryTransferBank(dict req, int reqid);
+	int reqQryTransferBank(const dict &req, int reqid);
 
-	int reqQryInvestorPositionDetail(dict req, int reqid);
+	int reqQryInvestorPositionDetail(const dict &req, int reqid);
 
-	int reqQryNotice(dict req, int reqid);
+	int reqQryNotice(const dict &req, int reqid);
 
-	int reqQrySettlementInfoConfirm(dict req, int reqid);
+	int reqQrySettlementInfoConfirm(const dict &req, int reqid);
 
-	int reqQryInvestorPositionCombineDetail(dict req, int reqid);
+	int reqQryInvestorPositionCombineDetail(const dict &req, int reqid);
 
-	int reqQryCFMMCTradingAccountKey(dict req, int reqid);
+	int reqQryCFMMCTradingAccountKey(const dict &req, int reqid);
 
-	int reqQryEWarrantOffset(dict req, int reqid);
+	int reqQryEWarrantOffset(const dict &req, int reqid);
 
-	int reqQryInvestorProductGroupMargin(dict req, int reqid);
+	int reqQryInvestorProductGroupMargin(const dict &req, int reqid);
 
-	int reqQryExchangeMarginRate(dict req, int reqid);
+	int reqQryExchangeMarginRate(const dict &req, int reqid);
 
-	int reqQryExchangeMarginRateAdjust(dict req, int reqid);
+	int reqQryExchangeMarginRateAdjust(const dict &req, int reqid);
 
-	int reqQryExchangeRate(dict req, int reqid);
+	int reqQryExchangeRate(const dict &req, int reqid);
 
-	int reqQrySecAgentACIDMap(dict req, int reqid);
+	int reqQrySecAgentACIDMap(const dict &req, int reqid);
 
-	int reqQryProductExchRate(dict req, int reqid);
+	int reqQryProductExchRate(const dict &req, int reqid);
 
-	int reqQryProductGroup(dict req, int reqid);
+	int reqQryProductGroup(const dict &req, int reqid);
 
-	int reqQryMMInstrumentCommissionRate(dict req, int reqid);
+	int reqQryMMInstrumentCommissionRate(const dict &req, int reqid);
 
-	int reqQryMMOptionInstrCommRate(dict req, int reqid);
+	int reqQryMMOptionInstrCommRate(const dict &req, int reqid);
 
-	int reqQryInstrumentOrderCommRate(dict req, int reqid);
+	int reqQryInstrumentOrderCommRate(const dict &req, int reqid);
 
-	int reqQryOptionInstrTradeCost(dict req, int reqid);
+	int reqQryOptionInstrTradeCost(const dict &req, int reqid);
 
-	int reqQryOptionInstrCommRate(dict req, int reqid);
+	int reqQryOptionInstrCommRate(const dict &req, int reqid);
 
-	int reqQryExecOrder(dict req, int reqid);
+	int reqQryExecOrder(const dict &req, int reqid);
 
-	int reqQryForQuote(dict req, int reqid);
+	int reqQryForQuote(const dict &req, int reqid);
 
-	int reqQryQuote(dict req, int reqid);
+	int reqQryQuote(const dict &req, int reqid);
 
-	int reqQryOptionSelfClose(dict req, int reqid);
+	int reqQryOptionSelfClose(const dict &req, int reqid);
 
-	int reqQryInvestUnit(dict req, int reqid);
+	int reqQryInvestUnit(const dict &req, int reqid);
 
-	int reqQryCombInstrumentGuard(dict req, int reqid);
+	int reqQryCombInstrumentGuard(const dict &req, int reqid);
 
-	int reqQryCombAction(dict req, int reqid);
+	int reqQryCombAction(const dict &req, int reqid);
 
-	int reqQryTransferSerial(dict req, int reqid);
+	int reqQryTransferSerial(const dict &req, int reqid);
 
-	int reqQryAccountregister(dict req, int reqid);
+	int reqQryAccountregister(const dict &req, int reqid);
 
-	int reqQryContractBank(dict req, int reqid);
+	int reqQryContractBank(const dict &req, int reqid);
 
-	int reqQryParkedOrder(dict req, int reqid);
+	int reqQryParkedOrder(const dict &req, int reqid);
 
-	int reqQryParkedOrderAction(dict req, int reqid);
+	int reqQryParkedOrderAction(const dict &req, int reqid);
 
-	int reqQryTradingNotice(dict req, int reqid);
+	int reqQryTradingNotice(const dict &req, int reqid);
 
-	int reqQryBrokerTradingParams(dict req, int reqid);
+	int reqQryBrokerTradingParams(const dict &req, int reqid);
 
-	int reqQryBrokerTradingAlgos(dict req, int reqid);
+	int reqQryBrokerTradingAlgos(const dict &req, int reqid);
 
-	int reqQueryCFMMCTradingAccountToken(dict req, int reqid);
+	int reqQueryCFMMCTradingAccountToken(const dict &req, int reqid);
 
-	int reqFromBankToFutureByFuture(dict req, int reqid);
+	int reqFromBankToFutureByFuture(const dict &req, int reqid);
 
-	int reqFromFutureToBankByFuture(dict req, int reqid);
+	int reqFromFutureToBankByFuture(const dict &req, int reqid);
 
-	int reqQueryBankAccountMoneyByFuture(dict req, int reqid);
+	int reqQueryBankAccountMoneyByFuture(const dict &req, int reqid);
 };


### PR DESCRIPTION
关于传参：
可以改为引用的地方全部改为引用，减少一次参数的复制。

关于getString:
strcpy的template特化版本可以在VisualStudio中使用。

关于getXXX中的异常：
异常会被上层捕获。getXXX的调用者全为reqXXXX，其上层为pybind11.
pybind11会将异常转化为python异常然后回传到python之中。所以在C++中不需要特地捕获异常。