### PR TITLE
Document CryptoHFTData historical datafeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ vnpy.alpha模块的设计理念受到[Qlib](https://github.com/microsoft/qlib)�
 
     * :arrow_up: polygon（[polygon](https://www.github.com/vnpy/vnpy_polygon)）：股票、期货、期权
 
+    * CryptoHFTData（[cryptohftdata](https://github.com/hmate9/vnpy_cryptohftdata)）：加密货币TICK、分钟线、小时线、日线
+
 8. :arrow_up: 跨进程通讯标准组件（rpc），用于实现分布式部署的复杂交易系统。
 
 9. :arrow_up: Python高性能K线图表（chart），支持大数据量图表显示以及实时数据更新功能。

--- a/README_ENG.md
+++ b/README_ENG.md
@@ -213,6 +213,8 @@ Modules marked with :arrow_up: have completed the upgrade compatibility testing 
     
     * :arrow_up: polygon ([polygon](https://www.github.com/vnpy/vnpy_polygon)): Stocks, futures, options
 
+    * CryptoHFTData ([cryptohftdata](https://github.com/hmate9/vnpy_cryptohftdata)): Crypto ticks, minute, hourly and daily bars
+
 8. :arrow_up: Standard component for inter-process communication (vnpy.rpc) for implementing complex trading systems in distributed deployments
 
 9. :arrow_up: Python high-performance K-line charts (vnpy.chart), supporting large data volume chart display and real-time data update functions

--- a/docs/community/info/datafeed.md
+++ b/docs/community/info/datafeed.md
@@ -8,7 +8,7 @@
 - datafeed.username：数据服务的用户名；
 - datafeed.password：数据服务的密码。
 
-以上字段对于所有数据服务都是必填的，如果是token方式授权请填写在datafeed.password字段中。目前VeighNa Trader支持以下七种数据服务，**具体每个数据服务的细节可在对应的项目地址中找到**。
+以上字段的具体用途由各数据服务适配器定义，如果是token方式授权通常填写在datafeed.password字段中。**具体每个数据服务的细节可在对应的项目地址中找到**。
 
 ## 迅投研
 
@@ -27,6 +27,16 @@
 - 注册申请：[RICEQUANT](https://www.ricequant.com/welcome/purchase?utm_source=vnpy)
 
 **请注意，配置信息里的username和password不是米筐官网登录用的账号和密码。**
+
+## CryptoHFTData
+
+CryptoHFTData提供多个加密货币交易所的历史高频行情数据。适配器将逐笔成交映射为VeighNa的TICK数据，并可从同一成交数据聚合分钟线、小时线和日线：
+- 项目地址：[vnpy_cryptohftdata](https://github.com/hmate9/vnpy_cryptohftdata)
+- 数据分类：加密货币现货、永续合约和期货
+- 数据周期：TICK、分钟线、小时线、日线
+- 服务文档：[CryptoHFTData](https://cryptohftdata.com/docs)
+
+使用时请将`datafeed.name`设置为`cryptohftdata`，将`datafeed.username`设置为CryptoHFTData交易所标识（例如`binance_futures`）。`datafeed.password`可填写API密钥，也可留空使用限速的免费层。由于VeighNa的`TickData`无法无损表示任意深度的顺序盘口更新，该适配器仅提供逐笔成交和成交聚合K线。
 
 
 ## UData


### PR DESCRIPTION
## Summary

Adds CryptoHFTData to VeighNa's external datafeed catalog in the English and Chinese READMEs and the detailed datafeed guide.

The implementation follows VeighNa's existing external-package convention and lives in [`vnpy_cryptohftdata`](https://github.com/hmate9/vnpy_cryptohftdata). It provides historical crypto trades as native `TickData` plus minute, hourly, and daily bars derived from those trades, with keyless free-tier access and optional API-key authentication.

The guide documents the provider-specific use of `datafeed.username` for the CryptoHFTData exchange identifier and clarifies why arbitrary-depth order-book updates are not exposed through VeighNa's fixed tick model.

Disclosure: I am the creator of CryptoHFTData.

## Validation

- `ruff check .`
- external package: 5 deterministic tests passed
- external package: Ruff and mypy clean; wheel and source distribution build successfully
- keyless live VeighNa workflow validated for KAVAUSDT ticks and trade-derived one-minute bars
