### PR TITLE
Update widget.py

### DIFF
--- a/vnpy/trader/ui/widget.py
+++ b/vnpy/trader/ui/widget.py
@@ -167,6 +167,8 @@ class TimeCell(BaseCell):
         millisecond = int(content.microsecond / 1000)
         if millisecond:
             timestamp = f"{timestamp}.{millisecond}"
+        else:
+            timestamp = f"{timestamp}.000"
 
         self.setText(timestamp)
         self._data = data


### PR DESCRIPTION



## 改进内容

1. 主窗口中，行情tab页签中，时间列，有的时间带有毫秒，有的没有带毫秒，显示的时候 总感觉该列在跳动，影响观感。
现在把没有带毫秒的时间末尾加上3个0，消除这种跳动感。

## 相关的Issue号（如有）

Close #