### PR TITLE
修复HuobisGateway的ConnectionResetError问题

### DIFF
--- a/vnpy/gateway/huobis/huobis_gateway.py
+++ b/vnpy/gateway/huobis/huobis_gateway.py
@@ -235,7 +235,8 @@ class HuobisRestApi(RestClient):
         Generate HUOBIS signature.
         """
         request.headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36"
+            "User-Agent": "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36",
+            "Connection": "close"
         }
         params_with_signature = create_signature(
             self.key,


### PR DESCRIPTION
修复HuobisGateway的ConnectionResetError问题，通过关闭HTTP连接的keep-alive功能实现