### PR TITLE
Backtester ui

### DIFF
--- a/vnpy/chart/widget.py
+++ b/vnpy/chart/widget.py
@@ -182,15 +182,34 @@ class ChartWidget(pg.PlotWidget):
         """
         Update the limit of plots.
         """
+        plot_y_range_map = {}
+        # 以plot中所有item y轴范围的最大值和最小值来设置
+        # plot的y轴上下限
+        # 解决plot中有多个item时，新添加的item y轴范围比
+        # 之前添加的item y轴范围小时，plot图像显示不全的问题
         for item, plot in self._item_plot_map.items():
-            min_value, max_value = item.get_y_range()
-
-            plot.setLimits(
-                xMin=-1,
-                xMax=self._manager.get_count(),
-                yMin=min_value,
-                yMax=max_value
-            )
+            y_range = item.get_y_range()
+            if plot not in plot_y_range_map:
+                plot_y_range_map[plot] = y_range
+                plot.setLimits(
+                    xMin=-1,
+                    xMax=self._manager.get_count(),
+                    yMin=y_range[0],
+                    yMax=y_range[1]
+                )
+            else:
+                min_y, max_y = plot_y_range_map[plot]
+                if y_range[0] < min_y:
+                    min_y = y_range[0]
+                if y_range[1] > max_y:
+                    max_y = y_range[1]
+                plot_y_range_map[plot] = (min_y, max_y)
+                plot.setLimits(
+                    xMin=-1,
+                    xMax=self._manager.get_count(),
+                    yMin=min_y,
+                    yMax=max_y
+                )
 
     def _update_x_range(self) -> None:
         """
@@ -212,10 +231,26 @@ class ChartWidget(pg.PlotWidget):
         min_ix = max(0, int(view_range[0][0]))
         max_ix = min(self._manager.get_count(), int(view_range[0][1]))
 
+        plot_y_range_map = {}
+
         # Update limit for y-axis
+        # 以plot中所有item y轴范围的最大值和最小值来设置
+        # plot的y轴范围
+        # 解决plot中有多个item时，新添加的item y轴范围比
+        # 之前添加的item y轴范围小时，plot图像显示不全的问题
         for item, plot in self._item_plot_map.items():
             y_range = item.get_y_range(min_ix, max_ix)
-            plot.setRange(yRange=y_range)
+            if plot not in plot_y_range_map:
+                plot_y_range_map[plot] = y_range
+                plot.setRange(yRange=y_range)
+            else:
+                min_y, max_y = plot_y_range_map[plot]
+                if y_range[0] < min_y:
+                    min_y = y_range[0]
+                if y_range[1] > max_y:
+                    max_y = y_range[1]
+                plot_y_range_map[plot] = (min_y, max_y)
+                plot.setRange(yRange=(min_y, max_y))
 
     def paintEvent(self, event: QtGui.QPaintEvent) -> None:
         """


### PR DESCRIPTION
## 改进内容

1. `vnpy.chart.widget.ChartWidget`中，若一个plot中添加了多个item，plot的y轴范围会按照最后添加的item的y轴范围来设置。如果最后添加的item的y轴最大、最小值不能包含其它item的y轴范围时，会导致其它item的图像无法完整显示。
   此处我通过修改`vnpy.chart.widget.ChartWidget`的`_update_plot_limits()`和`_update_y_range()`方法，在设置plot的item范围时，汇总plot中所有item的y轴最大最小值后再设置，保证所有item的图像都能完整显示。
2. `vnpy.chart.widget.ChartCursor`中，光标所在位置的提示信息框始终显示在plot的左上角，如果在左上角有图形，则左上角的图形会始终被信息提示框遮挡而无法看到。
   此处我通过修改`vnpy.chart.widget.ChartCursor`的`update_info()`方法，根据光标所在位置来调整信息提示框的位置。如果光标在绘图控件的右半侧，则信息提示框依然显示在plot的左上角。当光标在绘图控件左半侧，则信息提示框显示在plot的右上角，从而解决左上角图像可能始终被遮挡的问题。