### PR TITLE
数据库后端增加TimescaleDB支持

### DIFF
--- a/vnpy/trader/database/database.py
+++ b/vnpy/trader/database/database.py
@@ -100,9 +100,7 @@ class BaseDatabaseManager(ABC):
 
     @abstractmethod
     def get_bar_data_statistics(
-            self,
-            symbol: str,
-            exchange: "Exchange",
+            self
     ) -> List[Dict]:
         """
         Return data avaible in database with a list of symbol/exchange/interval/count.

--- a/vnpy/trader/database/database.py
+++ b/vnpy/trader/database/database.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from enum import Enum
 from typing import Optional, Sequence, List, Dict, TYPE_CHECKING
+
 from pytz import timezone
 
 from vnpy.trader.setting import SETTINGS
@@ -9,7 +10,6 @@ from vnpy.trader.setting import SETTINGS
 if TYPE_CHECKING:
     from vnpy.trader.constant import Interval, Exchange  # noqa
     from vnpy.trader.object import BarData, TickData  # noqa
-
 
 DB_TZ = timezone(SETTINGS["database.timezone"])
 
@@ -20,51 +20,52 @@ class Driver(Enum):
     POSTGRESQL = "postgresql"
     MONGODB = "mongodb"
     INFLUX = "influxdb"
+    TIMESCALEDB = 'timescaledb'
 
 
 class BaseDatabaseManager(ABC):
 
     @abstractmethod
     def load_bar_data(
-        self,
-        symbol: str,
-        exchange: "Exchange",
-        interval: "Interval",
-        start: datetime,
-        end: datetime
+            self,
+            symbol: str,
+            exchange: "Exchange",
+            interval: "Interval",
+            start: datetime,
+            end: datetime
     ) -> Sequence["BarData"]:
         pass
 
     @abstractmethod
     def load_tick_data(
-        self,
-        symbol: str,
-        exchange: "Exchange",
-        start: datetime,
-        end: datetime
+            self,
+            symbol: str,
+            exchange: "Exchange",
+            start: datetime,
+            end: datetime
     ) -> Sequence["TickData"]:
         pass
 
     @abstractmethod
     def save_bar_data(
-        self,
-        datas: Sequence["BarData"],
+            self,
+            datas: Sequence["BarData"],
     ):
         pass
 
     @abstractmethod
     def save_tick_data(
-        self,
-        datas: Sequence["TickData"],
+            self,
+            datas: Sequence["TickData"],
     ):
         pass
 
     @abstractmethod
     def get_newest_bar_data(
-        self,
-        symbol: str,
-        exchange: "Exchange",
-        interval: "Interval"
+            self,
+            symbol: str,
+            exchange: "Exchange",
+            interval: "Interval"
     ) -> Optional["BarData"]:
         """
         If there is data in database, return the one with greatest datetime(newest one)
@@ -74,10 +75,10 @@ class BaseDatabaseManager(ABC):
 
     @abstractmethod
     def get_oldest_bar_data(
-        self,
-        symbol: str,
-        exchange: "Exchange",
-        interval: "Interval"
+            self,
+            symbol: str,
+            exchange: "Exchange",
+            interval: "Interval"
     ) -> Optional["BarData"]:
         """
         If there is data in database, return the one with smallest datetime(oldest one)
@@ -87,9 +88,9 @@ class BaseDatabaseManager(ABC):
 
     @abstractmethod
     def get_newest_tick_data(
-        self,
-        symbol: str,
-        exchange: "Exchange",
+            self,
+            symbol: str,
+            exchange: "Exchange",
     ) -> Optional["TickData"]:
         """
         If there is data in database, return the one with greatest datetime(newest one)
@@ -99,9 +100,9 @@ class BaseDatabaseManager(ABC):
 
     @abstractmethod
     def get_bar_data_statistics(
-        self,
-        symbol: str,
-        exchange: "Exchange",
+            self,
+            symbol: str,
+            exchange: "Exchange",
     ) -> List[Dict]:
         """
         Return data avaible in database with a list of symbol/exchange/interval/count.
@@ -110,10 +111,10 @@ class BaseDatabaseManager(ABC):
 
     @abstractmethod
     def delete_bar_data(
-        self,
-        symbol: str,
-        exchange: "Exchange",
-        interval: "Interval"
+            self,
+            symbol: str,
+            exchange: "Exchange",
+            interval: "Interval"
     ) -> int:
         """
         Delete all bar data with given symbol + exchange + interval.

--- a/vnpy/trader/database/database_timescaledb.py
+++ b/vnpy/trader/database/database_timescaledb.py
@@ -152,6 +152,8 @@ class TimescaleDBManager(BaseDatabaseManager):
                    bar.open_price, bar.high_price, bar.low_price, bar.close_price, bar.volume, bar.open_interest]
                   for bar in data]
 
+        values = list({tuple(x[0:4]): x for x in values}.values())
+        
         on_conflict_clause = ','.join([column + '=excluded.' + column
                                        for column in columns
                                        if column not in ('symbol', 'exchange', 'interval', 'datetime')])

--- a/vnpy/trader/database/database_timescaledb.py
+++ b/vnpy/trader/database/database_timescaledb.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Optional, Sequence, List
 
 import psycopg2
+import psycopg2.extras
 
 from vnpy.trader.constant import Exchange, Interval
 from vnpy.trader.object import BarData, TickData
@@ -17,7 +18,69 @@ def init(_: Driver, settings: dict):
 
     conn = psycopg2.connect(f'postgres://{username}:{password}@{host}:{port}/{database}')
 
-    # TODO: Create database and tables if needed
+    query = ("create schema if not exists hist_md;\n"
+             "\n"
+             "create table if not exists hist_md.tickdata\n"
+             "(\n"
+             "    symbol        varchar(255)             not null,\n"
+             "    exchange      varchar(255)             not null,\n"
+             "    datetime      timestamp with time zone not null,\n"
+             "    name          varchar(255)             not null,\n"
+             "    volume        real                     not null,\n"
+             "    open_interest real                     not null,\n"
+             "    last_price    real                     not null,\n"
+             "    last_volume   real                     not null,\n"
+             "    limit_up      real                     not null,\n"
+             "    limit_down    real                     not null,\n"
+             "    open_price    real                     not null,\n"
+             "    high_price    real                     not null,\n"
+             "    low_price     real                     not null,\n"
+             "    pre_close     real                     not null,\n"
+             "    bid_price_1   real                     not null,\n"
+             "    bid_price_2   real,\n"
+             "    bid_price_3   real,\n"
+             "    bid_price_4   real,\n"
+             "    bid_price_5   real,\n"
+             "    ask_price_1   real                     not null,\n"
+             "    ask_price_2   real,\n"
+             "    ask_price_3   real,\n"
+             "    ask_price_4   real,\n"
+             "    ask_price_5   real,\n"
+             "    bid_volume_1  real                     not null,\n"
+             "    bid_volume_2  real,\n"
+             "    bid_volume_3  real,\n"
+             "    bid_volume_4  real,\n"
+             "    bid_volume_5  real,\n"
+             "    ask_volume_1  real                     not null,\n"
+             "    ask_volume_2  real,\n"
+             "    ask_volume_3  real,\n"
+             "    ask_volume_4  real,\n"
+             "    ask_volume_5  real,\n"
+             "    constraint tickdata_pk\n"
+             "        primary key (symbol, exchange, datetime)\n"
+             ");\n"
+             "\n"
+             "create table if not exists hist_md.bardata\n"
+             "(\n"
+             "    symbol        varchar(200)             not null,\n"
+             "    exchange      varchar(50)              not null,\n"
+             "    datetime      timestamp with time zone not null,\n"
+             "    interval      varchar(50)              not null,\n"
+             "    open          real,\n"
+             "    high          real,\n"
+             "    low           real,\n"
+             "    close         real,\n"
+             "    volume        real,\n"
+             "    open_interest integer,\n"
+             "    constraint bardata_pk\n"
+             "        primary key (symbol, exchange, datetime, interval)\n"
+             ");\n"
+             "\n"
+             "select create_hypertable('hist_md.tickdata', 'datetime', if_not_exists := true);\n"
+             "select create_hypertable('hist_md.bardata', 'datetime', if_not_exists := true);\n")
+
+    with conn.cursor() as cur:
+        cur.execute(query)
 
     return TimescaleDBManager(conn)
 
@@ -32,13 +95,13 @@ class TimescaleDBManager(BaseDatabaseManager):
                       ) -> Sequence[BarData]:
         columns = ('datetime', 'open', 'high', 'low', 'close', 'volume', 'open_interest')
 
-        query = f"SELECT {','.join(columns)} " \
-                f"FROM bardata " \
-                f"WHERE symbol = %s " \
-                f"    AND exchange = %s" \
-                f"    AND interval = %s " \
-                f"    AND datetime >= %s " \
-                f"    AND datetime <= %s;"
+        query = f"select {','.join(columns)} " \
+                f"from hist_md.bardata " \
+                f"where symbol = %s " \
+                f"    and exchange = %s " \
+                f"    and interval = %s " \
+                f"    and datetime >= %s " \
+                f"    and datetime <= %s;"
 
         params = (symbol, exchange, interval.value, start, end)
 
@@ -61,12 +124,12 @@ class TimescaleDBManager(BaseDatabaseManager):
             'bid_volume_1', 'bid_volume_2', 'bid_volume_3', 'bid_volume_4', 'bid_volume_5',
             'ask_volume_1', 'ask_volume_2', 'ask_volume_3', 'ask_volume_4', 'ask_volume_5')
 
-        query = f"SELECT {','.join(columns)}" \
-                f"FROM tickdata " \
-                f"WHERE symbol = %s " \
-                f"    AND exchange = %s" \
-                f"    AND datetime >= %s " \
-                f"    AND datetime <= %s;"
+        query = f"select {','.join(columns)} " \
+                f"from hist_md.tickdata " \
+                f"where symbol = %s " \
+                f"    and exchange = %s " \
+                f"    and datetime >= %s " \
+                f"    and datetime <= %s;"
 
         params = (symbol, exchange, start, end)
 
@@ -81,25 +144,156 @@ class TimescaleDBManager(BaseDatabaseManager):
         return ticks
 
     def save_bar_data(self, data: Sequence[BarData]):
-        pass
+        columns = ('symbol', 'exchange', 'interval', 'datetime',
+                   'open', 'high', 'low', 'close', 'volume', 'open_interest')
+
+        values = [{column: getattr(bar, column) for column in columns} for bar in data]
+        query = f"insert into hist_md.bardata {','.join(columns)} values %s;"
+        with self.__conn.cursor() as cur:
+            psycopg2.extras.execute_values(cur, query, values)
 
     def save_tick_data(self, data: Sequence[TickData]):
-        pass
+        columns = ('symbol', 'exchange', 'datetime',
+                   'name', 'volume', 'open_interest', 'last_price', 'last_volume',
+                   'limit_up', 'limit_down', 'open_price', 'high_price', 'low_price', 'pre_close',
+                   'bid_price_1', 'bid_price_2', 'bid_price_3', 'bid_price_4', 'bid_price_5',
+                   'ask_price_1', 'ask_price_2', 'ask_price_3', 'ask_price_4', 'ask_price_5',
+                   'bid_volume_1', 'bid_volume_2', 'bid_volume_3', 'bid_volume_4', 'bid_volume_5',
+                   'ask_volume_1', 'ask_volume_2', 'ask_volume_3', 'ask_volume_4', 'ask_volume_5')
+
+        values = [{column: getattr(bar, column) for column in columns} for bar in data]
+        query = f"insert into hist_md.tickdata {','.join(columns)} values %s;"
+        with self.__conn.cursor() as cur:
+            psycopg2.extras.execute_values(cur, query, values)
 
     def get_newest_bar_data(self, symbol: str, exchange: Exchange, interval: Interval) -> Optional[BarData]:
-        pass
+        columns = ('datetime', 'open', 'high', 'low', 'close', 'volume', 'open_interest')
+
+        query = f"select {','.join(columns)} " \
+                f"from hist_md.tickdata " \
+                f"where symbol = %s " \
+                f"    and exchange = %s " \
+                f"    and interval = %s " \
+                f"order by datetime desc " \
+                f"limit 1;"
+
+        params = (symbol, exchange, interval.value)
+
+        with self.__conn.cursor() as cur:
+            cur.execute(query)
+            result = cur.fetchall()
+
+        bars = [BarData(symbol=symbol, exchange=exchange, interval=interval,
+                        **{col: val for col, val in zip(columns, values) if val is not None})
+                for values in result]
+
+        if len(bars) == 0:
+            return None
+        else:
+            return bars[0]
 
     def get_oldest_bar_data(self, symbol: str, exchange: Exchange, interval: Interval) -> Optional[BarData]:
-        pass
+        columns = ('datetime', 'open', 'high', 'low', 'close', 'volume', 'open_interest')
+
+        query = f"select {','.join(columns)} " \
+                f"from hist_md.tickdata " \
+                f"where symbol = %s " \
+                f"    and exchange = %s " \
+                f"    and interval = %s " \
+                f"order by datetime " \
+                f"limit 1;"
+
+        params = (symbol, exchange, interval.value)
+
+        with self.__conn.cursor() as cur:
+            cur.execute(query)
+            result = cur.fetchall()
+
+        bars = [BarData(symbol=symbol, exchange=exchange, interval=interval,
+                        **{col: val for col, val in zip(columns, values) if val is not None})
+                for values in result]
+
+        if len(bars) == 0:
+            return None
+        else:
+            return bars[0]
 
     def get_newest_tick_data(self, symbol: str, exchange: Exchange) -> Optional[TickData]:
-        pass
+        columns = (
+            'name', 'volume', 'open_interest', 'last_price', 'last_volume',
+            'limit_up', 'limit_down', 'open_price', 'high_price', 'low_price', 'pre_close',
+            'bid_price_1', 'bid_price_2', 'bid_price_3', 'bid_price_4', 'bid_price_5',
+            'ask_price_1', 'ask_price_2', 'ask_price_3', 'ask_price_4', 'ask_price_5',
+            'bid_volume_1', 'bid_volume_2', 'bid_volume_3', 'bid_volume_4', 'bid_volume_5',
+            'ask_volume_1', 'ask_volume_2', 'ask_volume_3', 'ask_volume_4', 'ask_volume_5')
+
+        query = f"select {','.join(columns)} " \
+                f"from hist_md.tickdata " \
+                f"where symbol = %s " \
+                f"    and exchange = %s " \
+                f"order by datetime desc" \
+                f"limit 1;"
+
+        params = (symbol, exchange)
+
+        with self.__conn.cursor() as cur:
+            cur.execute(query, params)
+            result = cur.fetchall()
+
+        ticks = [TickData(symbol=symbol, exchange=exchange,
+                          **{col: val for col, val in zip(columns, values) if val is not None})
+                 for values in result]
+
+        if len(ticks) == 0:
+            return None
+        else:
+            return ticks[0]
 
     def get_bar_data_statistics(self, symbol: str, exchange: Exchange) -> List:
-        pass
+        columns = {'symbol', 'exchange', 'interval', }
+        query = f"select symbol, exchange, interval, count(*) as count " \
+                f"from hist_md.bardata " \
+                f"group by symbol, exchange, interval; "
+
+        with self.__conn.cursor() as cur:
+            cur.execute(query)
+            result = cur.fetchall()
+
+        statistics = [{col: val for col, val in zip(columns, result)}
+                      for values in result]
+
+        return statistics
 
     def delete_bar_data(self, symbol: str, exchange: Exchange, interval: Interval) -> int:
-        pass
+        query = f"delete " \
+                f"from hist_md.bardata " \
+                f"where symbol = %s " \
+                f"    and exchange = %s " \
+                f"    and interval = %s;"
+
+        params = (symbol, exchange, interval.value)
+
+        with self.__conn.cursor() as cur:
+            cur.execute(query, params)
+            count = cur.rowcount
+
+        return count
 
     def clean(self, symbol: str):
-        pass
+        query = f"delete " \
+                f"from hist_md.bardata " \
+                f"where symbol = %s; "
+
+        params = (symbol,)
+
+        with self.__conn.cursor() as cur:
+            cur.execute(query, params)
+
+        query = f"delete " \
+                f"from hist_md.tickdata " \
+                f"where symbol = %s; "
+
+        params = (symbol,)
+
+        with self.__conn.cursor() as cur:
+            cur.execute(query, params)

--- a/vnpy/trader/database/database_timescaledb.py
+++ b/vnpy/trader/database/database_timescaledb.py
@@ -1,0 +1,105 @@
+from datetime import datetime
+from typing import Optional, Sequence, List
+
+import psycopg2
+
+from vnpy.trader.constant import Exchange, Interval
+from vnpy.trader.object import BarData, TickData
+from .database import BaseDatabaseManager, Driver
+
+
+def init(_: Driver, settings: dict):
+    database = settings.get('database', 'vnpy')
+    host = settings['host']
+    port = settings.get('port', 5421)
+    username = settings.get("user", 'postgres')
+    password = settings.get("password", 'postgres')
+
+    conn = psycopg2.connect(f'postgres://{username}:{password}@{host}:{port}/{database}')
+
+    # TODO: Create database and tables if needed
+
+    return TimescaleDBManager(conn)
+
+
+class TimescaleDBManager(BaseDatabaseManager):
+    def __init__(self, conn):
+        self.__conn = conn
+
+    def load_bar_data(self,
+                      symbol: str, exchange: Exchange, interval: Interval,
+                      start: datetime, end: datetime
+                      ) -> Sequence[BarData]:
+        columns = ('datetime', 'open', 'high', 'low', 'close', 'volume', 'open_interest')
+
+        query = f"SELECT {','.join(columns)} " \
+                f"FROM bardata " \
+                f"WHERE symbol = %s " \
+                f"    AND exchange = %s" \
+                f"    AND interval = %s " \
+                f"    AND datetime >= %s " \
+                f"    AND datetime <= %s;"
+
+        params = (symbol, exchange, interval.value, start, end)
+
+        with self.__conn.cursor() as cur:
+            cur.execute(query, params)
+            result = cur.fetchall()
+
+        bars = [BarData(symbol=symbol, exchange=exchange, interval=interval,
+                        **{col: val for col, val in zip(columns, values) if val is not None})
+                for values in result]
+
+        return bars
+
+    def load_tick_data(self, symbol: str, exchange: Exchange, start: datetime, end: datetime) -> Sequence[TickData]:
+        columns = (
+            'name', 'volume', 'open_interest', 'last_price', 'last_volume',
+            'limit_up', 'limit_down', 'open_price', 'high_price', 'low_price', 'pre_close',
+            'bid_price_1', 'bid_price_2', 'bid_price_3', 'bid_price_4', 'bid_price_5',
+            'ask_price_1', 'ask_price_2', 'ask_price_3', 'ask_price_4', 'ask_price_5',
+            'bid_volume_1', 'bid_volume_2', 'bid_volume_3', 'bid_volume_4', 'bid_volume_5',
+            'ask_volume_1', 'ask_volume_2', 'ask_volume_3', 'ask_volume_4', 'ask_volume_5')
+
+        query = f"SELECT {','.join(columns)}" \
+                f"FROM tickdata " \
+                f"WHERE symbol = %s " \
+                f"    AND exchange = %s" \
+                f"    AND datetime >= %s " \
+                f"    AND datetime <= %s;"
+
+        params = (symbol, exchange, start, end)
+
+        with self.__conn.cursor() as cur:
+            cur.execute(query, params)
+            result = cur.fetchall()
+
+        ticks = [TickData(symbol=symbol, exchange=exchange,
+                          **{col: val for col, val in zip(columns, values) if val is not None})
+                 for values in result]
+
+        return ticks
+
+    def save_bar_data(self, data: Sequence[BarData]):
+        pass
+
+    def save_tick_data(self, data: Sequence[TickData]):
+        pass
+
+    def get_newest_bar_data(self, symbol: str, exchange: Exchange, interval: Interval) -> Optional[BarData]:
+        pass
+
+    def get_oldest_bar_data(self, symbol: str, exchange: Exchange, interval: Interval) -> Optional[BarData]:
+        pass
+
+    def get_newest_tick_data(self, symbol: str, exchange: Exchange) -> Optional[TickData]:
+        pass
+
+    def get_bar_data_statistics(self, symbol: str, exchange: Exchange) -> List:
+        pass
+
+    def delete_bar_data(self, symbol: str, exchange: Exchange, interval: Interval) -> int:
+        pass
+
+    def clean(self, symbol: str):
+        pass

--- a/vnpy/trader/database/database_timescaledb.py
+++ b/vnpy/trader/database/database_timescaledb.py
@@ -145,8 +145,8 @@ class TimescaleDBManager(BaseDatabaseManager):
         columns = ('symbol', 'exchange', 'interval', 'datetime',
                    'open_price', 'high_price', 'low_price', 'close_price', 'volume', 'open_interest')
 
-        values = [(bar.symbol, bar.exchange.value, bar.interval.value, bar.datetime,
-                   bar.open_price, bar.high_price, bar.low_price, bar.close_price, bar.volume, bar.open_interest)
+        values = [[bar.symbol, bar.exchange.value, bar.interval.value, bar.datetime,
+                   bar.open_price, bar.high_price, bar.low_price, bar.close_price, bar.volume, bar.open_interest]
                   for bar in data]
 
         query = f"insert into hist_md.bardata ({','.join(columns)}) values %s;"
@@ -163,8 +163,17 @@ class TimescaleDBManager(BaseDatabaseManager):
                    'bid_volume_1', 'bid_volume_2', 'bid_volume_3', 'bid_volume_4', 'bid_volume_5',
                    'ask_volume_1', 'ask_volume_2', 'ask_volume_3', 'ask_volume_4', 'ask_volume_5')
 
-        values = [{column: getattr(bar, column) for column in columns} for bar in data]
-        query = f"insert into hist_md.tickdata {','.join(columns)} values %s;"
+        values = [[tick.symbol, tick.exchange.value, tick.datetime,
+                   tick.name, tick.volume, tick.open_interest, tick.last_price, tick.last_volume,
+                   tick.limit_up, tick.limit_down, tick.open_price, tick.high_price, tick.low_price, tick.pre_close,
+                   tick.bid_price_1, tick.bid_price_2, tick.bid_price_3, tick.bid_price_4, tick.bid_price_5,
+                   tick.ask_price_1, tick.ask_price_2, tick.ask_price_3, tick.ask_price_4, tick.ask_price_5,
+                   tick.bid_volume_1, tick.bid_volume_2, tick.bid_volume_3, tick.bid_volume_4, tick.bid_volume_5,
+                   tick.ask_volume_1, tick.ask_volume_2, tick.ask_volume_3, tick.ask_volume_4, tick.ask_volume_5]
+                  for tick in data]
+
+
+        query = f"insert into hist_md.tickdata ({','.join(columns)}) values %s;"
         with self.__conn.cursor() as cur:
             psycopg2.extras.execute_values(cur, query, values)
             self.__conn.commit()

--- a/vnpy/trader/database/initialize.py
+++ b/vnpy/trader/database/initialize.py
@@ -8,6 +8,8 @@ def init(settings: dict) -> BaseDatabaseManager:
         return init_mongo(driver=driver, settings=settings)
     elif driver is Driver.INFLUX:
         return init_influx(driver=driver, settings=settings)
+    elif driver is Driver.TIMESCALEDB:
+        return init_timescaledb(driver=driver, settings=settings)
     else:
         return init_sql(driver=driver, settings=settings)
 
@@ -28,5 +30,10 @@ def init_mongo(driver: Driver, settings: dict):
 
 def init_influx(driver: Driver, settings: dict):
     from .database_influx import init
+    _database_manager = init(driver, settings=settings)
+    return _database_manager
+
+def init_timescaledb(driver: Driver, settings: dict):
+    from .database_timescaledb import init
     _database_manager = init(driver, settings=settings)
     return _database_manager

--- a/vnpy/trader/object.py
+++ b/vnpy/trader/object.py
@@ -71,6 +71,8 @@ class TickData(BaseData):
     ask_volume_4: float = 0
     ask_volume_5: float = 0
 
+    tick_id: str = None
+
     def __post_init__(self):
         """"""
         self.vt_symbol = f"{self.symbol}.{self.exchange.value}"


### PR DESCRIPTION
数据库后端增加TimescaleDB支持

## 改进内容

1. 增加新的数据库后端 timescaledb
2. 后端可以创建hypertable (如果表不存在)，但需要用户事先配置好timescaledb 插件

## 相关的Issue号

Close #2791 