### PR TITLE
[Bug]解决多进程参数优化过程中，内存泄露的问题

### DIFF
--- a/vnpy/app/cta_strategy/backtesting.py
+++ b/vnpy/app/cta_strategy/backtesting.py
@@ -538,7 +538,7 @@ class BacktestingEngine:
             return
 
         # Use multiprocessing pool for running backtesting with different setting
-        pool = multiprocessing.Pool(multiprocessing.cpu_count())
+        pool = multiprocessing.Pool(multiprocessing.cpu_count(), maxtasksperchild=1)
 
         results = []
         for setting in settings:


### PR DESCRIPTION
建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 在策略中使用Talib的某些指标时，会发生内存泄漏问题
2. 修改pool的逻辑，增加maxtasksperchild，回收内存

优化前：
<img width="928" alt="dae5f248852147152e5c39da2bbabdf" src="https://user-images.githubusercontent.com/2801450/70040852-27f9a900-15f7-11ea-8ad0-2b7f859ef77b.png">
优化后：
<img width="928" alt="4a8244b1f7d5567b7254fdabed721f5" src="https://user-images.githubusercontent.com/2801450/70040880-334cd480-15f7-11ea-816d-d6ad74ea1f4b.png">

## 相关的Issue号（如有）

Close #