### PR TITLE
do not import backtesting

### DIFF
--- a/vnpy/app/cta_backtester/engine.py
+++ b/vnpy/app/cta_backtester/engine.py
@@ -13,11 +13,8 @@ from vnpy.trader.utility import extract_vt_symbol
 from vnpy.trader.object import HistoryRequest
 from vnpy.trader.rqdata import rqdata_client
 from vnpy.trader.database import database_manager
-from vnpy.app.cta_strategy import (
-    CtaTemplate,
-    BacktestingEngine,
-    OptimizationSetting
-)
+from vnpy.app.cta_strategy import CtaTemplate
+from vnpy.app.cta_strategy.backtesting import BacktestingEngine, OptimizationSetting
 
 APP_NAME = "CtaBacktester"
 

--- a/vnpy/app/cta_strategy/__init__.py
+++ b/vnpy/app/cta_strategy/__init__.py
@@ -7,7 +7,6 @@ from vnpy.trader.utility import BarGenerator, ArrayManager
 
 from .base import APP_NAME, StopOrder
 from .engine import CtaEngine
-from .backtesting import BacktestingEngine, OptimizationSetting
 from .template import CtaTemplate, CtaSignal, TargetPosTemplate
 
 


### PR DESCRIPTION
cta_strategy 引入了 backtesting，其又 import 了一些较大的包，有些与图形相关，如果只是跑 CTA 策略我们并不需要图形相关的功能。根据最小依赖原则，可以去掉。其他引入 backtesting 的地方只有 cta_backtester，不影响已有功能。

因为 backtesting 是在 cta_strategy 的 `__init__.py` 中 import 的，我们如果不改源码无法绕过这个问题，修改之后对定制化开发者比较友好。