### PR TITLE
修正CTP Test撤单时报的类型转换异常: RuntimeError: Unable to cast Python instance to C++ type

### DIFF
--- a/vnpy/gateway/ctptest/ctptest_gateway.py
+++ b/vnpy/gateway/ctptest/ctptest_gateway.py
@@ -772,7 +772,7 @@ class CtpTdApi(TdApi):
 
         ctp_req = {
             "InstrumentID": req.symbol,
-            "ExchangeID": req.exchange,
+            "ExchangeID": req.exchange.value,
             "OrderRef": order_ref,
             "FrontID": int(frontid),
             "SessionID": int(sessionid),


### PR DESCRIPTION
修正CTP Test撤单时报的类型转换异常: RuntimeError: Unable to cast Python instance to C++ type

cancel_order方法中的ExchangeID字段传入req.exchange.value应该就不出错了。