### PR TITLE
docs: Fix a few typos

### DIFF
--- a/vnpy/api/websocket/websocket_client.py
+++ b/vnpy/api/websocket/websocket_client.py
@@ -91,10 +91,10 @@ class WebsocketClient:
 
     def start(self):
         """
-        Start the client and on_connected function is called after webscoket
+        Start the client and on_connected function is called after websocket
         is connected succesfully.
 
-        Please don't send packet untill on_connected fucntion is called.
+        Please don't send packet untill on_connected function is called.
         """
 
         self._active = True

--- a/vnpy/app/spread_trading/engine.py
+++ b/vnpy/app/spread_trading/engine.py
@@ -634,7 +634,7 @@ class SpreadAlgoEngine:
         # If no position to close, just open new
         if not available:
             offset = Offset.OPEN
-        # If enougth position to close, just close old
+        # If enough position to close, just close old
         elif volume < available:
             offset = Offset.CLOSE
         # Otherwise, just close existing position

--- a/vnpy/gateway/bitfinex/bitfinex_gateway.py
+++ b/vnpy/gateway/bitfinex/bitfinex_gateway.py
@@ -406,7 +406,7 @@ class BitfinexWebsocketApi(WebsocketClient):
 
     def subscribe(self, req: SubscribeRequest):
         """
-        Subscribe to tick data upate.
+        Subscribe to tick data update.
         """
         if req.symbol not in self.subscribed:
             self.subscribed[req.symbol] = req

--- a/vnpy/gateway/bitmex/bitmex_gateway.py
+++ b/vnpy/gateway/bitmex/bitmex_gateway.py
@@ -553,7 +553,7 @@ class BitmexWebsocketApi(WebsocketClient):
 
     def subscribe(self, req: SubscribeRequest):
         """
-        Subscribe to tick data upate.
+        Subscribe to tick data update.
         """
         tick = TickData(
             symbol=req.symbol,
@@ -610,7 +610,7 @@ class BitmexWebsocketApi(WebsocketClient):
 
     def authenticate(self):
         """
-        Authenticate websockey connection to subscribe private topic.
+        Authenticate websocket connection to subscribe private topic.
         """
         expires = int(time.time())
         method = "GET"

--- a/vnpy/gateway/coinbase/coinbase_gateway.py
+++ b/vnpy/gateway/coinbase/coinbase_gateway.py
@@ -732,7 +732,7 @@ class CoinbaseRestApi(RestClient):
         # For open orders from previous trading session, use sysid to cancel
         if orderid in sys_order_map:
             path = f"/orders/{orderid}"
-        # For open orders from currenct trading session, use client_oid to cancel
+        # For open orders from currency trading session, use client_oid to cancel
         else:
             path = f"/orders/client:{orderid}"
 

--- a/vnpy/gateway/gateios/gateios_gateway.py
+++ b/vnpy/gateway/gateios/gateios_gateway.py
@@ -537,7 +537,7 @@ class GateiosWebsocketApi(WebsocketClient):
 
     def subscribe(self, req: SubscribeRequest):
         """
-        Subscribe to tick data upate.
+        Subscribe to tick data update.
         """
         tick = TickData(
             symbol=req.symbol,

--- a/vnpy/gateway/hsoption/hsoption_gateway.py
+++ b/vnpy/gateway/hsoption/hsoption_gateway.py
@@ -860,7 +860,7 @@ class TdApi:
 
     def subcribe_topic(self, biz_name: str, topic_name: str) -> int:
         """"""
-        # Create subscrbe callback
+        # Create subscribe callback
         sub_callback = py_t2sdk.pySubCallBack(
             "vnpy.gateway.hsoption.hsoption_gateway",
             "TdSubCallback"

--- a/vnpy/gateway/onetoken/onetoken_gateway.py
+++ b/vnpy/gateway/onetoken/onetoken_gateway.py
@@ -413,7 +413,7 @@ class OnetokenDataWebsocketApi(WebsocketClient):
 
     def subscribe(self, req: SubscribeRequest):
         """
-        Subscribe to tick data upate.
+        Subscribe to tick data update.
         """
         self.subscribed[req.vt_symbol] = req
         tick = TickData(
@@ -464,7 +464,7 @@ class OnetokenDataWebsocketApi(WebsocketClient):
 
     def login(self):
         """
-        Need to login befores subscribe to websocket topic.
+        Need to login before subscribe to websocket topic.
         """
         req = {"uri": "auth"}
         self.send_packet(req)

--- a/vnpy/rpc/__init__.py
+++ b/vnpy/rpc/__init__.py
@@ -48,7 +48,7 @@ class RpcServer:
         """
         Constructor
         """
-        # Save functions dict: key is fuction name, value is fuction object
+        # Save functions dict: key is function name, value is function object
         self.__functions: Dict[str, Any] = {}
 
         # Zmq port related


### PR DESCRIPTION
There are small typos in:
- vnpy/api/websocket/websocket_client.py
- vnpy/app/spread_trading/engine.py
- vnpy/gateway/bitfinex/bitfinex_gateway.py
- vnpy/gateway/bitmex/bitmex_gateway.py
- vnpy/gateway/coinbase/coinbase_gateway.py
- vnpy/gateway/gateios/gateios_gateway.py
- vnpy/gateway/hsoption/hsoption_gateway.py
- vnpy/gateway/onetoken/onetoken_gateway.py
- vnpy/rpc/__init__.py

Fixes:
- Should read `websocket` rather than `websockey`.
- Should read `websocket` rather than `webscoket`.
- Should read `subscribe` rather than `subscrbe`.
- Should read `function` rather than `fuction`.
- Should read `function` rather than `fucntion`.
- Should read `enough` rather than `enougth`.
- Should read `currency` rather than `currenct`.
- Should read `update` rather than `upate`.
- Should read `before` rather than `befores`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md