### PR TITLE
fix: 修复 loguru 格式化错误 (Issue #3715)

### DIFF
--- a/vnpy/trader/engine.py
+++ b/vnpy/trader/engine.py
@@ -329,7 +329,7 @@ class LogEngine(BaseEngine):
 
         log: LogData = event.data
         level: str | int = self.level_map.get(log.level, log.level)
-        logger.log(level, log.msg, gateway_name=log.gateway_name)
+        logger.bind(gateway_name=log.gateway_name).log(level, log.msg)
 
     def register_log(self, event_type: str) -> None:
         """Register log event handler"""


### PR DESCRIPTION
## 问题描述

修复了 `LogEngine` 中 loguru 日志记录时的 `KeyError` 错误。

当调用 `write_log()` 方法记录日志时，会出现以下错误：
```
KeyError: "gateway_name"
```

## 问题原因

在 `vnpy/trader/engine.py` 的第 332 行，代码使用了：
```python
logger.log(level, log.msg, gateway_name=log.gateway_name)
```

loguru 的 `log()` 方法不接受 `gateway_name` 作为关键字参数，导致 `KeyError`。

## 解决方案

将日志记录方式改为使用 `bind()` 方法，将 `gateway_name` 绑定到 loguru 的 `extra` 上下文中：
```python
logger.bind(gateway_name=log.gateway_name).log(level, log.msg)
```

这样符合 loguru 的正确用法，也与 `logger.py` 中的日志格式配置（`{extra[gateway_name]}`）相匹配。

## 修改内容

- 修改文件：`vnpy/trader/engine.py`
- 修改行数：第 332 行
- 修改类型：单行代码修复

## 测试建议

1. 运行应用程序
2. 调用 `write_log()` 方法记录日志
3. 验证日志正常输出，不再出现 `KeyError`

## 相关 Issue

Fixes #3715

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=158349177