### PR TITLE
[Fix] 修复 init_cli_trading 的 type hint

### DIFF
--- a/vnpy/app/script_trader/cli.py
+++ b/vnpy/app/script_trader/cli.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Sequence, Type
 
 from vnpy.event import EventEngine, Event
 from vnpy.trader.engine import MainEngine
@@ -14,7 +14,7 @@ def process_log_event(event: Event):
     print(f"{log.time}\t{log.msg}")
 
 
-def init_cli_trading(gateways: Sequence[BaseGateway]):
+def init_cli_trading(gateways: Sequence[Type[BaseGateway]]):
     """"""
     event_engine = EventEngine()
     event_engine.register(EVENT_LOG, process_log_event)


### PR DESCRIPTION
建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

`init_cli_trading` 中，参数 `gateways` 的类型应该是 `BaseGateway` 类

`Sequence[BaseGateway]` 表示一个列表的 `BaseGateway` 对象，在 pycharm 中会报 warning

`Sequence[Type[BaseGateway]]` 则表示一个列表的 `BaseGateway` 类，与真实语义相符
