### PR TITLE
调整load_strategy_setting加载顺序

### DIFF
--- a/vnpy/app/cta_strategy/engine.py
+++ b/vnpy/app/cta_strategy/engine.py
@@ -107,8 +107,8 @@ class CtaEngine(BaseEngine):
         """
         self.init_rqdata()
         self.load_strategy_class()
-        self.load_strategy_setting()
         self.load_strategy_data()
+        self.load_strategy_setting()
         self.register_event()
         self.write_log("CTA策略引擎初始化成功")
 


### PR DESCRIPTION
load_strategy_setting函数放在load_strategy_class函数后面，有一定几率load_strategy_setting函数先运行导致self.classes类为空，出现class_name key error