### PR TITLE
Update ib_gateway.py: 过滤order返回为Nonetype时ib_gateway挂掉的情况.

### DIFF
--- a/vnpy/gateway/ib/ib_gateway.py
+++ b/vnpy/gateway/ib/ib_gateway.py
@@ -397,12 +397,15 @@ class IbApi(EWrapper):
 
         orderid = str(orderId)
         order = self.orders.get(orderid, None)
-        order.traded = filled
+        if order:
+            order.traded = filled
 
         # To filter PendingCancel status
         order_status = STATUS_IB2VT.get(status, None)
-        if order_status:
+        if order_status and order:
             order.status = order_status
+        else:
+            return
 
         self.gateway.on_order(copy(order))
 


### PR DESCRIPTION
建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 过滤order返回为Nonetype时ib_gateway挂掉的情况.
2. 
3.

## 相关的Issue号（如有）

Close #