### PR TITLE
Guard empty feature analysis input

### DIFF
--- a/tests/alpha/test_dataset_template.py
+++ b/tests/alpha/test_dataset_template.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+
+import polars as pl
+import pytest
+
+from vnpy.alpha.dataset.template import AlphaDataset
+
+
+def test_show_feature_performance_rejects_empty_factor_data() -> None:
+    """Feature analysis should fail with a clear message before calling alphalens on empty data."""
+    dt = datetime(2025, 1, 2)
+    result_df = pl.DataFrame(
+        {
+            "datetime": [dt],
+            "vt_symbol": ["300866.SZSE"],
+            "close": [1.0],
+        }
+    )
+    learn_df = pl.DataFrame(
+        {
+            "datetime": [dt],
+            "vt_symbol": ["300866.SZSE"],
+            "alpha36": [None],
+        }
+    )
+
+    dataset = AlphaDataset(
+        df=result_df,
+        train_period=("2025-01-01", "2025-01-31"),
+        valid_period=("2025-02-01", "2025-02-28"),
+        test_period=("2025-03-01", "2025-03-31"),
+    )
+    dataset.result_df = result_df
+    dataset.learn_df = learn_df
+
+    with pytest.raises(
+        ValueError,
+        match="No valid rows available for feature performance analysis: alpha36",
+    ):
+        dataset.show_feature_performance("alpha36")

--- a/vnpy/alpha/dataset/template.py
+++ b/vnpy/alpha/dataset/template.py
@@ -222,6 +222,10 @@ class AlphaDataset:
 
         # Fill NaN and drop nulls
         merged_df = merged_df.fill_nan(None).drop_nulls()
+        if merged_df.is_empty():
+            raise ValueError(
+                f"No valid rows available for feature performance analysis: {name}"
+            )
 
         # Extract feature
         feature_df: pd.DataFrame = merged_df.select(["datetime", "vt_symbol", name]).to_pandas()


### PR DESCRIPTION
## Summary
- detect when feature performance analysis has no non-null factor/price rows before calling alphalens
- raise a clear ValueError naming the affected feature instead of surfacing a pandas weekmask crash
- add a regression test for the empty feature-data path

## Testing
- python -m pytest -q tests/alpha/test_dataproxy.py tests/alpha/test_dataset_template.py