### PR TITLE
fix a bug in CTP login using UserProductInfo and AuthCode

### DIFF
--- a/vnpy/gateway/ctp/ctp_gateway.py
+++ b/vnpy/gateway/ctp/ctp_gateway.py
@@ -405,7 +405,7 @@ class CtpTdApi(TdApi):
         """"""
         if not error['ErrorID']:
             self.authStatus = True
-            self.writeLog("交易授权验证成功")
+            self.gateway.write_log("交易授权验证成功")
             self.login()
         else:
             self.gateway.write_error("交易授权验证失败", error)
@@ -418,7 +418,7 @@ class CtpTdApi(TdApi):
             self.login_status = True
             self.gateway.write_log("交易登录成功")
             
-            # Confirm settelment
+            # Confirm settlement
             req = {
                 "BrokerID": self.brokerid,
                 "InvestorID": self.userid
@@ -662,7 +662,7 @@ class CtpTdApi(TdApi):
             "UserID": self.userid,
             "BrokerID": self.brokerid,
             "AuthCode": self.auth_code,
-            "ProductInfo": self.product_info
+            "UserProductInfo": self.product_info
         }
         
         self.reqid += 1
@@ -678,7 +678,8 @@ class CtpTdApi(TdApi):
         req = {
             "UserID": self.userid,
             "Password": self.password,
-            "BrokerID": self.brokerid
+            "BrokerID": self.brokerid,
+            "UserProductInfo": self.product_info
         }
         
         self.reqid += 1


### PR DESCRIPTION
## 改进内容

1. CTP无法登陆需要“产品名称、授权编码”验证的期货公司账号，原因是函数authenticate() 和 login() 的"UserProductInfo"参数配置有bug

## 相关的Issue号（如有）

Close #1554