### PR TITLE
chore(ci): upgrade GitHub Actions and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  # Python pip 依赖更新
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    reviewers:
+      - "vnpy"
+
+  # GitHub Actions 工作流更新
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python 3.13
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: '3.13'
     - name: Install dependencies


### PR DESCRIPTION
## 变更内容

### CI/CD 改进
- 升级 GitHub Actions 版本：
  - `actions/checkout` v1 → v4
  - `actions/setup-python` v1 → v5

### 依赖管理
- 添加 Dependabot 配置，自动检查：
  - Python pip 依赖（每周一）
  - GitHub Actions 更新（每周一）

### 改进收益
1. 使用最新的 Actions 版本，获得更好的性能和安全性
2. 自动化依赖更新，及时获取安全补丁
3. 减少手动维护工作量

---

**检查清单：**
- [x] 仅修改 CI/CD 配置，不影响核心代码
- [x] 已在本地验证 YAML 语法正确