### PR TITLE
增加回测数据二级文件缓存

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ deap
 pyzmq
 wmi
 QScintilla
+mezmorize

--- a/vnpy/app/cta_strategy/backtesting.py
+++ b/vnpy/app/cta_strategy/backtesting.py
@@ -3,6 +3,7 @@ from datetime import date, datetime, timedelta
 from typing import Callable
 from itertools import product
 from functools import lru_cache
+from mezmorize import Cache
 from time import time
 import multiprocessing
 import random
@@ -33,6 +34,7 @@ sns.set_style("whitegrid")
 creator.create("FitnessMax", base.Fitness, weights=(1.0,))
 creator.create("Individual", list, fitness=creator.FitnessMax)
 
+file_cache = Cache(CACHE_TYPE='filesystem', CACHE_DIR='cache')
 
 class OptimizationSetting:
     """
@@ -1206,6 +1208,7 @@ def optimize(
 
 
 @lru_cache(maxsize=1000000)
+@file_cache.memoize()
 def _ga_optimize(parameter_values: tuple):
     """"""
     setting = dict(parameter_values)
@@ -1235,6 +1238,7 @@ def ga_optimize(parameter_values: list):
 
 
 @lru_cache(maxsize=999)
+@file_cache.memoize()
 def load_bar_data(
     symbol: str,
     exchange: Exchange,
@@ -1249,6 +1253,7 @@ def load_bar_data(
 
 
 @lru_cache(maxsize=999)
+@file_cache.memoize()
 def load_tick_data(
     symbol: str,
     exchange: Exchange,

--- a/vnpy/app/spread_trading/base.py
+++ b/vnpy/app/spread_trading/base.py
@@ -2,6 +2,7 @@ from typing import Dict, List
 from datetime import datetime
 from enum import Enum
 from functools import lru_cache
+from mezmorize import Cache
 
 from vnpy.trader.object import (
     TickData, PositionData, TradeData, ContractData, BarData
@@ -10,6 +11,7 @@ from vnpy.trader.constant import Direction, Offset, Exchange, Interval
 from vnpy.trader.utility import floor_to, ceil_to, round_to, extract_vt_symbol
 from vnpy.trader.database import database_manager
 
+file_cache = Cache(CACHE_TYPE='filesystem', CACHE_DIR='cache')
 
 EVENT_SPREAD_DATA = "eSpreadData"
 EVENT_SPREAD_POS = "eSpreadPos"
@@ -360,6 +362,7 @@ class BacktestingMode(Enum):
 
 
 @lru_cache(maxsize=999)
+@file_cache.memoize()
 def load_bar_data(
     spread: SpreadData,
     interval: Interval,
@@ -418,6 +421,7 @@ def load_bar_data(
 
 
 @lru_cache(maxsize=999)
+@file_cache.memoize()
 def load_tick_data(
     spread: SpreadData,
     start: datetime,


### PR DESCRIPTION
增加回测数据二级文件缓存

建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 在内存的@lru_cache的基础上增加基于系统文件缓存的二级缓存系统
2.在vnpy重新启动的时候，@lru_cache，会丢失数据，从数据库读取数据依然需要时间，增加二级缓存，可以减少数据库压力，也提升回测数据的读取速度
3.数据读取顺序是先从内存中寻找，无法找到的时候再从文件缓存中寻找，全部失败后才会从数据库中查找数据
4.重启vnpy后，数据读取，将从原来的1分钟，减少到2秒钟，@lru_cache依然生效

## 相关的Issue号（如有）

Close #