### PR TITLE
Bug Fix: 如果BarGenerator在初始化的时候, 没有设置X分钟线, 就会出现除0错误

### DIFF
--- a/vnpy/trader/vtUtility.py
+++ b/vnpy/trader/vtUtility.py
@@ -103,7 +103,7 @@ class BarGenerator(object):
         self.xminBar.volume += int(bar.volume)                
             
         # X分钟已经走完
-        if not (bar.datetime.minute + 1) % self.xmin:   # 可以用X整除
+        if self.xmin > 0 and not (bar.datetime.minute + 1) % self.xmin:   # 可以用X整除
             # 生成上一X分钟K线的时间戳
             self.xminBar.datetime = self.xminBar.datetime.replace(second=0, microsecond=0)  # 将秒和微秒设为0
             self.xminBar.date = self.xminBar.datetime.strftime('%Y%m%d')


### PR DESCRIPTION
Solution: 先判断X > 0