### PR TITLE
币安 gateway 支持被动委托（timeInForce: GTX）

### DIFF
--- a/vnpy/app/cta_strategy/engine.py
+++ b/vnpy/app/cta_strategy/engine.py
@@ -297,7 +297,8 @@ class CtaEngine(BaseEngine):
         price: float,
         volume: float,
         type: OrderType,
-        lock: bool
+        lock: bool,
+        timeInForce: str = 'GTC'
     ):
         """
         Send a new order to server.
@@ -311,6 +312,7 @@ class CtaEngine(BaseEngine):
             type=type,
             price=price,
             volume=volume,
+            timeInForce=timeInForce,
         )
 
         # Convert with offset converter
@@ -347,7 +349,8 @@ class CtaEngine(BaseEngine):
         offset: Offset,
         price: float,
         volume: float,
-        lock: bool
+        lock: bool,
+        timeInForce: str = 'GTC'
     ):
         """
         Send a limit order to server.
@@ -360,7 +363,8 @@ class CtaEngine(BaseEngine):
             price,
             volume,
             OrderType.LIMIT,
-            lock
+            lock,
+            timeInForce
         )
 
     def send_server_stop_order(
@@ -468,7 +472,8 @@ class CtaEngine(BaseEngine):
         price: float,
         volume: float,
         stop: bool,
-        lock: bool
+        lock: bool,
+        timeInForce: str = 'GTC'
     ):
         """
         """
@@ -487,7 +492,7 @@ class CtaEngine(BaseEngine):
             else:
                 return self.send_local_stop_order(strategy, direction, offset, price, volume, lock)
         else:
-            return self.send_limit_order(strategy, contract, direction, offset, price, volume, lock)
+            return self.send_limit_order(strategy, contract, direction, offset, price, volume, lock, timeInForce)
 
     def cancel_order(self, strategy: CtaTemplate, vt_orderid: str):
         """

--- a/vnpy/app/cta_strategy/template.py
+++ b/vnpy/app/cta_strategy/template.py
@@ -179,14 +179,15 @@ class CtaTemplate(ABC):
         price: float,
         volume: float,
         stop: bool = False,
-        lock: bool = False
+        lock: bool = False,
+        timeInForce: str = 'GTC'
     ):
         """
         Send a new order.
         """
         if self.trading:
             vt_orderids = self.cta_engine.send_order(
-                self, direction, offset, price, volume, stop, lock
+                self, direction, offset, price, volume, stop, lock, timeInForce
             )
             return vt_orderids
         else:

--- a/vnpy/gateway/binances/binances_gateway.py
+++ b/vnpy/gateway/binances/binances_gateway.py
@@ -54,7 +54,8 @@ STATUS_BINANCES2VT: Dict[str, Status] = {
     "PARTIALLY_FILLED": Status.PARTTRADED,
     "FILLED": Status.ALLTRADED,
     "CANCELED": Status.CANCELLED,
-    "REJECTED": Status.REJECTED
+    "REJECTED": Status.REJECTED,
+    "EXPIRED": Status.EXPIRED
 }
 
 ORDERTYPE_VT2BINANCES: Dict[OrderType, str] = {
@@ -359,7 +360,7 @@ class BinancesRestApi(RestClient):
 
         params = {
             "symbol": req.symbol,
-            "timeInForce": OrderRequest.timeInForce,
+            "timeInForce": req.timeInForce,
             "side": DIRECTION_VT2BINANCES[req.direction],
             "type": ORDERTYPE_VT2BINANCES[req.type],
             "price": float(req.price),

--- a/vnpy/gateway/binances/binances_gateway.py
+++ b/vnpy/gateway/binances/binances_gateway.py
@@ -359,7 +359,7 @@ class BinancesRestApi(RestClient):
 
         params = {
             "symbol": req.symbol,
-            "timeInForce": "GTC",
+            "timeInForce": OrderRequest.timeInForce,
             "side": DIRECTION_VT2BINANCES[req.direction],
             "type": ORDERTYPE_VT2BINANCES[req.type],
             "price": float(req.price),

--- a/vnpy/trader/constant.py
+++ b/vnpy/trader/constant.py
@@ -35,6 +35,7 @@ class Status(Enum):
     ALLTRADED = "全部成交"
     CANCELLED = "已撤销"
     REJECTED = "拒单"
+    EXPIRED = "无效订单"
 
 
 class Product(Enum):

--- a/vnpy/trader/object.py
+++ b/vnpy/trader/object.py
@@ -280,6 +280,7 @@ class OrderRequest:
     price: float = 0
     offset: Offset = Offset.NONE
     reference: str = ""
+    timeInForce: str = "GTC"
 
     def __post_init__(self):
         """"""
@@ -298,7 +299,7 @@ class OrderRequest:
             offset=self.offset,
             price=self.price,
             volume=self.volume,
-            gateway_name=gateway_name,
+            gateway_name=gateway_name
         )
         return order
 


### PR DESCRIPTION
币安 gateway 增加「被动委托」类型订单。Maker 和 taker 的手续费相差较大，在部分日内高频策略中通常需要确保策略没有主动 hit 单（吃单）。已测试通过。

## 改进内容

1. 在 Binances Gateway，main_engine, cta_engine, cta_template send_order 相关函数中 增加 timeInForce 参数
2. 在 object OrderRequest 中增加 timeInForce 属性
3. 在 constant 订单状态中（Status），增加 EXPIRED 属性。

## 相关的Issue号（如有）

Close #