### PR TITLE
[Mod] 修复converter的bug

### DIFF
--- a/vnpy/app/cta_strategy/converter.py
+++ b/vnpy/app/cta_strategy/converter.py
@@ -240,7 +240,7 @@ class PositionHolding:
             td_available = self.long_td - self.long_td_frozen
 
         if req.volume > pos_available:
-            return [req]
+            return []
         elif req.volume <= td_available:
             req_td = copy(req)
             req_td.offset = Offset.CLOSETODAY
@@ -278,7 +278,7 @@ class PositionHolding:
         # If no td_volume, we close opposite yd position first
         # then open new position
         else:
-            open_volume = max(0, yd_available - req.volume)
+            open_volume = max(0, req.volume - yd_available)
             req_list = []
 
             if yd_available:


### PR DESCRIPTION
建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 上期所模式中，平仓量超过总可用，拒绝，返回空列表，而不是【Req】
2. 锁仓模式，若无今仓，先平昨仓再开仓。该开仓量大小应为max(0, req.volume - yd_available)，而不是max(0, yd_available - req.volume)
