### PR TITLE
修复优化时max_drawdown_end可能为nan导致程序出错,顺便转化statistics可能出现的nan,inf值

### DIFF
--- a/vnpy/app/cta_strategy/backtesting.py
+++ b/vnpy/app/cta_strategy/backtesting.py
@@ -496,6 +496,8 @@ class BacktestingEngine:
             "return_drawdown_ratio": return_drawdown_ratio,
         }
         for key,value in statistics.items():
+            if value == np.inf:
+                value = 0
             statistics[key] = np.nan_to_num(value)
         return statistics
 

--- a/vnpy/app/cta_strategy/backtesting.py
+++ b/vnpy/app/cta_strategy/backtesting.py
@@ -495,7 +495,8 @@ class BacktestingEngine:
             "sharpe_ratio": sharpe_ratio,
             "return_drawdown_ratio": return_drawdown_ratio,
         }
-
+        for key,value in statistics.items():
+            statistics[key] = np.nan_to_num(value)
         return statistics
 
     def show_chart(self, df: DataFrame = None):

--- a/vnpy/app/cta_strategy/backtesting.py
+++ b/vnpy/app/cta_strategy/backtesting.py
@@ -396,13 +396,13 @@ class BacktestingEngine:
             max_drawdown = df["drawdown"].min()
             max_ddpercent = df["ddpercent"].min()
             max_drawdown_end = df["drawdown"].idxmin()
-            if max_drawdown_end:
-                max_drawdown_start = df["balance"][:max_drawdown_end].idxmax()
-                max_drawdown_duration = (max_drawdown_end - max_drawdown_start).days
-            else:
+            if max_drawdown_end == np.nan:
                 max_drawdown_start = 0
                 max_drawdown_end = 0
                 max_drawdown_duration = 0
+            else:
+                max_drawdown_start = df["balance"][:max_drawdown_end].idxmax()
+                max_drawdown_duration = (max_drawdown_end - max_drawdown_start).days
 
             total_net_pnl = df["net_pnl"].sum()
             daily_net_pnl = total_net_pnl / total_days

--- a/vnpy/app/cta_strategy/backtesting.py
+++ b/vnpy/app/cta_strategy/backtesting.py
@@ -396,7 +396,7 @@ class BacktestingEngine:
             max_drawdown = df["drawdown"].min()
             max_ddpercent = df["ddpercent"].min()
             max_drawdown_end = df["drawdown"].idxmin()
-            if isinstance(max_drawdown_end,datetime):
+            if max_drawdown_end:
                 max_drawdown_start = df["balance"][:max_drawdown_end].idxmax()
                 max_drawdown_duration = (max_drawdown_end - max_drawdown_start).days
             else:

--- a/vnpy/app/cta_strategy/backtesting.py
+++ b/vnpy/app/cta_strategy/backtesting.py
@@ -396,8 +396,13 @@ class BacktestingEngine:
             max_drawdown = df["drawdown"].min()
             max_ddpercent = df["ddpercent"].min()
             max_drawdown_end = df["drawdown"].idxmin()
-            max_drawdown_start = df["balance"][:max_drawdown_end].argmax()
-            max_drawdown_duration = (max_drawdown_end - max_drawdown_start).days
+            if isinstance(max_drawdown_end,datetime):
+                max_drawdown_start = df["balance"][:max_drawdown_end].idxmax()
+                max_drawdown_duration = (max_drawdown_end - max_drawdown_start).days
+            else:
+                max_drawdown_start = 0
+                max_drawdown_end = 0
+                max_drawdown_duration = 0
 
             total_net_pnl = df["net_pnl"].sum()
             daily_net_pnl = total_net_pnl / total_days

--- a/vnpy/app/cta_strategy/backtesting.py
+++ b/vnpy/app/cta_strategy/backtesting.py
@@ -496,7 +496,7 @@ class BacktestingEngine:
             "return_drawdown_ratio": return_drawdown_ratio,
         }
         for key,value in statistics.items():
-            if value == np.inf:
+            if value in (np.inf,-np.inf):
                 value = 0
             statistics[key] = np.nan_to_num(value)
         return statistics

--- a/vnpy/app/cta_strategy/backtesting.py
+++ b/vnpy/app/cta_strategy/backtesting.py
@@ -396,13 +396,13 @@ class BacktestingEngine:
             max_drawdown = df["drawdown"].min()
             max_ddpercent = df["ddpercent"].min()
             max_drawdown_end = df["drawdown"].idxmin()
-            if max_drawdown_end == np.nan:
+            if isinstance(max_drawdown_end,date):
+                max_drawdown_start = df["balance"][:max_drawdown_end].idxmax()
+                max_drawdown_duration = (max_drawdown_end - max_drawdown_start).days
+            else:
                 max_drawdown_start = 0
                 max_drawdown_end = 0
                 max_drawdown_duration = 0
-            else:
-                max_drawdown_start = df["balance"][:max_drawdown_end].idxmax()
-                max_drawdown_duration = (max_drawdown_end - max_drawdown_start).days
 
             total_net_pnl = df["net_pnl"].sum()
             daily_net_pnl = total_net_pnl / total_days

--- a/vnpy/app/cta_strategy/backtesting.py
+++ b/vnpy/app/cta_strategy/backtesting.py
@@ -400,8 +400,8 @@ class BacktestingEngine:
                 max_drawdown_start = df["balance"][:max_drawdown_end].idxmax()
                 max_drawdown_duration = (max_drawdown_end - max_drawdown_start).days
             else:
-                max_drawdown_start = 0
-                max_drawdown_end = 0
+                max_drawdown_start = ""
+                max_drawdown_end = ""
                 max_drawdown_duration = 0
 
             total_net_pnl = df["net_pnl"].sum()


### PR DESCRIPTION
修复优化时max_drawdown_end可能为nan导致程序出错,顺便转化statistics可能出现的nan,inf值