### PR TITLE
Update constant.py

### DIFF
--- a/vnpy/trader/constant.py
+++ b/vnpy/trader/constant.py
@@ -84,6 +84,7 @@ class Exchange(Enum):
     CZCE = "CZCE"           # Zhengzhou Commodity Exchange
     DCE = "DCE"             # Dalian Commodity Exchange
     INE = "INE"             # Shanghai International Energy Exchange
+    GFEX = "GFEX"           # Guangzhou Futures Exchange
     SSE = "SSE"             # Shanghai Stock Exchange
     SZSE = "SZSE"           # Shenzhen Stock Exchange
     BSE = "BSE"             # Beijing Stock Exchange


### PR DESCRIPTION
constant少了广州的期货交易所GFEX，但vnpy_ctp添加了，加载接口时报错

建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. constant少了广州的期货交易所GFEX，但vnpy_ctp添加了，加载接口时报错
2. 
3.

## 相关的Issue号（如有）

Close #