### PR TITLE
修复spreadtrading 回测手续费可能会负值的问题

### DIFF
--- a/vnpy/app/spread_trading/backtesting.py
+++ b/vnpy/app/spread_trading/backtesting.py
@@ -672,7 +672,7 @@ class DailyResult:
 
             self.end_pos += pos_change
 
-            turnover = trade.volume * size * trade.price
+            turnover = trade.volume * size * abs(trade.price)
             self.trading_pnl += pos_change * \
                 (self.close_price - trade.price) * size
             self.slippage += trade.volume * size * slippage


### PR DESCRIPTION
价差的收盘价，成交价可能会负值，回测实盘都要注意下