### PR TITLE
[Mod] 修复 实际夏普为负，但是输出结果为正的bug

### DIFF
--- a/vnpy/app/cta_strategy/backtesting.py
+++ b/vnpy/app/cta_strategy/backtesting.py
@@ -183,7 +183,7 @@ class BacktestingEngine:
         end: datetime = None,
         mode: BacktestingMode = BacktestingMode.BAR,
         inverse: bool = False,
-        risk_free: float = 0,
+        risk_free: float = 0.02,
         annual_days: int = 240
     ):
         """"""
@@ -412,10 +412,7 @@ class BacktestingEngine:
             # Calculate balance related time series data
             df["balance"] = df["net_pnl"].cumsum() + self.capital
 
-            # When balance falls below 0, set daily return to 0
-            x = df["balance"] / df["balance"].shift(1)
-            x[x <= 0] = np.nan
-            df["return"] = np.log(x).fillna(0)
+            df["return"] = df["balance"].pct_change().fillna(0)
 
             df["highlevel"] = (
                 df["balance"].rolling(

--- a/vnpy/app/portfolio_strategy/backtesting.py
+++ b/vnpy/app/portfolio_strategy/backtesting.py
@@ -95,7 +95,7 @@ class BacktestingEngine:
         priceticks: Dict[str, float],
         capital: int = 0,
         end: datetime = None,
-        risk_free: float = 0
+        risk_free: float = 0.02
     ) -> None:
         """"""
         self.vt_symbols = vt_symbols
@@ -300,7 +300,7 @@ class BacktestingEngine:
         else:
             # Calculate balance related time series data
             df["balance"] = df["net_pnl"].cumsum() + self.capital
-            df["return"] = np.log(df["balance"] / df["balance"].shift(1)).fillna(0)
+            df["return"] = df["balance"].pct_change().fillna(0)
             df["highlevel"] = (
                 df["balance"].rolling(
                     min_periods=1, window=len(df), center=False).max()


### PR DESCRIPTION
- 修复 实际夏普为负，但是输出结果为正的bug；
- 修复，risk free在初始化时候是0.02， 但是set parameter却默认是0的bug。

