### PR TITLE
Add Windows venv deployment notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pyo
 *.pyd
 *.egg-info/
+.venv/
 
 # Jupyter
 .ipynb_checkpoints

--- a/DEPLOYMENT_CN.md
+++ b/DEPLOYMENT_CN.md
@@ -4,43 +4,59 @@
 
 - 源码仓库：<https://github.com/vnpy/vnpy>
 - 本地路径：`C:\wmxsk\VNPY\vnpy`
-- 当前分支：`master`
-- 当前提交：`1b78494`
+- 当前分支：`codex/windows-venv-deploy`
 - 隔离方式：Windows Python 虚拟环境 `.venv`
 - Python 版本：`3.12.10 64-bit`
 - VeighNa 版本：`4.4.0`
+- C++ 构建工具：Visual Studio Build Tools 2022，包含 `Microsoft.VisualStudio.Workload.VCTools`
 
-## 已执行的部署步骤
+## 完整部署命令
+
+本机未检测到 Docker，因此本次采用虚拟环境方式隔离部署。`vnpy_ctp` 在 Python 3.12 下需要本机 MSVC 编译器，先安装 Visual Studio C++ 构建工具：
 
 ```powershell
-git clone --depth 1 https://github.com/vnpy/vnpy.git vnpy
-cd C:\wmxsk\VNPY\vnpy
-py -3.12 -m venv .venv
-.\.venv\Scripts\python.exe -m pip install --upgrade pip wheel --index-url https://pypi.org/simple
-.\.venv\Scripts\python.exe -m pip install --extra-index-url https://pypi.vnpy.com ta_lib==0.6.4
-.\.venv\Scripts\python.exe -m pip install . --index-url https://pypi.org/simple
+winget install --id Microsoft.VisualStudio.2022.BuildTools --source winget --accept-package-agreements --accept-source-agreements --override "--wait --quiet --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --norestart"
 ```
 
-也可以直接运行本仓库新增的脚本复现部署和基础校验：
+随后运行仓库脚本安装核心包、官方示例运行插件、alpha/dev 验证依赖并执行基础校验：
 
 ```powershell
+cd C:\wmxsk\VNPY\vnpy
 powershell -NoProfile -ExecutionPolicy Bypass -File .\deploy\windows_venv_install.ps1
 ```
 
-## 校验结果
+如只需要安装核心 `vnpy` 包，可使用：
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\deploy\windows_venv_install.ps1 -CoreOnly
+```
+
+## 已安装的运行插件
+
+- `vnpy_ctp`
+- `vnpy_ctastrategy`
+- `vnpy_ctabacktester`
+- `vnpy_datamanager`
+- `vnpy_sqlite`
+- `.[alpha,dev]`
+- `pytest`、`ruff`、`mypy`、`uv`、`types-tqdm`
+
+## 验证结果
 
 ```text
 pip check: No broken requirements found.
 compileall: compileall-ok
-Python: 3.12.10
-vnpy: 4.4.0
-ta-lib: 0.6.4
-PySide6: 6.8.2.1
-MainEngine: 导入成功
+ruff check .: All checks passed.
+mypy vnpy: Success, no issues found in 60 source files.
+pytest tests: 105 passed, 6 warnings.
+uv build: successfully built dist\vnpy-4.4.0.tar.gz and dist\vnpy-4.4.0-py3-none-any.whl.
+GUI smoke: gui-smoke-ok:0.
 ```
 
-## 说明
+GUI 冒烟测试使用 `QT_QPA_PLATFORM=offscreen` 创建 `MainWindow`，加载 `CtpGateway`、`CtaStrategyApp`、`CtaBacktesterApp` 和 `DataManagerApp`，进入 Qt 事件循环后自动退出。测试过程中出现“未配置数据服务”的提示属于默认配置提示，不影响窗口启动。
 
-- 本机未检测到 Docker 命令，因此本次按用户要求采用虚拟环境方式隔离部署。
+## 代码修复
+
+- 新增 `cast_to_int(feature)` 表达式函数，修复 Alpha101 表达式中 `cast_to_int(...)` 未注册导致的 `NameError`。
+- 为 MLP 批量预测返回值增加明确的 `np.ndarray` 类型变量，修复 mypy 对 `numpy.concatenate(...)` 返回 `Any` 的类型报错。
 - `.venv/` 已加入 `.gitignore`，不会把本地虚拟环境提交到仓库。
-- `tests` 目录当前主要覆盖 `alpha` 可选模块；本次核心部署没有安装 `.[alpha,dev]` 的大型可选依赖，因此未运行完整 alpha 测试。

--- a/DEPLOYMENT_CN.md
+++ b/DEPLOYMENT_CN.md
@@ -1,0 +1,46 @@
+# VeighNa 源码虚拟环境部署摘要
+
+## 本次部署信息
+
+- 源码仓库：<https://github.com/vnpy/vnpy>
+- 本地路径：`C:\wmxsk\VNPY\vnpy`
+- 当前分支：`master`
+- 当前提交：`1b78494`
+- 隔离方式：Windows Python 虚拟环境 `.venv`
+- Python 版本：`3.12.10 64-bit`
+- VeighNa 版本：`4.4.0`
+
+## 已执行的部署步骤
+
+```powershell
+git clone --depth 1 https://github.com/vnpy/vnpy.git vnpy
+cd C:\wmxsk\VNPY\vnpy
+py -3.12 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install --upgrade pip wheel --index-url https://pypi.org/simple
+.\.venv\Scripts\python.exe -m pip install --extra-index-url https://pypi.vnpy.com ta_lib==0.6.4
+.\.venv\Scripts\python.exe -m pip install . --index-url https://pypi.org/simple
+```
+
+也可以直接运行本仓库新增的脚本复现部署和基础校验：
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\deploy\windows_venv_install.ps1
+```
+
+## 校验结果
+
+```text
+pip check: No broken requirements found.
+compileall: compileall-ok
+Python: 3.12.10
+vnpy: 4.4.0
+ta-lib: 0.6.4
+PySide6: 6.8.2.1
+MainEngine: 导入成功
+```
+
+## 说明
+
+- 本机未检测到 Docker 命令，因此本次按用户要求采用虚拟环境方式隔离部署。
+- `.venv/` 已加入 `.gitignore`，不会把本地虚拟环境提交到仓库。
+- `tests` 目录当前主要覆盖 `alpha` 可选模块；本次核心部署没有安装 `.[alpha,dev]` 的大型可选依赖，因此未运行完整 alpha 测试。

--- a/deploy/windows_venv_install.ps1
+++ b/deploy/windows_venv_install.ps1
@@ -1,0 +1,35 @@
+﻿param(
+    [string]$Python = "py",
+    [string[]]$PythonArgs = @("-3.12"),
+    [string]$VenvPath = ".venv",
+    [string]$IndexUrl = "https://pypi.org/simple",
+    [string]$TaLibExtraIndexUrl = "https://pypi.vnpy.com"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# 切换到仓库根目录
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = Resolve-Path (Join-Path $ScriptDir "..")
+Set-Location $RepoRoot
+
+# 创建独立虚拟环境
+if (-not (Test-Path -LiteralPath $VenvPath)) {
+    & $Python @PythonArgs -m venv $VenvPath
+}
+
+$VenvPython = Join-Path $VenvPath "Scripts\python.exe"
+if (-not (Test-Path -LiteralPath $VenvPython)) {
+    throw "未找到虚拟环境 Python: $VenvPython"
+}
+
+# 安装构建工具和依赖
+& $VenvPython -m pip install --upgrade pip wheel --index-url $IndexUrl
+& $VenvPython -m pip install --extra-index-url $TaLibExtraIndexUrl ta_lib==0.6.4
+& $VenvPython -m pip install . --index-url $IndexUrl
+
+# 执行基础部署校验
+& $VenvPython -m pip check
+& $VenvPython -m compileall -q vnpy
+& $VenvPython -c "import sys, vnpy, talib, PySide6; from vnpy.trader.engine import MainEngine; print(sys.version); print(vnpy.__version__); print(talib.__version__); print(PySide6.__version__); print(MainEngine.__name__)"

--- a/deploy/windows_venv_install.ps1
+++ b/deploy/windows_venv_install.ps1
@@ -3,7 +3,8 @@
     [string[]]$PythonArgs = @("-3.12"),
     [string]$VenvPath = ".venv",
     [string]$IndexUrl = "https://pypi.org/simple",
-    [string]$TaLibExtraIndexUrl = "https://pypi.vnpy.com"
+    [string]$TaLibExtraIndexUrl = "https://pypi.vnpy.com",
+    [switch]$CoreOnly
 )
 
 Set-StrictMode -Version Latest
@@ -28,6 +29,28 @@ if (-not (Test-Path -LiteralPath $VenvPython)) {
 & $VenvPython -m pip install --upgrade pip wheel --index-url $IndexUrl
 & $VenvPython -m pip install --extra-index-url $TaLibExtraIndexUrl ta_lib==0.6.4
 & $VenvPython -m pip install . --index-url $IndexUrl
+
+# 安装官方示例和测试验证所需的完整运行环境
+if (-not $CoreOnly) {
+    $Vswhere = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
+    if (-not (Test-Path -LiteralPath $Vswhere)) {
+        throw "未找到 Visual Studio Build Tools。请先安装 C++ 构建工具：winget install --id Microsoft.VisualStudio.2022.BuildTools --source winget --accept-package-agreements --accept-source-agreements --override `"--wait --quiet --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --norestart`""
+    }
+
+    $VsInstallPath = & $Vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+    if (-not $VsInstallPath) {
+        throw "未找到 Visual Studio C++ 工具链，请确认已安装 Microsoft.VisualStudio.Workload.VCTools。"
+    }
+
+    $VsDevCmd = Join-Path $VsInstallPath "Common7\Tools\VsDevCmd.bat"
+    if (-not (Test-Path -LiteralPath $VsDevCmd)) {
+        throw "未找到 VS 开发者命令脚本：$VsDevCmd"
+    }
+
+    # vnpy_ctp 在 Python 3.12 下需要本机 MSVC 编译，因此通过 VS 开发者环境执行 pip。
+    $FullInstallCommand = "`"$VsDevCmd`" -arch=x64 -host_arch=x64 && `"$VenvPython`" -m pip install -e `".[alpha,dev]`" pytest ruff mypy uv types-tqdm vnpy_ctp vnpy_ctastrategy vnpy_ctabacktester vnpy_datamanager vnpy_sqlite --index-url $IndexUrl --extra-index-url $TaLibExtraIndexUrl && `"$VenvPython`" -m pip install scipy-stubs==1.16.3.0 --index-url $IndexUrl"
+    & cmd.exe /d /s /c $FullInstallCommand
+}
 
 # 执行基础部署校验
 & $VenvPython -m pip check

--- a/vnpy/alpha/dataset/math_function.py
+++ b/vnpy/alpha/dataset/math_function.py
@@ -70,6 +70,16 @@ def sign(feature: DataProxy) -> DataProxy:
     return DataProxy(df)
 
 
+def cast_to_int(feature: DataProxy) -> DataProxy:
+    """将特征数据转换为32位整数"""
+    df: pl.DataFrame = feature.df.select(
+        pl.col("datetime"),
+        pl.col("vt_symbol"),
+        pl.col("data").cast(pl.Int32, strict=False).alias("data")
+    )
+    return DataProxy(df)
+
+
 def quesval(threshold: float, feature1: DataProxy, feature2: DataProxy | float | int, feature3: DataProxy | float | int) -> DataProxy:
     """Return feature2 if threshold < feature1, otherwise feature3"""
     df_merged = feature1.df

--- a/vnpy/alpha/dataset/utility.py
+++ b/vnpy/alpha/dataset/utility.py
@@ -232,6 +232,7 @@ def calculate_by_expression(df: pl.DataFrame, expression: str) -> pl.DataFrame:
     from .math_function import (              # noqa
         less, greater, log, abs,
         sign, pow1, pow2,
+        cast_to_int,
         quesval, quesval2
     )
 

--- a/vnpy/alpha/model/models/mlp_model.py
+++ b/vnpy/alpha/model/models/mlp_model.py
@@ -377,7 +377,8 @@ class MlpModel(AlphaModel):
                 predictions.append(self.model(x.to(self.device)).detach().reshape(-1))
 
         if return_cpu:
-            return np.concatenate([pr.cpu().numpy() for pr in predictions])
+            result: np.ndarray = np.concatenate([pr.cpu().numpy() for pr in predictions])
+            return result
         else:
             return torch.cat(predictions, dim=0)
 


### PR DESCRIPTION
## 变更内容

- 新增 Windows 虚拟环境部署脚本 `deploy/windows_venv_install.ps1`
- 新增中文部署摘要 `DEPLOYMENT_CN.md`
- 将 `.venv/` 加入 `.gitignore`，避免提交本地虚拟环境
- 新增 `cast_to_int(feature)` 表达式函数，修复 Alpha101 表达式求值缺少函数注册的问题
- 为 MLP 批量预测返回值增加明确 `np.ndarray` 类型变量，修复 mypy 类型报错

## 背景

在没有 Docker 的 Windows 环境中，使用 Python venv 复现源码安装、官方示例插件安装、wheel 构建和 GUI 启动冒烟流程。`vnpy_ctp` 在 Python 3.12 下需要 MSVC 编译器，因此脚本会检测 Visual Studio C++ Build Tools 并在 VS 开发者环境中安装完整运行依赖。

## 验证

- `powershell -NoProfile -ExecutionPolicy Bypass -File .\deploy\windows_venv_install.ps1`
- `python -m pip check`
- `python -m compileall -q vnpy`
- `python -m ruff check .`
- `python -m mypy vnpy`
- `python -m pytest tests`，结果为 `105 passed, 6 warnings`
- `python -m uv build`
- GUI smoke：offscreen Qt 创建 `MainWindow`，加载 `CtpGateway`、`CtaStrategyApp`、`CtaBacktesterApp`、`DataManagerApp`，结果 `gui-smoke-ok:0`