### PR TITLE
Update backtesting.py

### DIFF
--- a/vnpy/app/cta_strategy/backtesting.py
+++ b/vnpy/app/cta_strategy/backtesting.py
@@ -390,7 +390,9 @@ class BacktestingEngine:
         else:
             # Calculate balance related time series data
             df["balance"] = df["net_pnl"].cumsum() + self.capital
-            df["return"] = np.log(df["balance"] / df["balance"].shift(1)).fillna(0)
+            x = df["balance"] / df["balance"].shift(1)
+            x[x <= 0] = np.nan
+            df["return"] = np.log(x).fillna(0)
             df["highlevel"] = (
                 df["balance"].rolling(
                     min_periods=1, window=len(df), center=False).max()


### PR DESCRIPTION
爆仓后，就会出现警告，log参数无效，不能算负数的对数。
爆仓的策略才是出现频率较高的，这个问题不应该指着用户改策略，大概率是改不出来好策略的。