### PR TITLE
增加单均线策略。

### DIFF
--- a/vnpy/trader/utility.py
+++ b/vnpy/trader/utility.py
@@ -335,7 +335,11 @@ class ArrayManager(object):
         """
         Simple moving average.
         """
-        result = talib.SMA(self.close, n)
+        if n == 1:
+            result = self.close
+        else:
+            result = talib.SMA(self.close, n)
+
         if array:
             return result
         return result[-1]


### PR DESCRIPTION
单均线策略不是我一个人的个性需求。

目前双均线策略将均线长度设置为1，会造成回测死掉。

这既是一个bug，又是一个用户需求。如果你认为是我一个人的个性需求，我只能说你不懂用户需求。