### PR TITLE
[FIX] 修复 pickle 在 python2.7 环境下的编译错误，兼容python2.7

### DIFF
--- a/vnpy/rpc/vnrpc.py
+++ b/vnpy/rpc/vnrpc.py
@@ -8,9 +8,13 @@ import zmq
 from msgpack import packb, unpackb
 from json import dumps, loads
 
-import cPickle
-pDumps = cPickle.dumps
-pLoads = cPickle.loads
+try:
+    from cPickle import Pickler, Unpickler
+except ImportError:
+    from pickle import Pickler, Unpickler
+
+pDumps = Pickler.dump
+pLoads = Pickler.load
 
 
 # 实现Ctrl-c中断recv


### PR DESCRIPTION
编译出现如下错误：
File "/Users/abcd/anaconda3/envs/python2/lib/python2.7/shelve.py", line 122, in __getitem__
    value = Unpickler(f).load()
ValueError: unsupported pickle protocol: 3

建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 修复 python2.7 环境下，提示"ValueError: unsupported pickle protocol: 3"错误

## 相关的Issue号（如有）

Close #无