### PR TITLE
Update utility.py

### DIFF
--- a/vnpy/trader/utility.py
+++ b/vnpy/trader/utility.py
@@ -122,6 +122,8 @@ def round_to(value: float, target: float) -> float:
     """
     decimal_value: Decimal = Decimal(str(value))
     decimal_target: Decimal = Decimal(str(target))
+    if target == 0:
+        return value
     rounded: float = float(int(round(decimal_value / decimal_target)) * decimal_target)
     return rounded
 
@@ -132,6 +134,8 @@ def floor_to(value: float, target: float) -> float:
     """
     decimal_value: Decimal = Decimal(str(value))
     decimal_target: Decimal = Decimal(str(target))
+    if target == 0:
+        return value
     result: float = float(int(floor(decimal_value / decimal_target)) * decimal_target)
     return result
 
@@ -142,6 +146,8 @@ def ceil_to(value: float, target: float) -> float:
     """
     decimal_value: Decimal = Decimal(str(value))
     decimal_target: Decimal = Decimal(str(target))
+    if target == 0:
+        return value
     result: float = float(int(ceil(decimal_value / decimal_target)) * decimal_target)
     return result
 


### PR DESCRIPTION
防止除数为0，抛出错误

建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 反正取整时候除数为0，如ib的XAUUSD-USD-CMDTY.SMART品种的最小单位为0，导致开仓错误
2. 
3.

## 相关的Issue号（如有）

Close #