### PR TITLE
解决 vn trader UI中 已完成order 有时会在 ActiveOrderMonitor中显示的bug

### DIFF
--- a/vnpy/trader/ui/widget.py
+++ b/vnpy/trader/ui/widget.py
@@ -882,7 +882,7 @@ class ActiveOrderMonitor(OrderMonitor):
         if order.is_active():
             self.showRow(row)
         else:
-            self.hideRow(row)
+            self.removeRow(row)
 
 
 class ContractManager(QtWidgets.QWidget):


### PR DESCRIPTION
解决 vn trader UI中 已完成order 有时会在 ActiveOrderMonitor中显示的bug