### PR TITLE
[Mod] 改进Linux的构建脚本

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
   include:
     - name: "code quality analysis: flake8"
       before_install:
-        - pip install flake8
+        - python -m pip install flake8
       install:
         - ""  # prevent running "pip install -r requirements.txt"
       script:
@@ -48,7 +48,7 @@ matrix:
         # update pip & setuptools
         - python -m pip install --upgrade pip wheel setuptools
         # Linux install script
-        - pip install https://pip.vnpy.com/colletion/ibapi-9.75.1-001-py3-none-any.whl
+        - python -m pip install https://pip.vnpy.com/colletion/ibapi-9.75.1-001-py3-none-any.whl
         - bash ./install.sh
 
     - name: "sdist install under Ubuntu: gcc-7"
@@ -73,11 +73,11 @@ matrix:
         -   make
         -   sudo make install
         - popd
-        - pip install numpy
-        - pip install --pre --extra-index-url https://rquser:ricequant99@py.ricequant.com/simple/ rqdatac
-        - pip install https://pip.vnpy.com/colletion/ibapi-9.75.1-001-py3-none-any.whl
+        - python -m pip install numpy
+        - python -m pip install --pre --extra-index-url https://rquser:ricequant99@py.ricequant.com/simple/ rqdatac
+        - python -m pip install https://pip.vnpy.com/colletion/ibapi-9.75.1-001-py3-none-any.whl
         - python setup.py sdist
-        - pip install dist/`ls dist`
+        - python -m pip install dist/`ls dist`
 
     - name: "pip install under osx"
       os: osx
@@ -85,7 +85,7 @@ matrix:
       services: []
       before_install: []
       install:
-        - pip3 install https://pip.vnpy.com/colletion/ibapi-9.75.1-001-py3-none-any.whl
+        - python -m pip install https://pip.vnpy.com/colletion/ibapi-9.75.1-001-py3-none-any.whl
         - bash ./install_osx.sh
       before_script: []
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ matrix:
       services: []
       before_install: []
       install:
-        - python -m pip install https://pip.vnpy.com/colletion/ibapi-9.75.1-001-py3-none-any.whl
+        - python3 -m pip install https://pip.vnpy.com/colletion/ibapi-9.75.1-001-py3-none-any.whl
         - bash ./install_osx.sh
       before_script: []
       script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,10 +53,10 @@ for:
         - configuration: sdist
     build_script:
       - python setup.py sdist
-      - pip install --pre --extra-index-url https://rquser:ricequant99@py.ricequant.com/simple/ rqdatac
-      - pip install https://pip.vnpy.com/colletion/TA_Lib-0.4.17-cp37-cp37m-win_amd64.whl
-      - pip install https://pip.vnpy.com/colletion/ibapi-9.75.1-001-py3-none-any.whl
-      - ps: $name=(ls dist).name; pip install "dist/$name"
+      - python -m pip install --pre --extra-index-url https://rquser:ricequant99@py.ricequant.com/simple/ rqdatac
+      - python -m pip install https://pip.vnpy.com/colletion/TA_Lib-0.4.17-cp37-cp37m-win_amd64.whl
+      - python -m pip install https://pip.vnpy.com/colletion/ibapi-9.75.1-001-py3-none-any.whl
+      - ps: $name=(ls dist).name; python -m pip install "dist/$name"
 
 test_script:
   - cd tests

--- a/install.bat
+++ b/install.bat
@@ -1,10 +1,13 @@
+:: Upgrade pip & setuptools
+python -m pip install --upgrade pip setuptools
+
 ::Install talib and ibapi
-pip install https://pip.vnpy.com/colletion/rqdatac-2.1.0.tar.gz
-pip install https://pip.vnpy.com/colletion/TA_Lib-0.4.17-cp37-cp37m-win_amd64.whl
-pip install https://pip.vnpy.com/colletion/ibapi-9.75.1-001-py3-none-any.whl
+python -m pip install https://pip.vnpy.com/colletion/rqdatac-2.1.0.tar.gz
+python -m pip install https://pip.vnpy.com/colletion/TA_Lib-0.4.17-cp37-cp37m-win_amd64.whl
+python -m pip install https://pip.vnpy.com/colletion/ibapi-9.75.1-001-py3-none-any.whl
 
 ::Install Python Modules
-pip install -r requirements.txt
+python -m pip install -r requirements.txt
 
 :: Install vn.py
-pip install .
+python -m pip install .

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 python=$1
-prefix=$3
+prefix=$2
 
 [[ -z $python ]] && python=python
 [[ -z $prefix ]] && prefix=/usr

--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 python=$1
-pip=$2
 prefix=$3
 
 [[ -z $python ]] && python=python
-[[ -z $pip ]] && pip=pip
 [[ -z $prefix ]] && prefix=/usr
+
+$python -m pip install --upgrade pip setuptools wheel
 
 # Get and build ta-lib
 pushd /tmp
@@ -19,18 +19,18 @@ sudo make install
 popd
 
 # old versions of ta-lib imports numpy in setup.py
-$pip install numpy
+$python -m pip install numpy
 
 # Install extra packages
-$pip install --pre --extra-index-url https://rquser:ricequant99@py.ricequant.com/simple/ rqdatac
-$pip install ta-lib
-$pip install https://vnpy-pip.oss-cn-shanghai.aliyuncs.com/colletion/ibapi-9.75.1-py3-none-any.whl
+$python -m pip install --pre --extra-index-url https://rquser:ricequant99@py.ricequant.com/simple/ rqdatac
+$python -m pip install ta-lib
+$python -m pip install https://vnpy-pip.oss-cn-shanghai.aliyuncs.com/colletion/ibapi-9.75.1-py3-none-any.whl
 
 # Install Python Modules
-$pip install -r requirements.txt
+$python -m pip install -r requirements.txt
 
 # Install local Chinese language environment
 sudo locale-gen zh_CN.GB18030
 
 # Install vn.py
-$pip install .
+$python -m pip install .

--- a/install_osx.sh
+++ b/install_osx.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-bash ./install.sh python3 pip3 /usr/local
+bash ./install.sh python3 /usr/local

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,15 @@ else:
 
 pkgs = find_packages()
 
+
+def is_psycopg2_exists():
+    try:
+        import psycopg2
+        return True
+    except ImportError:
+        return False
+
+
 install_requires = [
     "PyQt5<5.12",
     "qdarkstyle",
@@ -114,7 +123,6 @@ install_requires = [
     "websocket-client",
     "peewee",
     "pymysql",
-    "psycopg2",
     "mongoengine",
     "numpy",
     "pandas",
@@ -127,6 +135,9 @@ install_requires = [
     "ibapi",
     "deap"
 ]
+if not is_psycopg2_exists():
+    install_requires.append("psycopg2-binary")
+
 if sys.version_info.minor < 7:
     install_requires.append("dataclasses")
 

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ pkgs = find_packages()
 
 def is_psycopg2_exists():
     try:
-        import psycopg2
+        import psycopg2  # noqa
         return True
     except ImportError:
         return False


### PR DESCRIPTION
主要修改：
[Add] install.sh增加升级pip的脚本，以确保能正确安装各个pip包（可能会导致Ubuntu下/usr/bin/pip3失效）
[Mod] 使用python -m pip 来运行pip，以确保在/usr/bin/pip3失效时脚本仍然正常运行
[Mod] 在setup.py中使用psycopg2-binary替代psycopg2，并且只有在psycopg2包不不存在时安装。
