### PR TITLE
[Fix] query_history

### DIFF
--- a/vnpy/gateway/bybit/bybit_gateway.py
+++ b/vnpy/gateway/bybit/bybit_gateway.py
@@ -547,6 +547,9 @@ class BybitRestApi(RestClient):
                     )
                     buf.append(bar)
 
+                if not buf:
+                    continue
+
                 history.extend(buf)
 
                 begin = buf[0].datetime


### PR DESCRIPTION
建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. query_history 函数有时返回空列表，导致策略初始化失败
