### PR TITLE
argmax() to idxmax()

### DIFF
--- a/vnpy/app/spread_trading/backtesting.py
+++ b/vnpy/app/spread_trading/backtesting.py
@@ -281,7 +281,7 @@ class BacktestingEngine:
             max_drawdown = df["drawdown"].min()
             max_ddpercent = df["ddpercent"].min()
             max_drawdown_end = df["drawdown"].idxmin()
-            max_drawdown_start = df["balance"][:max_drawdown_end].argmax()
+            max_drawdown_start = df["balance"][:max_drawdown_end].idxmax()
             max_drawdown_duration = (max_drawdown_end - max_drawdown_start).days
 
             total_net_pnl = df["net_pnl"].sum()


### PR DESCRIPTION
建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 由于vnstudio自带pandas版本过旧，使用时出现TypeError: Cannot interpret ‘＜attribute ‘dtype‘ of ‘numpy.generic‘ objects＞‘ as a data type，故手动进行升级，结果发现回测报错，发现升级之后argmax()定义已经出现变化，参考portfolio_strategy那边的回测代码改用idxmax()，代码中除了此处没有其它地方使用argmax()

## 相关的Issue号（如有）

Close #