### PR TITLE
fix #1877, save order and trade object to database

### DIFF
--- a/vnpy/trader/database/database.py
+++ b/vnpy/trader/database/database.py
@@ -5,7 +5,7 @@ from typing import Optional, Sequence, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from vnpy.trader.constant import Interval, Exchange  # noqa
-    from vnpy.trader.object import BarData, TickData  # noqa
+    from vnpy.trader.object import BarData, TickData, OrderData, TradeData  # noqa
 
 
 class Driver(Enum):
@@ -49,6 +49,20 @@ class BaseDatabaseManager(ABC):
     def save_tick_data(
         self,
         datas: Sequence["TickData"],
+    ):
+        pass
+
+    @abstractmethod
+    def save_order_data(
+        self,
+        datas: Sequence["OrderData"],
+    ):
+        pass
+
+    @abstractmethod
+    def save_trade_data(
+        self,
+        datas: Sequence["TradeData"],
     ):
         pass
 

--- a/vnpy/trader/database/database_mongo.py
+++ b/vnpy/trader/database/database_mongo.py
@@ -269,7 +269,7 @@ class DbOrderData(Document):
 
     symbol: str = StringField()
     exchange: str = StringField()
-    orderid: str = StringField()
+    orderid: str = StringField(unique=True)
 
     type: str = StringField()
     direction: str = StringField()
@@ -281,14 +281,7 @@ class DbOrderData(Document):
     time: str = StringField()
     update_date: datetime = DateTimeField(default=datetime.now)
 
-    meta = {
-        "indexes": [
-            {
-                "fields": "orderid",
-                "unique": True,
-            }
-        ]
-    }
+    meta = {}
 
     @staticmethod
     def from_order(order: OrderData):
@@ -341,7 +334,7 @@ class DbTradeData(Document):
     symbol: str = StringField()
     exchange: str = StringField()
     orderid: str = StringField()
-    tradeid: str = StringField()
+    tradeid: str = StringField(unique=True)
 
     direction: str = StringField()
     offset: str = StringField()
@@ -350,14 +343,7 @@ class DbTradeData(Document):
     time: str = StringField()
     update_date: datetime = DateTimeField(default=datetime.now)
 
-    meta = {
-        "indexes": [
-            {
-                "fields": "tradeid",
-                "unique": True,
-            }
-        ]
-    }
+    meta = {}
 
     @staticmethod
     def from_trade(trade: TradeData):


### PR DESCRIPTION
建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. save order and trade object to database
2. 
3.

## 相关的Issue号（如有）

Close #1877 