### PR TITLE
Store timestamp in _text attribute

### DIFF
--- a/vnpy/trader/ui/widget.py
+++ b/vnpy/trader/ui/widget.py
@@ -204,7 +204,8 @@ class TimeCell(BaseCell):
             timestamp = f"{timestamp}.{millisecond}"
         else:
             timestamp = f"{timestamp}.000"
-
+            
+        self._text = timestamp
         self.setText(timestamp)
         self._data = data
 


### PR DESCRIPTION
TimeCell.set_content() 没有设置 self._text
BaseCell.__lt__ 用的是 self._text < other._text，但 TimeCell 的 _text 永远是空字符串 ""。所以排序时所有行被认为相等，Qt 觉得"无需重排"，列头点击完全没反应。 加完 self._text = timestamp 后点击排序就正常了。

建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 
2. 
3.

## 相关的Issue号（如有）

Close #