### PR TITLE
增加QuantOS获取期货分钟交易数据示例

### DIFF
--- a/examples/DataRecording/runDataRecording.py
+++ b/examples/DataRecording/runDataRecording.py
@@ -71,9 +71,9 @@ def runParentProcess():
         recording = False
 
         # 判断当前处于的时间段
-        if ((currentTime >= DAY_START and currentTime <= DAY_END) or
-            (currentTime >= NIGHT_START) or
-            (currentTime <= NIGHT_END)):
+        if ((DAY_START <= currentTime <= DAY_END) or
+                (currentTime >= NIGHT_START) or
+                (currentTime <= NIGHT_END)):
             recording = True
             
         # 过滤周末时间段：周六全天，周五夜盘，周日日盘

--- a/examples/DataService/QuantOSDataService/config.json
+++ b/examples/DataService/QuantOSDataService/config.json
@@ -1,0 +1,12 @@
+{
+  "MONGO_HOST": "localhost",
+  "MONGO_PORT": 27017,
+  "QUANTOS_ADDR": "tcp://data.quantos.org:8910",
+  "PHONE": "quantos申请",
+  "QUANTOS_TOKEN": "quantos申请",
+  "SYMBOLS": [
+    "TA905.CZC"
+  ],
+  "START_DATE": "20190220",
+  "END_DATE": "20190225"
+}

--- a/examples/DataService/QuantOSDataService/dataService.py
+++ b/examples/DataService/QuantOSDataService/dataService.py
@@ -1,0 +1,105 @@
+# encoding: UTF-8
+
+from __future__ import print_function
+
+import datetime
+import json
+import time
+
+import pandas as pd
+from jaqs.data import DataApi
+from pymongo import MongoClient, ASCENDING
+from vnpy.trader.app.ctaStrategy.ctaBase import MINUTE_DB_NAME
+from vnpy.trader.vtObject import VtBarData
+
+"""
+该文件使用到jaqs中的数据api，需要安装相关依赖和注册账号
+
+1，注册账号（https://www.quantos.org），使用手机号注册，注册后获取API令牌。将手机号和令牌填入配置文件
+2，安装jaqs（pip install jaqs），或参考https://www.quantos.org/jaqs/doc.html
+3，市场代码说明 https://www.quantos.org/jaqs/doc.html
+"""
+
+# 加载配置
+config = open('config.json')
+setting = json.load(config)
+
+MONGO_HOST = setting['MONGO_HOST']
+MONGO_PORT = setting['MONGO_PORT']
+QUANTOS_ADDR = setting['QUANTOS_ADDR']
+PHONE = setting['PHONE']
+QUANTOS_TOKEN = setting['QUANTOS_TOKEN']
+SYMBOLS = setting['SYMBOLS']
+START_DATE = setting['START_DATE']
+END_DATE = setting['END_DATE']
+
+api = DataApi(addr=QUANTOS_ADDR)  # 历史行情服务API对象
+api.login(PHONE, QUANTOS_TOKEN)
+mc = MongoClient(MONGO_HOST, MONGO_PORT)  # Mongo连接
+db = mc[MINUTE_DB_NAME]  # 数据库
+
+
+# ----------------------------------------------------------------------
+def generateVtBar(d):
+    """生成K线"""
+    bar = VtBarData()
+
+    bar.symbol = d['code']
+    bar.vtSymbol = d['code']
+    bar.date = str(d['date'])
+    timeStr = str(d['time'])
+    if len(timeStr) == 5:
+        timeStr = '0' + timeStr
+    bar.time = ':'.join([timeStr[:2], timeStr[2:4]])
+    bar.open = d['open']
+    bar.high = d['high']
+    bar.low = d['low']
+    bar.close = d['close']
+    bar.volume = d['volume']
+    bar.openInterest = d['oi']
+    bar.datetime = datetime.datetime.strptime(' '.join([bar.date, bar.time]),
+                                              '%Y%m%d %H:%M')
+    return bar
+
+
+# ---------------------------------------------------------------------
+def downMinuteBarBySymbol(symbol, trade_date):
+    """下载某一合约的分钟线数据"""
+    start = time.time()
+
+    cl = db[symbol.split('.')[0]]  # 集合
+    cl.ensure_index([('datetime', ASCENDING)], unique=True)  # 添加索引
+
+    df, msg = api.bar(symbol=symbol, trade_date=trade_date, freq="1M")
+    for ix, row in df.iterrows():
+        bar = generateVtBar(row)
+        d = bar.__dict__
+        flt = {'datetime': bar.datetime}
+        cl.replace_one(flt, d, True)
+
+    end = time.time()
+    cost = (end - start) * 1000
+
+    print(u'合约%s 日期%s 数据下载完成，耗时%s毫秒' % (symbol, trade_date, cost))
+
+
+# ---------------------------------------------------------------------
+def downloadAllMinuteBar(start_date, end_date):
+    """下载所有配置中的合约的分钟线数据"""
+    print('-' * 50)
+    print(u'开始下载合约分钟线数据')
+    print('-' * 50)
+
+    for symbol in SYMBOLS:
+        di = pd.date_range(start_date, end_date)
+        for d in di:
+            downMinuteBarBySymbol(symbol, str(d)[:10])
+            time.sleep(1)
+
+    print('-' * 50)
+    print(u'合约分钟线数据下载完成')
+    print('-' * 50)
+
+
+if __name__ == '__main__':
+    downloadAllMinuteBar(START_DATE, END_DATE)

--- a/examples/DataService/QuantOSDataService/downloadData.py
+++ b/examples/DataService/QuantOSDataService/downloadData.py
@@ -1,0 +1,12 @@
+# encoding: UTF-8
+
+"""
+立即下载数据到数据库中，用于手动执行更新操作。
+
+下载的日期范围在config.json中配置
+"""
+
+from dataService import *
+
+if __name__ == '__main__':
+    downloadAllMinuteBar(START_DATE, END_DATE)

--- a/examples/DataService/QuantOSDataService/runService.py
+++ b/examples/DataService/QuantOSDataService/runService.py
@@ -1,0 +1,34 @@
+# encoding: UTF-8
+
+"""
+定时服务，可无人值守运行，实现每日自动下载更新历史行情数据到数据库中。
+"""
+from __future__ import print_function
+
+import random
+from datetime import timedelta
+
+from dataService import *
+
+if __name__ == '__main__':
+    taskCompletedDate = None
+
+    # 生成一个随机的任务下载时间，用于避免所有用户在同一时间访问数据服务器
+    taskTime = datetime.time(hour=17, minute=random.randint(1, 59))
+
+    # 进入主循环
+    while True:
+        t = datetime.datetime.now()
+
+        # 每天到达任务下载时间后，执行数据下载的操作
+        if t.time() > taskTime and (
+                taskCompletedDate is None or t.date() != taskCompletedDate):
+            # 以防平台更新数据不及时，下载最近两天交易数据
+            downloadAllMinuteBar((t + timedelta(days=-1)).date(), t.date())
+
+            # 更新任务完成的日期
+            taskCompletedDate = t.date()
+        else:
+            print(u'当前时间%s，任务定时%s' % (t, taskTime))
+
+        time.sleep(60)

--- a/vnpy/trader/app/dataRecorder/drEngine.py
+++ b/vnpy/trader/app/dataRecorder/drEngine.py
@@ -217,8 +217,7 @@ class DrEngine(object):
             return
         
         # 上一个时间戳尚未到收盘时间，且当前时间戳已经到收盘时间
-        if (self.lastTimerTime < self.marketCloseTime and
-            currentTime >= self.marketCloseTime):
+        if self.lastTimerTime < self.marketCloseTime <= currentTime:
             # 强制所有的K线生成器立即完成K线
             for bg in self.bgDict.values():
                 bg.generate()
@@ -237,13 +236,13 @@ class DrEngine(object):
             if vtSymbol in self.activeSymbolDict:
                 activeSymbol = self.activeSymbolDict[vtSymbol]
                 self.insertData(TICK_DB_NAME, activeSymbol, tick)
-            
-            
-            self.writeDrLog(text.TICK_LOGGING_MESSAGE.format(symbol=tick.vtSymbol,
-                                                             time=tick.time, 
-                                                             last=tick.lastPrice, 
-                                                             bid=tick.bidPrice1, 
-                                                             ask=tick.askPrice1))
+
+            self.writeDrLog(
+                text.TICK_LOGGING_MESSAGE.format(symbol=tick.vtSymbol,
+                                                 time=tick.time,
+                                                 last=tick.lastPrice,
+                                                 bid=tick.bidPrice1,
+                                                 ask=tick.askPrice1))
     
     #----------------------------------------------------------------------
     def onBar(self, bar):
@@ -314,5 +313,4 @@ class DrEngine(object):
         log.logContent = content
         event = Event(type_=EVENT_DATARECORDER_LOG)
         event.dict_['data'] = log
-        self.eventEngine.put(event)   
-    
+        self.eventEngine.put(event)


### PR DESCRIPTION
交易员大大你好。刚接触vn.py，非常感谢你的付出。

## 改进内容

1. examples下，增加从QuantOS（JAQS）获取期货分钟交易数据的示例：QuantOSDataService
2. 简化行情记录模块两处if判断写法
3.

## 相关的Issue号（如有）

Close #