### PR TITLE
[Fix] Fix Charts to support pyqtgraph==0.11.1

### DIFF
--- a/vnpy/chart/widget.py
+++ b/vnpy/chart/widget.py
@@ -50,7 +50,8 @@ class ChartWidget(pg.PlotWidget):
         self._layout.setZValue(0)
         self.setCentralItem(self._layout)
 
-        self._x_axis = DatetimeAxis(self._manager, orientation='bottom')
+    def _get_new_x_axis(self):
+        return DatetimeAxis(self._manager, orientation='bottom')
 
     def add_cursor(self) -> None:
         """"""
@@ -69,7 +70,7 @@ class ChartWidget(pg.PlotWidget):
         Add plot area.
         """
         # Create plot object
-        plot = pg.PlotItem(axisItems={'bottom': self._x_axis})
+        plot = pg.PlotItem(axisItems={'bottom': self._get_new_x_axis()})
         plot.setMenuEnabled(False)
         plot.setClipToView(True)
         plot.hideAxis('left')


### PR DESCRIPTION
```python
# 当pyqtgraph版本大于0.10.0， 运行examples/candle_chart/run.py会报错
Traceback (most recent call last):
  File "run.py", line 22, in <module>
    widget.add_plot("volume", maximum_height=200)
  File "/Users/chandler/.pyenv/versions/3.8.1/lib/python3.8/site-packages/vnpy/chart/widget.py", line 72, in add_plot
    plot = pg.PlotItem(axisItems={'bottom': self._x_axis})
  File "/Users/chandler/.pyenv/versions/3.8.1/lib/python3.8/site-packages/pyqtgraph/graphicsItems/PlotItem/PlotItem.py", line 159, in __init__
    self.setAxisItems(axisItems)
  File "/Users/chandler/.pyenv/versions/3.8.1/lib/python3.8/site-packages/pyqtgraph/graphicsItems/PlotItem/PlotItem.py", line 329, in setAxisItems
    raise RuntimeError(
RuntimeError: Can't add an axis to multiple plots. Shared axes can be achieved with multiple AxisItem instances and set[X/Y]Link.
```

## 改进内容

1. 修复bug，已测试兼容旧版本pyqtgraph==0.10.0

## 相关的Issue号（如有）

Close #