### PR TITLE
[fix] MA_Type object is not callable

### DIFF
--- a/vnpy/trader/utility.py
+++ b/vnpy/trader/utility.py
@@ -1087,9 +1087,9 @@ class ArrayManager:
             self.close,
             fastk_period,
             slowk_period,
-            talib.MA_Type(slowk_matype),
+            slowk_matype,
             slowd_period,
-            talib.MA_Type(slowd_matype)
+            slowd_matype
         )
         if array:
             return k, d


### PR DESCRIPTION
fix
```
Traceback (most recent call last):
  File "/home/baozhu/storage/MoneyGrove/a_main.py", line 170, in <module>
    main()
    ~~~~^^
  File "/home/baozhu/storage/MoneyGrove/a_main.py", line 146, in main
    conditions_met, indicators = check_conditions(bars)
                                 ~~~~~~~~~~~~~~~~^^^^^^
  File "/home/baozhu/storage/MoneyGrove/a_main.py", line 93, in check_conditions
    k, d = am.stoch(9, 3, 0, 3, 0, array=True)  # Correct parameters order: fastk_period, slowk_period, slowk_matype, slowd_period, slowd_matype
           ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/baozhu/anaconda3/envs/vnpy/lib/python3.13/site-packages/vnpy/trader/utility.py", line 1090, in stoch
    talib.MA_Type(slowk_matype),
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^
TypeError: 'MA_Type' object is not callable
```

建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 
2. 
3.

## 相关的Issue号（如有）

Close #