### PR TITLE
修复portfolio_strateg回测的一个BUG

### DIFF
--- a/vnpy/app/portfolio_strategy/backtesting.py
+++ b/vnpy/app/portfolio_strategy/backtesting.py
@@ -476,7 +476,6 @@ class BacktestingEngine:
         """"""
         self.datetime = dt
 
-        self.bars.clear()
         for vt_symbol in self.vt_symbols:
             bar = self.history_data.get((dt, vt_symbol), None)
             if bar:


### PR DESCRIPTION
self.bars推送前不能清空，不然数据量不一样的标的组合回测会丢数据