### PR TITLE
修复run_backtesting时，第一条数据没有计数问题

### DIFF
--- a/vnpy/app/cta_strategy/backtesting.py
+++ b/vnpy/app/cta_strategy/backtesting.py
@@ -277,11 +277,13 @@ class BacktestingEngine:
         ix = 0
 
         for ix, data in enumerate(self.history_data):
-            if self.datetime and data.datetime.day != self.datetime.day:
+            if self.datetime：
+                if data.datetime.day != self.datetime.day:
+                    day_count += 1
+                    if day_count >= self.days:
+                        break
+            else:
                 day_count += 1
-                if day_count >= self.days:
-                    break
-
             self.datetime = data.datetime
 
             try:


### PR DESCRIPTION
第一条数据时，由于self.datetime为none，导致不满足条件，day_count没有加1


## 改进内容
self.datetime为none时，也 day_count+=1


## 相关的Issue号（如有）

Close #2539