### PR TITLE
Add macOS support: run_no_ctp.py and installation guide

### DIFF
--- a/examples/veighna_trader/run_no_ctp.py
+++ b/examples/veighna_trader/run_no_ctp.py
@@ -1,0 +1,49 @@
+"""
+VeighNa Trader 启动脚本（不依赖 CTP，适合 macOS）
+
+由于 vnpy_ctp 在 macOS 上编译存在问题，此版本使用 PaperAccount（本地仿真账户）
+进行测试，无需连接真实的交易接口。
+"""
+
+from vnpy.event import EventEngine
+
+from vnpy.trader.engine import MainEngine
+from vnpy.trader.ui import MainWindow, create_qapp
+
+# 注释掉 CTP（macOS 上编译有问题）
+# from vnpy_ctp import CtpGateway
+
+# 使用本地仿真账户（不需要编译，纯 Python 实现）
+from vnpy_paperaccount import PaperAccountApp
+
+from vnpy_ctastrategy import CtaStrategyApp
+from vnpy_ctabacktester import CtaBacktesterApp
+from vnpy_datamanager import DataManagerApp
+
+
+def main():
+    """Start VeighNa Trader"""
+    qapp = create_qapp()
+
+    event_engine = EventEngine()
+    main_engine = MainEngine(event_engine)
+    
+    # 不添加 CTP Gateway（macOS 编译问题）
+    # main_engine.add_gateway(CtpGateway)
+    
+    # 添加本地仿真账户（用于测试，无需真实交易接口）
+    main_engine.add_app(PaperAccountApp)
+    
+    # 添加功能模块
+    main_engine.add_app(CtaStrategyApp)
+    main_engine.add_app(CtaBacktesterApp)
+    main_engine.add_app(DataManagerApp)
+
+    main_window = MainWindow(main_engine, event_engine)
+    main_window.showMaximized()
+
+    qapp.exec()
+
+
+if __name__ == "__main__":
+    main()

--- a/macOS_CTP_install_readme.md
+++ b/macOS_CTP_install_readme.md
@@ -1,0 +1,77 @@
+# macOS 上 vnpy_ctp 安装问题说明
+
+## 问题描述
+
+在 macOS 上安装 `vnpy_ctp` 时，会遇到编译错误：
+
+```
+error: unknown type name 'CThostFtdcInvestorInfoCommRecField'
+error: unknown type name 'CThostFtdcCombLegField'
+error: unknown type name 'CThostFtdcInputOffsetSettingField'
+```
+
+这是因为 CTP API 的 macOS 版本头文件中缺少某些类型定义。
+
+## 解决方案
+
+### 方案一：使用本地仿真账户（推荐，用于测试）
+
+`vnpy_paperaccount` 是纯 Python 实现的本地仿真账户，无需编译，适合在 macOS 上测试使用。
+
+**安装：**
+```bash
+source .venv/bin/activate
+uv pip install vnpy_paperaccount
+```
+
+**使用：**
+运行 `examples/veighna_trader/run_no_ctp.py` 而不是 `run.py`
+
+### 方案二：从源代码安装 vnpy_ctp
+
+如果确实需要 CTP 接口，可以尝试从源代码安装：
+
+```bash
+# 1. 克隆仓库
+git clone https://github.com/vnpy/vnpy_ctp.git
+cd vnpy_ctp
+
+# 2. 激活虚拟环境
+source ../.venv/bin/activate  # 回到 vnpy 目录
+
+# 3. 安装
+cd vnpy_ctp
+pip install .
+```
+
+**注意：** 即使从源代码安装，也可能遇到同样的编译错误，因为问题出在 CTP API 的头文件上。
+
+### 方案三：使用其他交易接口
+
+如果不需要 CTP，可以考虑使用其他交易接口：
+
+- **Interactive Brokers (IB)**: `vnpy_ib` - 支持海外市场
+- **TTS (仿真)**: `vnpy_tts` - 国内期货仿真
+- **其他接口**: 根据需求选择
+
+### 方案四：在 Windows/Linux 上使用 CTP
+
+CTP 接口主要针对 Windows 和 Linux 平台设计，在 macOS 上支持不完善。如果必须使用 CTP，建议：
+
+1. 使用 Windows 虚拟机
+2. 使用 Linux 容器（Docker）
+3. 使用远程服务器（Linux）
+
+## 推荐做法
+
+对于 macOS 用户，建议：
+
+1. **开发和测试阶段**：使用 `vnpy_paperaccount`（本地仿真）
+2. **实盘交易**：在 Windows 或 Linux 服务器上运行
+3. **策略开发**：可以在 macOS 上开发策略，然后部署到生产环境
+
+## 相关链接
+
+- [vnpy_ctp GitHub](https://github.com/vnpy/vnpy_ctp)
+- [VeighNa 社区论坛](https://www.vnpy.com/forum/)
+- [VeighNa 文档](https://www.vnpy.com/docs/cn/index.html)


### PR DESCRIPTION
- Add run_no_ctp.py for macOS users (avoids CTP compilation issues)
- Add macOS_CTP_install_readme.md with installation instructions