### PR TITLE
fix(BarGenerator): new minute bug

### DIFF
--- a/vnpy/trader/utility.py
+++ b/vnpy/trader/utility.py
@@ -211,7 +211,7 @@ class BarGenerator:
 
         if not self.bar:
             new_minute = True
-        elif self.bar.datetime.minute != tick.datetime.minute:
+        elif(self.bar.datetime.minute != tick.datetime.minute) or (self.bar.datetime.hour != tick.datetime.hour):
             self.bar.datetime = self.bar.datetime.replace(
                 second=0, microsecond=0
             )


### PR DESCRIPTION

建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 对于商品期货 11:30午间休市，13:30下午开盘，只判断minute会导致11:30的tick被吸收到下午的分钟bar里去。修改后的分钟数据，与wind的数据一致。
