### PR TITLE
[Mod] RestClient: Replace multiprocessing.dummy.Pool

### DIFF
--- a/vnpy/api/rest/rest_client.py
+++ b/vnpy/api/rest/rest_client.py
@@ -2,7 +2,6 @@ import sys
 import traceback
 from datetime import datetime
 from enum import Enum
-from multiprocessing.dummy import Pool
 from queue import Empty, Queue
 from typing import Any, Callable, Optional, Union, Type
 from types import TracebackType
@@ -97,7 +96,7 @@ class RestClient(object):
         self._active: bool = False
 
         self._queue: Queue = Queue()
-        self._pool: Pool = None
+        self._pool = None
 
         self.proxies: dict = None
 
@@ -125,8 +124,9 @@ class RestClient(object):
             return
 
         self._active = True
-        self._pool = Pool(n)
-        self._pool.apply_async(self._run)
+        self._pool = [Thread(target=self._run) for _ in range(n)]
+        for t in self._pool:
+            t.start()
 
     def stop(self) -> None:
         """


### PR DESCRIPTION
Replace `Pool` with `Thread` List to reduce three threads used in `Pool`: `_worker_handler`, `_task_handler`, `_result_handler`.

## 改进内容

`Pool`自带3个管理线程, 即`size`为`n`的`Pool`, 实际线程数为`n+3`. 
本次改动用`Thread`列表替换`Pool`, 为每个`RestClient`实例减少3个线程.