### PR TITLE
解决类变量重复赋值的Bug

### DIFF
--- a/vnpy/app/cta_strategy/template.py
+++ b/vnpy/app/cta_strategy/template.py
@@ -1,5 +1,6 @@
 """"""
 from abc import ABC
+from copy import copy
 from typing import Any, Callable
 
 from vnpy.trader.constant import Interval, Direction, Offset
@@ -32,12 +33,12 @@ class CtaTemplate(ABC):
         self.trading = False
         self.pos = 0
 
-        if "inited" not in self.variables:
-            self.variables.insert(0, "inited")
-        if "trading" not in self.variables:
-            self.variables.insert(1, "trading")
-        if "pos" not in self.variables:
-            self.variables.insert(2, "pos")
+        # Copy a new variables list here to avoid duplicate insert when multiple 
+        # strategy instances are created with the same strategy class.
+        self.variables = copy(self.variables)
+        self.variables.insert(0, "inited")
+        self.variables.insert(1, "trading")
+        self.variables.insert(2, "pos")
 
         self.update_setting(setting)
 

--- a/vnpy/app/cta_strategy/template.py
+++ b/vnpy/app/cta_strategy/template.py
@@ -32,9 +32,12 @@ class CtaTemplate(ABC):
         self.trading = False
         self.pos = 0
 
-        self.variables.insert(0, "inited")
-        self.variables.insert(1, "trading")
-        self.variables.insert(2, "pos")
+        if "inited" not in self.variables:
+            self.variables.insert(0, "inited")
+        if "trading" not in self.variables:
+            self.variables.insert(1, "trading")
+        if "pos" not in self.variables:
+            self.variables.insert(2, "pos")
 
         self.update_setting(setting)
 


### PR DESCRIPTION
## 改进内容

1. 通过策略类多次构建实例，因variables是类变量，在CtaTemplate的__init__中会对variables重复赋值。