### PR TITLE
Travis CI: Upgrade testing to Python 3.7 again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: python
-python:
-  - "3.6"
-install:
-  - pip install -r requirements.txt
-  - pip install flake8
-script:
-  - python check.py
+dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+python: "3.7"
+install: pip install flake8 -r requirements.txt
+script: python check.py


### PR DESCRIPTION
In alignment with travis-ci/travis-ci#9069 and https://blog.travis-ci.com/2018-11-08-xenial-release