### PR TITLE
[Mod] update MenuBar Style

### DIFF
--- a/vnpy/trader/ui/editor.py
+++ b/vnpy/trader/ui/editor.py
@@ -54,6 +54,7 @@ class CodeEditor(QtWidgets.QMainWindow):
     def init_menu(self) -> None:
         """"""
         bar = self.menuBar()
+        bar.setNativeMenuBar(False)
 
         file_menu = bar.addMenu("文件")
         self.add_menu_action(file_menu, "新建文件", self.new_file, "Ctrl+N")
@@ -82,11 +83,11 @@ class CodeEditor(QtWidgets.QMainWindow):
         self.add_menu_action(edit_menu, "替换", self.replace, "Ctrl+H")
 
     def add_menu_action(
-        self,
-        menu: QtWidgets.QMenu,
-        action_name: str,
-        func: Callable,
-        shortcut: str = "",
+            self,
+            menu: QtWidgets.QMenu,
+            action_name: str,
+            func: Callable,
+            shortcut: str = "",
     ) -> None:
         """"""
         action = QtWidgets.QAction(action_name, self)
@@ -325,9 +326,9 @@ class FindDialog(QtWidgets.QDialog):
     """"""
 
     def __init__(
-        self,
-        editor: Qsci.QsciScintilla,
-        show_replace: bool = False
+            self,
+            editor: Qsci.QsciScintilla,
+            show_replace: bool = False
     ):
         """"""
         super().__init__()

--- a/vnpy/trader/ui/mainwindow.py
+++ b/vnpy/trader/ui/mainwindow.py
@@ -92,6 +92,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def init_menu(self) -> None:
         """"""
         bar = self.menuBar()
+        bar.setNativeMenuBar(False)
 
         # System menu
         sys_menu = bar.addMenu("系统")


### PR DESCRIPTION
建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1.  修改 setNativeMenuBar 为 False ，目的是不使用操作系统菜单样式，而是统一使用 PyQt 的默认样式（macOS 菜单和 Windows 不同）。可以解决 macOS 下 菜单栏不能点击的问题，Ubuntu 下也存在次问题。