### PR TITLE
[Fix] RpcGateway增加从远程服务端获取历史数据功能

### DIFF
--- a/vnpy/gateway/rpc/rpc_gateway.py
+++ b/vnpy/gateway/rpc/rpc_gateway.py
@@ -1,12 +1,16 @@
+from typing import List
+
 from vnpy.event import Event
 from vnpy.rpc import RpcClient
 from vnpy.trader.gateway import BaseGateway
 from vnpy.trader.object import (
     SubscribeRequest,
+    HistoryRequest,
     CancelRequest,
     OrderRequest
 )
 from vnpy.trader.constant import Exchange
+from vnpy.trader.object import BarData
 
 
 class RpcGateway(BaseGateway):
@@ -64,6 +68,11 @@ class RpcGateway(BaseGateway):
     def query_position(self):
         """"""
         pass
+
+    def query_history(self, req: HistoryRequest) -> List[BarData]:
+        """"""
+        gateway_name = self.symbol_gateway_map.get(req.vt_symbol, "")
+        return self.client.query_history(req, gateway_name)
 
     def query_all(self):
         """"""


### PR DESCRIPTION
建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 策略初始化的时候一般需要通过load_bars载入一部分历史数据，这里修改RpcGateway使得策略可以通过服务端获取历史数据

## 相关的Issue号（如有）

Close #