### PR TITLE
调整register_event函数加载顺序，避免策略未初始化却先触发事件推送导致策略出错

### DIFF
--- a/vnpy/app/cta_strategy/engine.py
+++ b/vnpy/app/cta_strategy/engine.py
@@ -630,10 +630,9 @@ class CtaEngine(BaseEngine):
 
             # Put event to update init completed status.
             strategy.inited = True
-            self.register_event()
             self.put_strategy_event(strategy)
             self.write_log(f"{strategy_name}初始化完成")
-        
+        self.register_event()      
         self.init_thread = None
 
     def start_strategy(self, strategy_name: str):

--- a/vnpy/app/cta_strategy/engine.py
+++ b/vnpy/app/cta_strategy/engine.py
@@ -109,7 +109,6 @@ class CtaEngine(BaseEngine):
         self.load_strategy_class()
         self.load_strategy_setting()
         self.load_strategy_data()
-        self.register_event()
         self.write_log("CTA策略引擎初始化成功")
 
     def close(self):
@@ -631,6 +630,7 @@ class CtaEngine(BaseEngine):
 
             # Put event to update init completed status.
             strategy.inited = True
+            self.register_event()
             self.put_strategy_event(strategy)
             self.write_log(f"{strategy_name}初始化完成")
         


### PR DESCRIPTION
调整register_event函数加载顺序，避免策略未初始化却先在init_engine里面触发事件推送导致策略出错