### PR TITLE
[codex] Add alpha risk metrics

### DIFF
--- a/tests/alpha/test_backtesting_statistics.py
+++ b/tests/alpha/test_backtesting_statistics.py
@@ -1,0 +1,47 @@
+import importlib.util
+from math import sqrt
+from pathlib import Path
+
+module_path = Path(__file__).parents[2] / "vnpy" / "alpha" / "strategy" / "statistics.py"
+spec = importlib.util.spec_from_file_location("alpha_strategy_statistics", module_path)
+statistics = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(statistics)
+
+
+def test_calculate_sharpe_ratio() -> None:
+    """Test annualized Sharpe ratio calculation."""
+    ratio = statistics.calculate_sharpe_ratio(
+        daily_return=0.2,
+        return_std=1,
+        risk_free=0,
+        annual_days=252,
+    )
+
+    assert ratio == 0.2 * sqrt(252)
+
+
+def test_calculate_sortino_ratio() -> None:
+    """Test annualized Sortino ratio calculation."""
+    ratio = statistics.calculate_sortino_ratio(
+        daily_return=0.2,
+        downside_std=0.5,
+        risk_free=0,
+        annual_days=252,
+    )
+
+    assert ratio == 0.4 * sqrt(252)
+
+
+def test_calculate_calmar_ratio() -> None:
+    """Test Calmar ratio calculation."""
+    ratio = statistics.calculate_calmar_ratio(annual_return=18, max_ddpercent=-12)
+
+    assert ratio == 1.5
+
+
+def test_risk_metric_zero_denominators() -> None:
+    """Test risk metrics return zero when denominator is zero."""
+    assert statistics.calculate_sharpe_ratio(1, 0, 0, 252) == 0
+    assert statistics.calculate_sortino_ratio(1, 0, 0, 252) == 0
+    assert statistics.calculate_calmar_ratio(1, 0) == 0

--- a/vnpy/alpha/strategy/backtesting.py
+++ b/vnpy/alpha/strategy/backtesting.py
@@ -17,6 +17,11 @@ from vnpy.trader.utility import round_to, extract_vt_symbol
 from ..logger import logger
 from ..lab import AlphaLab
 from .template import AlphaStrategy
+from .statistics import (
+    calculate_calmar_ratio,
+    calculate_sharpe_ratio,
+    calculate_sortino_ratio,
+)
 
 
 class BacktestingEngine:
@@ -251,7 +256,10 @@ class BacktestingEngine:
         annual_return: float = 0
         daily_return: float = 0
         return_std: float = 0
+        downside_std: float = 0
         sharpe_ratio: float = 0
+        sortino_ratio: float = 0
+        calmar_ratio: float = 0
         return_drawdown_ratio: float = 0
 
         # Check if bankruptcy occurred
@@ -323,12 +331,22 @@ class BacktestingEngine:
             annual_return = total_return / total_days * self.annual_days
             daily_return = cast(float, df["return"].mean()) * 100
             return_std = cast(float, df["return"].std()) * 100
+            downside_returns = df.filter(pl.col("return") < 0)["return"]
+            downside_std = cast(float, downside_returns.std() or 0) * 100
 
-            if return_std:
-                daily_risk_free = self.risk_free / np.sqrt(self.annual_days)
-                sharpe_ratio = (daily_return - daily_risk_free) / return_std * np.sqrt(self.annual_days)
-            else:
-                sharpe_ratio = 0
+            sharpe_ratio = calculate_sharpe_ratio(
+                daily_return,
+                return_std,
+                self.risk_free,
+                self.annual_days
+            )
+            sortino_ratio = calculate_sortino_ratio(
+                daily_return,
+                downside_std,
+                self.risk_free,
+                self.annual_days
+            )
+            calmar_ratio = calculate_calmar_ratio(annual_return, max_ddpercent)
 
             return_drawdown_ratio = -total_net_pnl / max_drawdown
 
@@ -362,7 +380,10 @@ class BacktestingEngine:
 
         logger.info(f"日均收益率：  {daily_return:,.2f}%")
         logger.info(f"收益标准差：  {return_std:,.2f}%")
+        logger.info(f"下行标准差：  {downside_std:,.2f}%")
         logger.info(f"Sharpe Ratio：  {sharpe_ratio:,.2f}")
+        logger.info(f"Sortino Ratio：  {sortino_ratio:,.2f}")
+        logger.info(f"Calmar Ratio：  {calmar_ratio:,.2f}")
         logger.info(f"收益回撤比：  {return_drawdown_ratio:,.2f}")
 
         statistics: dict = {
@@ -388,7 +409,10 @@ class BacktestingEngine:
             "annual_return": annual_return,
             "daily_return": daily_return,
             "return_std": return_std,
+            "downside_std": downside_std,
             "sharpe_ratio": sharpe_ratio,
+            "sortino_ratio": sortino_ratio,
+            "calmar_ratio": calmar_ratio,
             "return_drawdown_ratio": return_drawdown_ratio,
         }
 

--- a/vnpy/alpha/strategy/statistics.py
+++ b/vnpy/alpha/strategy/statistics.py
@@ -1,0 +1,37 @@
+from math import sqrt
+
+
+def calculate_sharpe_ratio(
+    daily_return: float,
+    return_std: float,
+    risk_free: float,
+    annual_days: int
+) -> float:
+    """Calculate annualized Sharpe ratio."""
+    if not return_std:
+        return 0
+
+    daily_risk_free: float = risk_free / sqrt(annual_days)
+    return (daily_return - daily_risk_free) / return_std * sqrt(annual_days)
+
+
+def calculate_sortino_ratio(
+    daily_return: float,
+    downside_std: float,
+    risk_free: float,
+    annual_days: int
+) -> float:
+    """Calculate annualized Sortino ratio."""
+    if not downside_std:
+        return 0
+
+    daily_risk_free: float = risk_free / sqrt(annual_days)
+    return (daily_return - daily_risk_free) / downside_std * sqrt(annual_days)
+
+
+def calculate_calmar_ratio(annual_return: float, max_ddpercent: float) -> float:
+    """Calculate Calmar ratio from annual return and max drawdown percent."""
+    if not max_ddpercent:
+        return 0
+
+    return annual_return / abs(max_ddpercent)


### PR DESCRIPTION
## Summary

- Add reusable alpha strategy statistics helpers for Sharpe, Sortino, and Calmar ratios.
- Include downside standard deviation, Sortino ratio, and Calmar ratio in alpha backtesting statistics output.
- Add focused tests for the new risk metric calculations and zero-denominator behavior.

## Validation

- `pytest tests\alpha\test_backtesting_statistics.py -q`
- `ruff check vnpy\alpha\strategy\statistics.py vnpy\alpha\strategy\backtesting.py tests\alpha\test_backtesting_statistics.py`
- `python -m py_compile vnpy\alpha\strategy\statistics.py vnpy\alpha\strategy\backtesting.py tests\alpha\test_backtesting_statistics.py`
- `git diff --check`

## Notes

Validated locally with an isolated Python 3.12 environment because Python 3.13 was not installed on this machine.