### PR TITLE
支持华鑫N视界期货仿真环境

### DIFF
--- a/vnpy/gateway/ctp/ctp_gateway.py
+++ b/vnpy/gateway/ctp/ctp_gateway.py
@@ -102,8 +102,7 @@ EXCHANGE_CTP2VT = {
     "SHFE": Exchange.SHFE,
     "CZCE": Exchange.CZCE,
     "DCE": Exchange.DCE,
-    "INE": Exchange.INE,
-    "SGE": Exchange.SGE
+    "INE": Exchange.INE
 }
 
 PRODUCT_CTP2VT = {
@@ -591,10 +590,11 @@ class CtpTdApi(TdApi):
         Callback of instrument query.
         """
         product = PRODUCT_CTP2VT.get(data["ProductClass"], None)
-        if product:
+        exchange = EXCHANGE_CTP2VT.get(data["ExchangeID"], None)
+        if product and exchange:
             contract = ContractData(
                 symbol=data["InstrumentID"],
-                exchange=EXCHANGE_CTP2VT[data["ExchangeID"]],
+                exchange=exchange,
                 name=data["InstrumentName"],
                 product=product,
                 size=data["VolumeMultiple"],

--- a/vnpy/gateway/ctp/ctp_gateway.py
+++ b/vnpy/gateway/ctp/ctp_gateway.py
@@ -102,7 +102,8 @@ EXCHANGE_CTP2VT = {
     "SHFE": Exchange.SHFE,
     "CZCE": Exchange.CZCE,
     "DCE": Exchange.DCE,
-    "INE": Exchange.INE
+    "INE": Exchange.INE,
+    "SGE": Exchange.SGE
 }
 
 PRODUCT_CTP2VT = {
@@ -297,7 +298,8 @@ class CtpMdApi(MdApi):
         if not exchange:
             return
 
-        timestamp = f"{data['ActionDay']} {data['UpdateTime']}.{int(data['UpdateMillisec']/100)}"
+        md_date = data['ActionDay'] if data['ActionDay'] else data['TradingDay']
+        timestamp = f"{md_date} {data['UpdateTime']}.{int(data['UpdateMillisec']/100)}"
 
         tick = TickData(
             symbol=symbol,

--- a/vnpy/gateway/ctptest/ctptest_gateway.py
+++ b/vnpy/gateway/ctptest/ctptest_gateway.py
@@ -99,7 +99,8 @@ EXCHANGE_CTP2VT = {
     "SHFE": Exchange.SHFE,
     "CZCE": Exchange.CZCE,
     "DCE": Exchange.DCE,
-    "INE": Exchange.INE
+    "INE": Exchange.INE,
+    "SGE": Exchange.SGE
 }
 
 PRODUCT_CTP2VT = {
@@ -291,7 +292,8 @@ class CtpMdApi(MdApi):
         if not exchange:
             return
 
-        timestamp = f"{data['ActionDay']} {data['UpdateTime']}.{int(data['UpdateMillisec']/100)}"
+        md_date = data['ActionDay'] if data['ActionDay'] else data['TradingDay']
+        timestamp = f"{md_date} {data['UpdateTime']}.{int(data['UpdateMillisec']/100)}"
 
         tick = TickData(
             symbol=symbol,

--- a/vnpy/gateway/ctptest/ctptest_gateway.py
+++ b/vnpy/gateway/ctptest/ctptest_gateway.py
@@ -99,8 +99,7 @@ EXCHANGE_CTP2VT = {
     "SHFE": Exchange.SHFE,
     "CZCE": Exchange.CZCE,
     "DCE": Exchange.DCE,
-    "INE": Exchange.INE,
-    "SGE": Exchange.SGE
+    "INE": Exchange.INE
 }
 
 PRODUCT_CTP2VT = {
@@ -556,10 +555,11 @@ class CtpTdApi(TdApi):
         Callback of instrument query.
         """
         product = PRODUCT_CTP2VT.get(data["ProductClass"], None)
-        if product:
+        exchange = EXCHANGE_CTP2VT.get(data["ExchangeID"], None)
+        if product and exchange:
             contract = ContractData(
                 symbol=data["InstrumentID"],
-                exchange=EXCHANGE_CTP2VT[data["ExchangeID"]],
+                exchange=exchange,
                 name=data["InstrumentName"],
                 product=product,
                 size=data["VolumeMultiple"],


### PR DESCRIPTION
## 改进内容

1. 华鑫N视界期货仿真环境除模拟了国内现有期货交易所的各个合约之外，还以期货方式模拟了上海黄金交易所的两个现货延期交收合约，导致ctp_gateway以及ctptest_gateway在处理返回合约信息时出错。
2、华鑫N视界期货仿真环境现在行情中ActionDay字段为空，因此生成行情时间戳时暂以TradingDay替代。
本次修改主要为使用华鑫N视界期货仿真环境测试的用户解决使用中的问题。
