### PR TITLE
[Fix]修正BarGenerator的update_tick

### DIFF
--- a/vnpy/trader/utility.py
+++ b/vnpy/trader/utility.py
@@ -237,6 +237,15 @@ class BarGenerator:
                 close_price=tick.last_price,
                 open_interest=tick.open_interest
             )
+
+            if (self.last_tick and tick.high_price > self.last_tick.high_price) or (self.last_tick is None):
+                self.bar.high_price = max(self.bar.high_price, tick.high_price)
+            if (self.last_tick and tick.low_price < self.last_tick.low_price) or (self.last_tick is None):
+                self.bar.low_price = min(self.bar.low_price, tick.low_price)
+
+            if self.last_tick is None:
+                self.bar.volume = max(tick.volume, 0)
+                self.bar.turnover = max(tick.volume, 0)
         elif self.bar:
             self.bar.high_price = max(self.bar.high_price, tick.last_price)
             if self.last_tick and tick.high_price > self.last_tick.high_price:


### PR DESCRIPTION
## 改进内容

1. 修正BarGenerator的update_tick函数在新的bar线第一个tick出现当日最高价或是最低价时，原有算法取不到该值的问题，同步更新初始成交量、成交金额。

## 相关的Issue号（如有）
已与小何在论坛进行了讨论，详见《在BarGenerator利用tick数据合成1分钟bar时，uptick函数在处理9:30的bar时无法取到第1个tick内产生的最低值》
https://www.vnpy.com/forum/topic/34171-zai-bargeneratorli-yong-tickshu-ju-he-cheng-1fen-zhong-barshi-uptickhan-shu-zai-chu-li-9:30de-barshi-wu-fa-qu-dao-di-1ge-ticknei-chan-sheng-de-zui-di-zhi?page=1#pid69504
Close #