### PR TITLE
[Fix] typo

### DIFF
--- a/vnpy/gateway/okex/okex_gateway.py
+++ b/vnpy/gateway/okex/okex_gateway.py
@@ -723,9 +723,9 @@ class OkexWebsocketApi(WebsocketClient):
             return
 
         tick.last_price = float(d["last"])
-        tick.open = float(d["open_24h"])
-        tick.high = float(d["high_24h"])
-        tick.low = float(d["low_24h"])
+        tick.open_price = float(d["open_24h"])
+        tick.high_price = float(d["high_24h"])
+        tick.low_price = float(d["low_24h"])
         tick.volume = float(d["base_volume_24h"])
         tick.datetime = datetime.strptime(
             d["timestamp"], "%Y-%m-%dT%H:%M:%S.%fZ")


### PR DESCRIPTION
修复参数拼写错误，该错误会导致OKEX接口下的「行情」中的参数（开盘价、最高价、最低价）缺失。