### PR TITLE
fix bug: RPC客户端不使用定时器, 造成调用EventEngine2.stop()报错

### DIFF
--- a/vnpy/event/eventEngine.py
+++ b/vnpy/event/eventEngine.py
@@ -273,8 +273,9 @@ class EventEngine2(object):
         self.__active = False
         
         # 停止计时器
-        self.__timerActive = False
-        self.__timer.join()
+        if self.__timerActive:
+            self.__timerActive = False
+            self.__timer.join()
         
         # 等待事件处理线程退出
         self.__thread.join()


### PR DESCRIPTION
客户端不使用定时器
初始化, MainEngineProxy(EventEngine2()) -> EventEngine2.start(timer=False).
退出时, MainEngineProxy.stop() -> EventEngine2.stop(), 此时Timer线程并没有启动, 就报错了.

所以需要加判断条件: 在Timer启用的情况下, 再停止Timer线程