### PR TITLE
turtle_signal_strategy.py:add more variable into variables list.

### DIFF
--- a/vnpy/app/cta_strategy/strategies/turtle_signal_strategy.py
+++ b/vnpy/app/cta_strategy/strategies/turtle_signal_strategy.py
@@ -32,7 +32,7 @@ class TurtleSignalStrategy(CtaTemplate):
     short_stop = 0
 
     parameters = ["entry_window", "exit_window", "atr_window", "fixed_size"]
-    variables = ["entry_up", "entry_down", "exit_up", "exit_down", "atr_value"]
+    variables = ["entry_up", "entry_down", "exit_up", "exit_down", "atr_value", "long_entry", "short_entry", "long_stop", "short_stop"]
 
     def __init__(self, cta_engine, strategy_name, vt_symbol, setting):
         """"""

--- a/vnpy/app/cta_strategy/strategies/turtle_signal_strategy.py
+++ b/vnpy/app/cta_strategy/strategies/turtle_signal_strategy.py
@@ -80,10 +80,9 @@ class TurtleSignalStrategy(CtaTemplate):
 
         self.entry_up, self.entry_down = self.am.donchian(self.entry_window)
         self.exit_up, self.exit_down = self.am.donchian(self.exit_window)
+        self.atr_value = self.am.atr(self.atr_window)
 
         if not self.pos:
-            self.atr_value = self.am.atr(self.atr_window)
-
             self.long_entry = 0
             self.short_entry = 0
             self.long_stop = 0


### PR DESCRIPTION
Signed-off-by: Shaoguo Chai <shgchai@163.com>

## 改进内容

1、在海龟策略中增加"long_entry", "short_entry", "long_stop", "short_stop"这四个变量到variables列表中，防止在已经持有部分仓位的情况下，策略退出后再次进入的时候，这四个变量值为0，导致后面提交的委托单的价格是0，被交易所拒单。

２、调整on_bar函数中ATR值的位置，否则只在空仓的时候计算了一次，后续如果持有部分仓位的时候，ATR值一直没有实时更新，后续如果下单，对应的下单的价格，还是依靠的第一次空仓时的ATR值。

## 相关的Issue号
#2082

Close #