### PR TITLE
Update backtesting_demo.ipynb

### DIFF
--- a/examples/cta_backtesting/backtesting_demo.ipynb
+++ b/examples/cta_backtesting/backtesting_demo.ipynb
@@ -3,88 +3,89 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "#%%\r\n",
-    "from vnpy_ctastrategy.backtesting import BacktestingEngine, OptimizationSetting\r\n",
-    "from vnpy_ctastrategy.strategies.atr_rsi_strategy import (\r\n",
-    "    AtrRsiStrategy,\r\n",
-    ")\r\n",
+    "#%%\n",
+    "from vnpy.trader.optimize import OptimizationSetting\n",
+    "from vnpy_ctastrategy.backtesting import BacktestingEngine\n",
+    "from vnpy_ctastrategy.strategies.atr_rsi_strategy import (\n",
+    "    AtrRsiStrategy,\n",
+    ")\n",
     "from datetime import datetime"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "#%%\r\n",
-    "engine = BacktestingEngine()\r\n",
-    "engine.set_parameters(\r\n",
-    "    vt_symbol=\"IF888.CFFEX\",\r\n",
-    "    interval=\"1m\",\r\n",
-    "    start=datetime(2019, 1, 1),\r\n",
-    "    end=datetime(2019, 4, 30),\r\n",
-    "    rate=0.3/10000,\r\n",
-    "    slippage=0.2,\r\n",
-    "    size=300,\r\n",
-    "    pricetick=0.2,\r\n",
-    "    capital=1_000_000,\r\n",
-    ")\r\n",
+    "#%%\n",
+    "engine = BacktestingEngine()\n",
+    "engine.set_parameters(\n",
+    "    vt_symbol=\"IF888.CFFEX\",\n",
+    "    interval=\"1m\",\n",
+    "    start=datetime(2019, 1, 1),\n",
+    "    end=datetime(2019, 4, 30),\n",
+    "    rate=0.3/10000,\n",
+    "    slippage=0.2,\n",
+    "    size=300,\n",
+    "    pricetick=0.2,\n",
+    "    capital=1_000_000,\n",
+    ")\n",
     "engine.add_strategy(AtrRsiStrategy, {})"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
    "source": [
-    "#%%\r\n",
-    "engine.load_data()\r\n",
-    "engine.run_backtesting()\r\n",
-    "df = engine.calculate_result()\r\n",
-    "engine.calculate_statistics()\r\n",
+    "#%%\n",
+    "engine.load_data()\n",
+    "engine.run_backtesting()\n",
+    "df = engine.calculate_result()\n",
+    "engine.calculate_statistics()\n",
     "engine.show_chart()"
-   ],
-   "outputs": [],
-   "metadata": {
-    "scrolled": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
    "source": [
-    "setting = OptimizationSetting()\r\n",
-    "setting.set_target(\"sharpe_ratio\")\r\n",
-    "setting.add_parameter(\"atr_length\", 25, 27, 1)\r\n",
-    "setting.add_parameter(\"atr_ma_length\", 10, 30, 10)\r\n",
-    "\r\n",
+    "setting = OptimizationSetting()\n",
+    "setting.set_target(\"sharpe_ratio\")\n",
+    "setting.add_parameter(\"atr_length\", 25, 27, 1)\n",
+    "setting.add_parameter(\"atr_ma_length\", 10, 30, 10)\n",
+    "\n",
     "engine.run_ga_optimization(setting)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "scrolled": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
    "source": [
     "engine.run_bf_optimization(setting)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "scrolled": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [],
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. V2.4后优化算法移动到trader下，vnpy_ctastrategy.backtesting下无OptimizationSetting类
    故将from vnpy_ctastrategy.backtesting import BacktestingEngine, OptimizationSetting

    改为from vnpy.trader.optimize import OptimizationSetting
            from vnpy_ctastrategy.backtesting import BacktestingEngine

## 相关的Issue号（如有）

Close #