### PR TITLE
修复错误多列索引顺序导致大数据查询效率低下问题

### DIFF
--- a/vnpy/trader/database/database_mongo.py
+++ b/vnpy/trader/database/database_mongo.py
@@ -55,7 +55,7 @@ class DbBarData(Document):
     meta = {
         "indexes": [
             {
-                "fields": ("datetime", "interval", "symbol", "exchange"),
+                "fields": ("symbol", "exchange", "interval", "datetime"),
                 "unique": True,
             }
         ]
@@ -150,7 +150,7 @@ class DbTickData(Document):
     meta = {
         "indexes": [
             {
-                "fields": ("datetime", "symbol", "exchange"),
+                "fields": ("symbol", "exchange", "datetime"),
                 "unique": True,
             }
         ],

--- a/vnpy/trader/database/database_sql.py
+++ b/vnpy/trader/database/database_sql.py
@@ -82,7 +82,7 @@ def init_models(db: Database, driver: Driver):
 
         class Meta:
             database = db
-            indexes = ((("datetime", "interval", "symbol", "exchange"), True),)
+            indexes = ((("symbol", "exchange", "interval", "datetime"), True),)
 
         @staticmethod
         def from_bar(bar: BarData):
@@ -194,7 +194,7 @@ def init_models(db: Database, driver: Driver):
 
         class Meta:
             database = db
-            indexes = ((("datetime", "symbol", "exchange"), True),)
+            indexes = ((("symbol", "exchange", "datetime"), True),)
 
         @staticmethod
         def from_tick(tick: TickData):


### PR DESCRIPTION
建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 修复多列索引建立顺序错误问题
2. 提高在大数据量情况下的搜索速度
3. 实测，从五千万条数据中，读取某一品种三年的数据，从没修改前的 2分30秒，减少到 12 秒
```shell
(vnpy) ➜  vnpy git:(master) ✗ python backtest.py
2019-05-08 11:22:57.871550      开始加载历史数据
2019-05-08 11:23:09.539976      历史数据加载完成，数据量：175200
```

## 相关的Issue号（如有）

Close #1662