### PR TITLE
提高行情记录性能

### DIFF
--- a/vnpy/app/data_recorder/engine.py
+++ b/vnpy/app/data_recorder/engine.py
@@ -40,6 +40,9 @@ class RecorderEngine(BaseEngine):
         self.thread = Thread(target=self.run)
         self.active = False
 
+        self.batch_size = None
+        self.commit_delay = None
+
         self.tick_recordings = {}
         self.bar_recordings = {}
         self.bar_generators = {}
@@ -54,12 +57,14 @@ class RecorderEngine(BaseEngine):
         setting = load_json(self.setting_filename)
         self.tick_recordings = setting.get("tick", {})
         self.bar_recordings = setting.get("bar", {})
-        self.batch_size = setting.get("batch_size", 1000)
+        self.batch_size = setting.get("batch_size", 10000)
         self.commit_delay = setting.get("commit_delay", 30)
 
     def save_setting(self):
         """"""
         setting = {
+            "batch_size": self.batch_size,
+            "commit_delay": self.commit_delay,
             "tick": self.tick_recordings,
             "bar": self.bar_recordings
         }
@@ -271,6 +276,8 @@ class RecorderEngine(BaseEngine):
         bar_symbols.sort()
 
         data = {
+            "batch_size": self.batch_size,
+            "commit_delay": self.commit_delay,
             "tick": tick_symbols,
             "bar": bar_symbols
         }

--- a/vnpy/app/data_recorder/ui/widget.py
+++ b/vnpy/app/data_recorder/ui/widget.py
@@ -64,6 +64,12 @@ class RecorderManager(QtWidgets.QWidget):
         remove_tick_button = QtWidgets.QPushButton("移除")
         remove_tick_button.clicked.connect(self.remove_tick_recording)
 
+        self.batch_size_edit = QtWidgets.QLineEdit()
+        self.commit_delay_edit = QtWidgets.QLineEdit()
+
+        self.batch_size_edit.editingFinished.connect(self.update_batch_size)
+        self.commit_delay_edit.editingFinished.connect(self.update_commit_delay)
+
         self.bar_recording_edit = QtWidgets.QTextEdit()
         self.bar_recording_edit.setReadOnly(True)
 
@@ -81,6 +87,13 @@ class RecorderManager(QtWidgets.QWidget):
         grid.addWidget(QtWidgets.QLabel("Tick记录"), 1, 0)
         grid.addWidget(add_tick_button, 1, 1)
         grid.addWidget(remove_tick_button, 1, 2)
+
+        grid.addWidget(QtWidgets.QLabel("批量写入"), 0, 4)
+        grid.addWidget(self.batch_size_edit, 0, 5)
+        grid.addWidget(QtWidgets.QLabel("写入间隔"), 1, 4)
+        grid.addWidget(self.commit_delay_edit, 1, 5)
+
+
 
         hbox = QtWidgets.QHBoxLayout()
         hbox.addWidget(QtWidgets.QLabel("本地代码"))
@@ -125,6 +138,9 @@ class RecorderManager(QtWidgets.QWidget):
         """"""
         data = event.data
 
+        self.batch_size_edit.setText(str(data["batch_size"]))
+        self.commit_delay_edit.setText(str(data["commit_delay"]))
+
         self.bar_recording_edit.clear()
         bar_text = "\n".join(data["bar"])
         self.bar_recording_edit.setText(bar_text)
@@ -165,3 +181,20 @@ class RecorderManager(QtWidgets.QWidget):
         """"""
         vt_symbol = self.symbol_line.text()
         self.recorder_engine.remove_tick_recording(vt_symbol)
+
+    def update_batch_size(self):
+        try:
+            self.recorder_engine.batch_size = int(self.batch_size_edit.text())
+            self.recorder_engine.save_setting()
+            self.recorder_engine.put_event()
+        except ValueError:
+            pass
+
+    def update_commit_delay(self):
+        try:
+            self.recorder_engine.commit_delay = int(self.commit_delay_edit.text())
+            self.recorder_engine.save_setting()
+            self.recorder_engine.put_event()
+        except ValueError:
+            pass
+


### PR DESCRIPTION
通过批量写入数据库，提高行情记录性能和吞吐量

## 改进内容

1. 行情记录模块不会逐条将数据写入数据库，而是等待足够数量的数据(batch_size)或者间隔一定的时间(commit_delay)后批量写入
2. batch_size和commit_delay可以在行情记录模块中设置，默认值为10000和30秒
3. 行情记录的UI提供修改设置的功能

## 相关的Issue号

Close #2795 