### PR TITLE
feat: add C++ matching engine demo

### DIFF
--- a/examples/cpp_matching_engine/.clang-format
+++ b/examples/cpp_matching_engine/.clang-format
@@ -1,0 +1,6 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 100
+AllowShortFunctionsOnASingleLine: Empty
+BreakBeforeBraces: Attach
+SortIncludes: CaseSensitive

--- a/examples/cpp_matching_engine/.gitignore
+++ b/examples/cpp_matching_engine/.gitignore
@@ -1,0 +1,2 @@
+/build/
+/build-*/

--- a/examples/cpp_matching_engine/CMakeLists.txt
+++ b/examples/cpp_matching_engine/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(vnpy_cpp_matching_engine_demo LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+option(MATCHING_ENGINE_ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
+
+add_library(matching_engine
+    src/matching_engine.cpp
+)
+
+target_include_directories(matching_engine
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+if(MSVC)
+    target_compile_options(matching_engine PRIVATE /W4 /permissive-)
+else()
+    target_compile_options(matching_engine PRIVATE -Wall -Wextra -Wpedantic -Wshadow)
+
+    if(MATCHING_ENGINE_ENABLE_SANITIZERS)
+        target_compile_options(matching_engine PUBLIC -fsanitize=address,undefined -fno-omit-frame-pointer)
+        target_link_options(matching_engine PUBLIC -fsanitize=address,undefined)
+    endif()
+endif()
+
+add_executable(matching_engine_demo
+    src/main.cpp
+)
+target_link_libraries(matching_engine_demo PRIVATE matching_engine)
+
+add_executable(matching_engine_tests
+    tests/test_matching_engine.cpp
+)
+target_link_libraries(matching_engine_tests PRIVATE matching_engine)
+
+add_executable(matching_engine_bench
+    benchmarks/benchmark.cpp
+)
+target_link_libraries(matching_engine_bench PRIVATE matching_engine)
+
+enable_testing()
+add_test(NAME matching_engine_tests COMMAND matching_engine_tests)

--- a/examples/cpp_matching_engine/README.md
+++ b/examples/cpp_matching_engine/README.md
@@ -1,0 +1,278 @@
+# C++ Price-Time Priority Matching Engine Demo
+
+这是一个面向学习和面试交流的单品种撮合引擎。它刻意保持依赖少、规则明确、结果可复现，用来展示订单簿设计、价格时间优先、订单生命周期、正确性验证和延迟测量。
+
+它不是交易所生产系统，也不宣称是 HFT 基础设施。
+
+## 已实现的范围
+
+- C++20，除标准库外无第三方依赖
+- 单品种、单线程、同步、确定性撮合
+- 限价单、市价单和撤单
+- 买卖多档订单簿
+- 价格优先、同价时间优先（FIFO）
+- 部分成交和跨价位成交
+- 成交价取 maker（簿上订单）价格
+- 限价单未成交余量继续挂簿，相当于 GTC
+- 市价单未成交余量立即撤销，相当于 IOC
+- Accepted、Trade、Canceled、Rejected 等顺序事件
+- 订单簿快照和内部不变量检查
+- 命令文件确定性重放
+- 无测试框架依赖的单元测试和随机状态测试
+- 输出 P50/P99/P999 的简单混合负载基准
+
+明确没有实现：改单、FOK、冰山单、STP（自成交保护）、账户和风控、持久化日志、故障恢复、多线程、多品种分片、生产级增量行情发布。
+
+## 撮合语义
+
+1. 合法新订单先产生 `OrderAccepted`。
+2. 买单从最低卖价开始成交，卖单从最高买价开始成交。
+3. 同一个价位按照 `arrival_sequence` 的先后顺序成交。
+4. 成交价格使用 maker 的挂单价格，而不是 taker 的限价。
+5. 每次成交产生一个 `Trade`，其中包含 maker/taker ID、taker方向、成交量以及双方剩余量。
+6. 限价订单的剩余量加入自己的订单簿；市价订单的剩余量产生 `OrderCanceled`。
+7. 已被接受的订单 ID 在一次引擎生命周期内不能复用，即使订单已经成交或撤销。
+8. 协议校验失败的订单没有被接受，因此修正后允许复用相同 ID。
+9. 每条输出事件和每笔成交在单个引擎生命周期内都有全局递增序号，便于审计与确定性重放；`clear()`会开启新的生命周期并重置序号和ID集合。
+
+API约定限价单价格必须大于0，市价单价格必须等于0。对于已经接受过的ID，重复ID拒绝优先于重试请求中其他字段的校验错误。
+
+消费者可以根据 `Trade.maker_remaining` 和 `Trade.taker_remaining` 推导 `PARTTRADED` 或 `ALLTRADED`，Demo没有额外发送 Filled 事件。
+
+## 数据结构
+
+```text
+BidBook: map<Price, PriceLevel, greater<Price>>
+AskBook: map<Price, PriceLevel, less<Price>>
+
+PriceLevel:
+    total_quantity
+    list<RestingOrder>       # 同价FIFO
+
+active_orders:
+    unordered_map<OrderId, {side, price, list_iterator}>
+
+seen_order_ids:
+    unordered_set<OrderId>   # 当前引擎生命周期内的已接受ID
+```
+
+选择这些结构是为了让规则和复杂度容易验证：
+
+| 操作 | 复杂度 | 原因 |
+|---|---:|---|
+| 查询最优买卖价 | `O(1)` | 有序映射的 `begin()` |
+| 新增挂单 | `O(log P)` | 查找或创建价位，价位内尾插为 `O(1)` |
+| 撤单 | 平均 `O(log P)` | ID索引平均 `O(1)`，随后按价格查价位 `O(log P)` |
+| 撮合 | `O(F + L)` | `F`为触达订单数，`L`为清空价位数 |
+| 残量挂簿 | 额外 `O(log P)` | 查找己方价位 |
+| 全量快照 | `O(P + N)` | 遍历价位和所有挂单 |
+
+`std::map`和`std::list`会产生节点分配，适合清晰的面试 Demo，但不是最低延迟实现。为拒绝终态订单ID复用，`seen_order_ids`在生命周期内只增不减，这也是长时间运行时需要用会话化ID或持久化去重机制解决的Demo取舍。生产版本还可以讨论预分配对象池、intrusive list、稠密价格数组、缓存局部性和按品种分片。
+
+## 构建和运行
+
+在本目录执行：
+
+```bash
+cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+运行内置场景：
+
+```bash
+./build/matching_engine_demo
+```
+
+内置场景会依次展示：
+
+1. 两笔同价卖单进入FIFO队列；
+2. 一笔限价买单先吃掉队首，再部分成交第二笔；
+3. 一笔市价买单跨两档扫单；
+4. 市价单无法成交的余量自动撤销；
+5. 普通挂单撤单和不变量检查。
+
+交互模式：
+
+```bash
+./build/matching_engine_demo --interactive
+```
+
+支持的指令如下，价格均使用整数 tick：
+
+```text
+LIMIT  <id> <BUY|SELL> <price> <qty>
+MARKET <id> <BUY|SELL> <qty>
+CANCEL <id>
+BOOK [depth]
+CHECK
+QUIT
+```
+
+重放示例命令：
+
+```bash
+./build/matching_engine_demo --file examples/demo_commands.txt
+```
+
+## 正确性验证
+
+测试覆盖以下关键规则：
+
+- 买卖方向对称
+- maker价格成交
+- 更优价格优先
+- 同价FIFO
+- 部分成交和价位汇总量更新
+- 跨档扫单
+- 限价余量挂簿
+- 市价余量撤销
+- 撤销价位中的头部、中间和最后一笔订单
+- 活动、已成交和已撤销订单ID去重
+- 非法ID、数量和价格
+- 价位总量整数溢出保护
+- 事件与成交序号递增
+- 相同命令重放得到完全一致的事件和快照
+- 5,000步确定性随机命令过程中持续检查内部不变量
+
+引擎的核心不变量包括：
+
+- 不存在空价位；
+- 所有挂单剩余量大于0；
+- 价位汇总量等于该价位所有订单剩余量之和；
+- 同价订单的到达序号严格递增；
+- 订单簿与订单ID索引一一对应；
+- 每个活动订单都属于已接受ID集合；
+- 一条命令处理结束后，最优买价严格低于最优卖价。
+
+Sanitizer验证：
+
+```bash
+cmake -S . -B build-asan -G Ninja \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DMATCHING_ENGINE_ENABLE_SANITIZERS=ON
+cmake --build build-asan
+ctest --test-dir build-asan --output-on-failure
+```
+
+## 基准测试
+
+使用 Release 构建，不要用 Debug 数字讨论性能：
+
+```bash
+cmake -S . -B build-release -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake --build build-release
+./build-release/matching_engine_bench --operations 1000000 --seed 42
+```
+
+混合负载为55%非交叉限价挂单、35%撤单、10%市价单。基准复用事件缓冲区，单次延迟只包围 `submit/cancel` 调用；吞吐量则包含随机负载生成、候选订单维护以及逐操作计时。因此二者口径不同，需要分别解释。
+
+程序会分别报告限价挂单、撤单和市价单的延迟分布，并输出整体吞吐量：
+
+```text
+throughput_ops_per_second
+limit_latency_p50/p99/p999_ns
+cancel_latency_p50/p99/p999_ns
+market_latency_p50/p99/p999_ns
+active_orders_initial/final
+events_generated
+trades_final
+```
+
+这些数字是本机进程内微基准，不包含网络、序列化、风控、持久化、CPU绑核、NUMA和真实行情突发，也没有消除操作系统调度噪声。每笔延迟还包含两次 `steady_clock::now()` 的计时开销；订单簿和 `seen_order_ids` 会随当前混合负载增长，因此它不是严格的稳态测试。不要把一次运行的结果包装成生产性能结论；面试中应报告编译模式、硬件、负载、订单簿深度、轮数以及分位数。
+
+## 与 vn.py 的关系
+
+vn.py在实盘中负责策略、订单路由、OMS和交易接口适配；真正撮合通常发生在交易所。当前版本尚未接入vn.py，下面是把这个Demo作为本地仿真交易所的下一步适配设计：
+
+```text
+vn.py Strategy/App
+      |
+      | OrderRequest
+      v
+Custom MatchingGateway
+      |
+      | NewOrder / Cancel
+      v
+C++ MatchingEngine
+      |
+      | Accepted / Trade / Canceled / Rejected
+      v
+Gateway.on_order / Gateway.on_trade
+      |
+      v
+vn.py EventEngine + OmsEngine
+```
+
+适配层需要完成：
+
+- 将 `vt_symbol` 路由到对应品种的引擎实例；
+- 将价格除以最小跳动转换为整数 tick；
+- 把 vn.py 的订单方向、类型和数量转换成引擎命令；
+- 根据事件中的剩余量生成 `OrderData` 状态；
+- 把 `Trade`转换为 `TradeData`并调用 Gateway 回调；
+- 保证订单和成交ID在重启、重放时一致。
+
+当前快照函数只是调试查询接口，并不是生产级增量行情发布器。
+
+公共C++ API假设调用方传入类型合法的枚举值；交互CLI会校验方向、订单类型和完整数值文本。跨语言或网络接入时，适配层仍需进行协议级枚举校验。
+
+## 面试时怎么讲
+
+### 60秒版本
+
+> 我实现了一个单品种、单线程、确定性的C++订单撮合引擎。买卖盘使用按价格排序的map，价位内部使用list维护FIFO，再用unordered_map保存订单ID到链表节点的索引。它支持限价、市价、撤单、部分成交和跨档成交，成交价取maker价格。每个命令会生成带单调序号的领域事件，并通过单元测试、随机状态测试和内部不变量验证正确性。我还写了Release微基准，报告吞吐量和P50/P99/P999，同时明确区分进程内Demo和生产低延迟系统的差距。
+
+### 常见追问
+
+**为什么价格不用 `double`？**
+
+交易价格只能落在最小变动单位上。把价格转换为整数 tick 可以避免浮点比较和哈希的不确定性，例如 `0.1 + 0.2` 无法精确表示的问题。
+
+**为什么是 `map + list + unordered_map`？**
+
+`map`维护价格优先级，`list`稳定地维护同价FIFO，ID索引让撤单无需扫描订单簿。代价是节点分配多、缓存局部性一般，所以它强调正确性和可解释性，而不是声称最低延迟。
+
+**为什么成交价使用 maker 价格？**
+
+taker表示愿意以不差于其限价成交，真正簿上已经存在的报价是maker价格。比如买价105打到卖价100，应当在100成交。
+
+**为什么使用单线程？**
+
+同一个订单簿需要严格确定的全序。单写者模型避免锁竞争，也使事件顺序和重放结果稳定。多核扩展通常优先按品种分片，而不是让多个线程同时修改同一本订单簿。
+
+**撤单是 `O(1)` 吗？**
+
+当前实现不是。ID索引平均 `O(1)` 找到订单，但还要用价格在 `map`中查找价位，所以整体是平均 `O(log P)`。若要进一步优化，可以在handle中保存稳定的价位节点或容器迭代器。
+
+**如何保证正确性？**
+
+除了场景测试，我把订单簿规则写成可执行不变量，并在随机命令序列中周期性检查。相同命令在两个引擎实例中还必须产生完全相同的事件和最终快照。
+
+**如何恢复崩溃？**
+
+当前版本不做持久化。生产化方案会把输入命令或输出事件追加到WAL，周期性生成带序号快照；恢复时加载快照并从最后序号继续重放，同时需要校验和、幂等ID和主备切换协议。
+
+**下一步怎么降低延迟？**
+
+先建立稳定基准，再依次考虑预分配订单池、intrusive list、减少variant/vector分配、稠密价格数组、缓存行布局、CPU绑核和按品种分片。任何优化都必须继续通过相同的不变量和重放测试。
+
+## 五分钟演示顺序
+
+1. 运行 `ctest`，说明先证明规则正确。
+2. 运行内置场景，指着FIFO队列解释价格时间优先。
+3. 展示 `Trade`中的maker、taker和双方剩余量。
+4. 运行一次Release基准，说明测试口径和局限。
+5. 最后说明如何通过自定义Gateway接入vn.py，以及生产化还缺哪些组件。
+
+## 目录结构
+
+```text
+include/matching_engine/matching_engine.hpp  公共类型和引擎API
+src/matching_engine.cpp                      订单簿和撮合实现
+src/main.cpp                                 内置场景、交互CLI和命令重放
+tests/test_matching_engine.cpp               单元与随机状态测试
+benchmarks/benchmark.cpp                     混合负载微基准
+examples/demo_commands.txt                   可重放命令示例
+```

--- a/examples/cpp_matching_engine/benchmarks/benchmark.cpp
+++ b/examples/cpp_matching_engine/benchmarks/benchmark.cpp
@@ -1,0 +1,187 @@
+#include "matching_engine/matching_engine.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace vm = vnpy::matching;
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+struct Options {
+    std::size_t operations{200'000};
+    std::uint64_t seed{42};
+};
+
+Options parse_options(int argc, char **argv) {
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        const std::string argument = argv[i];
+        if (argument == "--operations" && i + 1 < argc) {
+            options.operations = std::stoull(argv[++i]);
+        } else if (argument == "--seed" && i + 1 < argc) {
+            options.seed = std::stoull(argv[++i]);
+        } else if (argument == "--help" || argument == "-h") {
+            std::cout << "Usage: matching_engine_bench [--operations N] [--seed N]\n";
+            std::exit(0);
+        } else {
+            throw std::runtime_error("unknown argument: " + argument);
+        }
+    }
+    if (options.operations == 0) {
+        throw std::runtime_error("operations must be greater than zero");
+    }
+    return options;
+}
+
+std::uint64_t percentile(const std::vector<std::uint64_t> &sorted, double quantile) {
+    const double raw_index = quantile * static_cast<double>(sorted.size() - 1);
+    const auto index = static_cast<std::size_t>(raw_index);
+    return sorted[index];
+}
+
+void print_distribution(std::string_view name, std::vector<std::uint64_t> &latencies) {
+    if (latencies.empty()) {
+        std::cout << name << "_operations=0\n";
+        return;
+    }
+
+    std::sort(latencies.begin(), latencies.end());
+    std::cout << name << "_operations=" << latencies.size() << '\n'
+              << name << "_latency_p50_ns=" << percentile(latencies, 0.50) << '\n'
+              << name << "_latency_p99_ns=" << percentile(latencies, 0.99) << '\n'
+              << name << "_latency_p999_ns=" << percentile(latencies, 0.999) << '\n'
+              << name << "_latency_max_ns=" << latencies.back() << '\n';
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+    try {
+        const Options options = parse_options(argc, argv);
+        vm::MatchingEngine engine;
+        vm::EventBuffer events;
+        events.reserve(32);
+
+        std::mt19937_64 rng(options.seed);
+        vm::OrderId next_id = 1;
+        std::vector<vm::OrderId> cancel_candidates;
+        cancel_candidates.reserve(options.operations + 10'000);
+
+        // Warm the allocator and create a realistic multi-level book.
+        for (std::size_t i = 0; i < 10'000; ++i) {
+            const vm::Side side = (i & 1U) == 0 ? vm::Side::Buy : vm::Side::Sell;
+            const vm::Price price = side == vm::Side::Buy
+                                        ? 9'900 - static_cast<vm::Price>(i % 100)
+                                        : 10'100 + static_cast<vm::Price>(i % 100);
+            const vm::OrderId id = next_id++;
+            engine.submit({id, side, vm::OrderType::Limit, price, 1 + i % 20}, events);
+            cancel_candidates.push_back(id);
+        }
+
+        const std::size_t active_orders_initial = engine.active_order_count();
+        std::vector<std::uint64_t> limit_latencies_ns;
+        std::vector<std::uint64_t> cancel_latencies_ns;
+        std::vector<std::uint64_t> market_latencies_ns;
+        limit_latencies_ns.reserve(options.operations * 55 / 100 + 1);
+        cancel_latencies_ns.reserve(options.operations * 35 / 100 + 1);
+        market_latencies_ns.reserve(options.operations * 10 / 100 + 1);
+        std::size_t events_generated = 0;
+        std::size_t cancel_rejects = 0;
+
+        const auto benchmark_start = Clock::now();
+        for (std::size_t i = 0; i < options.operations; ++i) {
+            const std::uint64_t choice = rng() % 100;
+
+            if (choice < 55) {
+                const vm::Side side = (rng() & 1U) == 0 ? vm::Side::Buy : vm::Side::Sell;
+                const vm::Price price = side == vm::Side::Buy
+                                            ? 9'900 - static_cast<vm::Price>(rng() % 100)
+                                            : 10'100 + static_cast<vm::Price>(rng() % 100);
+                const vm::OrderId id = next_id++;
+                const vm::NewOrder request{id, side, vm::OrderType::Limit, price, 1 + rng() % 20};
+
+                const auto start = Clock::now();
+                engine.submit(request, events);
+                const auto end = Clock::now();
+                limit_latencies_ns.push_back(static_cast<std::uint64_t>(
+                    std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count()));
+                events_generated += events.size();
+                cancel_candidates.push_back(id);
+            } else if (choice < 90) {
+                vm::OrderId id = 0;
+                while (!cancel_candidates.empty()) {
+                    const vm::OrderId candidate = cancel_candidates.back();
+                    cancel_candidates.pop_back();
+                    if (engine.contains(candidate)) {
+                        id = candidate;
+                        break;
+                    }
+                }
+
+                const auto start = Clock::now();
+                engine.cancel(id, events);
+                const auto end = Clock::now();
+                cancel_latencies_ns.push_back(static_cast<std::uint64_t>(
+                    std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count()));
+                events_generated += events.size();
+                if (id == 0) {
+                    ++cancel_rejects;
+                }
+            } else {
+                const vm::Side side = (rng() & 1U) == 0 ? vm::Side::Buy : vm::Side::Sell;
+                const vm::NewOrder request{next_id++, side, vm::OrderType::Market, 0,
+                                           1 + rng() % 25};
+
+                const auto start = Clock::now();
+                engine.submit(request, events);
+                const auto end = Clock::now();
+                market_latencies_ns.push_back(static_cast<std::uint64_t>(
+                    std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count()));
+                events_generated += events.size();
+            }
+        }
+        const auto benchmark_end = Clock::now();
+
+        std::string invariant_error;
+        if (!engine.check_invariants(&invariant_error)) {
+            std::cerr << "invariant check failed: " << invariant_error << '\n';
+            return 1;
+        }
+
+        const double wall_seconds =
+            std::chrono::duration<double>(benchmark_end - benchmark_start).count();
+        const double throughput = static_cast<double>(options.operations) / wall_seconds;
+
+        std::cout << "benchmark=mixed_single_instrument\n"
+                  << "operations=" << options.operations << '\n'
+                  << "seed=" << options.seed << '\n'
+                  << "workload=55%_resting_limit,35%_cancel,10%_market\n"
+                  << std::fixed << std::setprecision(0)
+                  << "throughput_ops_per_second=" << throughput << '\n'
+                  << "events_generated=" << events_generated << '\n'
+                  << "cancel_rejects=" << cancel_rejects << '\n'
+                  << "active_orders_initial=" << active_orders_initial << '\n'
+                  << "active_orders_final=" << engine.active_order_count() << '\n'
+                  << "trades_final=" << engine.last_trade_id() << '\n';
+        print_distribution("limit", limit_latencies_ns);
+        print_distribution("cancel", cancel_latencies_ns);
+        print_distribution("market", market_latencies_ns);
+    } catch (const std::exception &exception) {
+        std::cerr << "benchmark error: " << exception.what() << '\n';
+        return 1;
+    }
+
+    return 0;
+}

--- a/examples/cpp_matching_engine/examples/demo_commands.txt
+++ b/examples/cpp_matching_engine/examples/demo_commands.txt
@@ -1,0 +1,18 @@
+# Price-time priority: order 1 must trade before order 2.
+LIMIT 1 SELL 10100 5
+LIMIT 2 SELL 10100 7
+LIMIT 3 SELL 10200 4
+BOOK
+
+# Cross the best ask. This fills order 1, then partially fills order 2.
+LIMIT 10 BUY 10100 8
+BOOK
+
+# Sweep the remaining asks and cancel any unfilled market quantity.
+MARKET 11 BUY 10
+BOOK
+
+# Rest and cancel an order.
+LIMIT 20 BUY 9900 3
+CANCEL 20
+CHECK

--- a/examples/cpp_matching_engine/include/matching_engine/matching_engine.hpp
+++ b/examples/cpp_matching_engine/include/matching_engine/matching_engine.hpp
@@ -1,0 +1,205 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <list>
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <variant>
+#include <vector>
+
+namespace vnpy::matching {
+
+using OrderId = std::uint64_t;
+using TradeId = std::uint64_t;
+using Sequence = std::uint64_t;
+using Price = std::int64_t;
+using Quantity = std::uint64_t;
+
+enum class Side {
+    Buy,
+    Sell,
+};
+
+enum class OrderType {
+    Limit,
+    Market,
+};
+
+enum class RejectReason {
+    InvalidOrderId,
+    InvalidQuantity,
+    InvalidPrice,
+    QuantityOverflow,
+    DuplicateOrderId,
+};
+
+enum class CancelReason {
+    UserRequested,
+    UnfilledMarketRemainder,
+};
+
+struct NewOrder {
+    OrderId order_id{};
+    Side side{Side::Buy};
+    OrderType type{OrderType::Limit};
+    Price price{};
+    Quantity quantity{};
+
+    bool operator==(const NewOrder &) const = default;
+};
+
+struct OrderAccepted {
+    Sequence sequence{};
+    OrderId order_id{};
+    Side side{Side::Buy};
+    OrderType type{OrderType::Limit};
+    Price price{};
+    Quantity quantity{};
+
+    bool operator==(const OrderAccepted &) const = default;
+};
+
+struct Trade {
+    Sequence sequence{};
+    TradeId trade_id{};
+    OrderId maker_order_id{};
+    OrderId taker_order_id{};
+    Side taker_side{Side::Buy};
+    Price price{};
+    Quantity quantity{};
+    Quantity maker_remaining{};
+    Quantity taker_remaining{};
+
+    bool operator==(const Trade &) const = default;
+};
+
+struct OrderCanceled {
+    Sequence sequence{};
+    OrderId order_id{};
+    Quantity canceled_quantity{};
+    CancelReason reason{CancelReason::UserRequested};
+
+    bool operator==(const OrderCanceled &) const = default;
+};
+
+struct OrderRejected {
+    Sequence sequence{};
+    OrderId order_id{};
+    RejectReason reason{RejectReason::InvalidOrderId};
+
+    bool operator==(const OrderRejected &) const = default;
+};
+
+struct CancelRejected {
+    Sequence sequence{};
+    OrderId order_id{};
+
+    bool operator==(const CancelRejected &) const = default;
+};
+
+using Event = std::variant<OrderAccepted, Trade, OrderCanceled, OrderRejected, CancelRejected>;
+
+using EventBuffer = std::vector<Event>;
+
+struct OrderView {
+    OrderId order_id{};
+    Quantity remaining{};
+    Sequence arrival_sequence{};
+
+    bool operator==(const OrderView &) const = default;
+};
+
+struct PriceLevelView {
+    Price price{};
+    Quantity total_quantity{};
+    std::vector<OrderView> orders;
+
+    bool operator==(const PriceLevelView &) const = default;
+};
+
+struct BookSnapshot {
+    std::vector<PriceLevelView> bids;
+    std::vector<PriceLevelView> asks;
+
+    bool operator==(const BookSnapshot &) const = default;
+};
+
+class MatchingEngine {
+  public:
+    MatchingEngine() = default;
+
+    [[nodiscard]] EventBuffer submit(const NewOrder &request);
+    void submit(const NewOrder &request, EventBuffer &events);
+
+    [[nodiscard]] EventBuffer cancel(OrderId order_id);
+    void cancel(OrderId order_id, EventBuffer &events);
+
+    [[nodiscard]] bool contains(OrderId order_id) const noexcept;
+    [[nodiscard]] std::size_t active_order_count() const noexcept;
+    [[nodiscard]] std::optional<Price> best_bid() const noexcept;
+    [[nodiscard]] std::optional<Price> best_ask() const noexcept;
+    [[nodiscard]] BookSnapshot snapshot(std::size_t depth = 0) const;
+
+    // Intended for tests, diagnostics, and interview discussion. Production
+    // systems commonly compile expensive invariant checks out of the hot path.
+    [[nodiscard]] bool check_invariants(std::string *error = nullptr) const;
+
+    [[nodiscard]] Sequence last_event_sequence() const noexcept;
+    [[nodiscard]] TradeId last_trade_id() const noexcept;
+
+    void clear() noexcept;
+
+  private:
+    struct RestingOrder {
+        OrderId order_id{};
+        Side side{Side::Buy};
+        Price price{};
+        Quantity remaining{};
+        Sequence arrival_sequence{};
+    };
+
+    struct PriceLevel {
+        Quantity total_quantity{};
+        std::list<RestingOrder> orders;
+    };
+
+    using BidBook = std::map<Price, PriceLevel, std::greater<Price>>;
+    using AskBook = std::map<Price, PriceLevel, std::less<Price>>;
+    using OrderIterator = std::list<RestingOrder>::iterator;
+
+    struct OrderHandle {
+        Side side{Side::Buy};
+        Price price{};
+        OrderIterator iterator;
+    };
+
+    BidBook bids_;
+    AskBook asks_;
+    std::unordered_map<OrderId, OrderHandle> active_orders_;
+    std::unordered_set<OrderId> seen_order_ids_;
+
+    Sequence event_sequence_{};
+    TradeId trade_id_{};
+
+    [[nodiscard]] Sequence next_sequence() noexcept;
+    [[nodiscard]] std::optional<RejectReason> validate(const NewOrder &request) const noexcept;
+
+    void match_buy(RestingOrder &taker, OrderType type, EventBuffer &events);
+    void match_sell(RestingOrder &taker, OrderType type, EventBuffer &events);
+    void match_level(RestingOrder &taker, PriceLevel &level, EventBuffer &events);
+    void rest(RestingOrder &&order);
+};
+
+[[nodiscard]] Sequence event_sequence(const Event &event) noexcept;
+[[nodiscard]] std::string_view to_string(Side value) noexcept;
+[[nodiscard]] std::string_view to_string(OrderType value) noexcept;
+[[nodiscard]] std::string_view to_string(RejectReason value) noexcept;
+[[nodiscard]] std::string_view to_string(CancelReason value) noexcept;
+
+} // namespace vnpy::matching

--- a/examples/cpp_matching_engine/src/main.cpp
+++ b/examples/cpp_matching_engine/src/main.cpp
@@ -1,0 +1,317 @@
+#include "matching_engine/matching_engine.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <charconv>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <system_error>
+#include <type_traits>
+#include <utility>
+
+namespace vm = vnpy::matching;
+
+namespace {
+
+std::string upper(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    return value;
+}
+
+std::optional<vm::Side> parse_side(std::string value) {
+    value = upper(std::move(value));
+    if (value == "BUY" || value == "B") {
+        return vm::Side::Buy;
+    }
+    if (value == "SELL" || value == "S") {
+        return vm::Side::Sell;
+    }
+    return std::nullopt;
+}
+
+template <typename T> std::optional<T> parse_integer(const std::string &text) {
+    T value{};
+    const char *begin = text.data();
+    const char *end = text.data() + text.size();
+    const auto [position, error] = std::from_chars(begin, end, value);
+    if (error != std::errc{} || position != end) {
+        return std::nullopt;
+    }
+    return value;
+}
+
+bool has_extra_token(std::istringstream &input) {
+    std::string extra;
+    return static_cast<bool>(input >> extra);
+}
+
+void print_event(const vm::Event &event) {
+    std::visit(
+        [](const auto &value) {
+            using T = std::decay_t<decltype(value)>;
+            std::cout << "  [seq=" << value.sequence << "] ";
+
+            if constexpr (std::is_same_v<T, vm::OrderAccepted>) {
+                std::cout << "ACCEPT order=" << value.order_id
+                          << " side=" << vm::to_string(value.side)
+                          << " type=" << vm::to_string(value.type) << " price=" << value.price
+                          << " qty=" << value.quantity;
+            } else if constexpr (std::is_same_v<T, vm::Trade>) {
+                std::cout << "TRADE id=" << value.trade_id << " maker=" << value.maker_order_id
+                          << " taker=" << value.taker_order_id
+                          << " taker_side=" << vm::to_string(value.taker_side)
+                          << " price=" << value.price << " qty=" << value.quantity
+                          << " maker_rem=" << value.maker_remaining
+                          << " taker_rem=" << value.taker_remaining;
+            } else if constexpr (std::is_same_v<T, vm::OrderCanceled>) {
+                std::cout << "CANCEL order=" << value.order_id << " qty=" << value.canceled_quantity
+                          << " reason=" << vm::to_string(value.reason);
+            } else if constexpr (std::is_same_v<T, vm::OrderRejected>) {
+                std::cout << "REJECT order=" << value.order_id
+                          << " reason=" << vm::to_string(value.reason);
+            } else if constexpr (std::is_same_v<T, vm::CancelRejected>) {
+                std::cout << "CANCEL_REJECT order=" << value.order_id
+                          << " reason=UNKNOWN_OR_TERMINAL_ORDER";
+            }
+            std::cout << '\n';
+        },
+        event);
+}
+
+void print_events(const vm::EventBuffer &events) {
+    for (const vm::Event &event : events) {
+        print_event(event);
+    }
+}
+
+void print_level(const vm::PriceLevelView &level) {
+    std::cout << "  price=" << std::setw(6) << level.price << " total=" << std::setw(4)
+              << level.total_quantity << " fifo=[";
+    for (std::size_t i = 0; i < level.orders.size(); ++i) {
+        const vm::OrderView &order = level.orders[i];
+        if (i != 0) {
+            std::cout << ", ";
+        }
+        std::cout << order.order_id << ':' << order.remaining;
+    }
+    std::cout << "]\n";
+}
+
+void print_book(const vm::MatchingEngine &engine, std::size_t depth = 0) {
+    const vm::BookSnapshot book = engine.snapshot(depth);
+    std::cout << "ASKS (best first)\n";
+    for (const vm::PriceLevelView &level : book.asks) {
+        print_level(level);
+    }
+    std::cout << "------------------------------\n";
+    std::cout << "BIDS (best first)\n";
+    for (const vm::PriceLevelView &level : book.bids) {
+        print_level(level);
+    }
+    std::cout << "active_orders=" << engine.active_order_count() << "\n";
+}
+
+void print_help() {
+    std::cout << "Commands (all prices are integer ticks):\n"
+              << "  LIMIT  <id> <BUY|SELL> <price> <qty>\n"
+              << "  MARKET <id> <BUY|SELL> <qty>\n"
+              << "  CANCEL <id>\n"
+              << "  BOOK [depth]       0 or omitted means all levels\n"
+              << "  CHECK              validate internal invariants\n"
+              << "  HELP\n"
+              << "  QUIT\n";
+}
+
+bool process_line(vm::MatchingEngine &engine, std::string line) {
+    const std::size_t comment = line.find('#');
+    if (comment != std::string::npos) {
+        line.erase(comment);
+    }
+
+    std::istringstream input(line);
+    std::string command;
+    if (!(input >> command)) {
+        return true;
+    }
+    command = upper(std::move(command));
+
+    if (command == "LIMIT") {
+        std::string id_text;
+        std::string side_text;
+        std::string price_text;
+        std::string quantity_text;
+        if (!(input >> id_text >> side_text >> price_text >> quantity_text) ||
+            has_extra_token(input)) {
+            std::cout << "error: expected LIMIT <id> <BUY|SELL> <price> <qty>\n";
+            return true;
+        }
+        const auto id = parse_integer<vm::OrderId>(id_text);
+        const auto side = parse_side(side_text);
+        const auto price = parse_integer<vm::Price>(price_text);
+        const auto quantity = parse_integer<vm::Quantity>(quantity_text);
+        if (!id.has_value() || !side.has_value() || !price.has_value() || !quantity.has_value()) {
+            std::cout << "error: invalid LIMIT field\n";
+            return true;
+        }
+        print_events(engine.submit(vm::NewOrder{
+            .order_id = *id,
+            .side = *side,
+            .type = vm::OrderType::Limit,
+            .price = *price,
+            .quantity = *quantity,
+        }));
+    } else if (command == "MARKET") {
+        std::string id_text;
+        std::string side_text;
+        std::string quantity_text;
+        if (!(input >> id_text >> side_text >> quantity_text) || has_extra_token(input)) {
+            std::cout << "error: expected MARKET <id> <BUY|SELL> <qty>\n";
+            return true;
+        }
+        const auto id = parse_integer<vm::OrderId>(id_text);
+        const auto side = parse_side(side_text);
+        const auto quantity = parse_integer<vm::Quantity>(quantity_text);
+        if (!id.has_value() || !side.has_value() || !quantity.has_value()) {
+            std::cout << "error: invalid MARKET field\n";
+            return true;
+        }
+        print_events(engine.submit(vm::NewOrder{
+            .order_id = *id,
+            .side = *side,
+            .type = vm::OrderType::Market,
+            .price = 0,
+            .quantity = *quantity,
+        }));
+    } else if (command == "CANCEL") {
+        std::string id_text;
+        if (!(input >> id_text) || has_extra_token(input)) {
+            std::cout << "error: expected CANCEL <id>\n";
+            return true;
+        }
+        const auto id = parse_integer<vm::OrderId>(id_text);
+        if (!id.has_value()) {
+            std::cout << "error: invalid order ID\n";
+            return true;
+        }
+        print_events(engine.cancel(*id));
+    } else if (command == "BOOK") {
+        std::size_t depth = 0;
+        std::string depth_text;
+        if (input >> depth_text) {
+            const auto parsed_depth = parse_integer<std::size_t>(depth_text);
+            if (!parsed_depth.has_value() || has_extra_token(input)) {
+                std::cout << "error: depth must be a non-negative integer\n";
+                return true;
+            }
+            depth = *parsed_depth;
+        }
+        print_book(engine, depth);
+    } else if (command == "CHECK") {
+        std::string error;
+        if (engine.check_invariants(&error)) {
+            std::cout << "invariants: OK\n";
+        } else {
+            std::cout << "invariants: FAILED: " << error << '\n';
+        }
+    } else if (command == "HELP") {
+        print_help();
+    } else if (command == "QUIT" || command == "EXIT") {
+        return false;
+    } else {
+        std::cout << "error: unknown command '" << command << "'\n";
+    }
+
+    return true;
+}
+
+void run_stream(vm::MatchingEngine &engine, std::istream &input, bool prompt) {
+    std::string line;
+    while (true) {
+        if (prompt) {
+            std::cout << "> " << std::flush;
+        }
+        if (!std::getline(input, line)) {
+            break;
+        }
+        if (!process_line(engine, line)) {
+            break;
+        }
+    }
+}
+
+void submit_and_show(vm::MatchingEngine &engine, const vm::NewOrder &order) {
+    std::cout << "\n>>> " << vm::to_string(order.type) << ' ' << order.order_id << ' '
+              << vm::to_string(order.side);
+    if (order.type == vm::OrderType::Limit) {
+        std::cout << " price=" << order.price;
+    }
+    std::cout << " qty=" << order.quantity << '\n';
+    print_events(engine.submit(order));
+}
+
+void run_builtin_demo() {
+    vm::MatchingEngine engine;
+    std::cout << "Price-time-priority matching demo\n"
+              << "Prices are represented as integer ticks.\n";
+
+    submit_and_show(engine, {100, vm::Side::Sell, vm::OrderType::Limit, 10'100, 5});
+    submit_and_show(engine, {101, vm::Side::Sell, vm::OrderType::Limit, 10'100, 7});
+    submit_and_show(engine, {102, vm::Side::Sell, vm::OrderType::Limit, 10'200, 4});
+
+    std::cout << "\nTwo orders share price 10100; order 100 is first in FIFO.\n";
+    print_book(engine);
+
+    submit_and_show(engine, {200, vm::Side::Buy, vm::OrderType::Limit, 10'100, 8});
+    std::cout << "\nOrder 200 fills order 100 first, then partially fills order 101.\n";
+    print_book(engine);
+
+    submit_and_show(engine, {201, vm::Side::Buy, vm::OrderType::Market, 0, 10});
+    std::cout << "\nThe market order sweeps all asks; its unmatched remainder is canceled.\n";
+    print_book(engine);
+
+    submit_and_show(engine, {300, vm::Side::Buy, vm::OrderType::Limit, 9'900, 3});
+    std::cout << "\n>>> CANCEL 300\n";
+    print_events(engine.cancel(300));
+
+    std::string error;
+    std::cout << "\nInvariant check: " << (engine.check_invariants(&error) ? "OK" : error) << '\n';
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+    if (argc == 1) {
+        run_builtin_demo();
+        return 0;
+    }
+
+    const std::string option = argv[1];
+    vm::MatchingEngine engine;
+
+    if (option == "--interactive" || option == "-i") {
+        print_help();
+        run_stream(engine, std::cin, true);
+        return 0;
+    }
+
+    if (option == "--file" && argc == 3) {
+        std::ifstream file(argv[2]);
+        if (!file) {
+            std::cerr << "failed to open command file: " << argv[2] << '\n';
+            return 1;
+        }
+        run_stream(engine, file, false);
+        return 0;
+    }
+
+    std::cout << "Usage:\n"
+              << "  matching_engine_demo             run built-in scenario\n"
+              << "  matching_engine_demo -i          interactive mode\n"
+              << "  matching_engine_demo --file PATH replay command file\n";
+    return option == "--help" || option == "-h" ? 0 : 1;
+}

--- a/examples/cpp_matching_engine/src/matching_engine.cpp
+++ b/examples/cpp_matching_engine/src/matching_engine.cpp
@@ -1,0 +1,456 @@
+#include "matching_engine/matching_engine.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <iterator>
+#include <limits>
+#include <utility>
+
+namespace vnpy::matching {
+
+namespace {
+
+void set_error(std::string *error, std::string message) {
+    if (error != nullptr) {
+        *error = std::move(message);
+    }
+}
+
+} // namespace
+
+EventBuffer MatchingEngine::submit(const NewOrder &request) {
+    EventBuffer events;
+    events.reserve(8);
+    submit(request, events);
+    return events;
+}
+
+void MatchingEngine::submit(const NewOrder &request, EventBuffer &events) {
+    events.clear();
+
+    if (const auto reason = validate(request); reason.has_value()) {
+        events.emplace_back(OrderRejected{
+            .sequence = next_sequence(),
+            .order_id = request.order_id,
+            .reason = *reason,
+        });
+        return;
+    }
+
+    seen_order_ids_.insert(request.order_id);
+
+    const Sequence arrival_sequence = next_sequence();
+    events.emplace_back(OrderAccepted{
+        .sequence = arrival_sequence,
+        .order_id = request.order_id,
+        .side = request.side,
+        .type = request.type,
+        .price = request.price,
+        .quantity = request.quantity,
+    });
+
+    RestingOrder taker{
+        .order_id = request.order_id,
+        .side = request.side,
+        .price = request.price,
+        .remaining = request.quantity,
+        .arrival_sequence = arrival_sequence,
+    };
+
+    if (request.side == Side::Buy) {
+        match_buy(taker, request.type, events);
+    } else {
+        match_sell(taker, request.type, events);
+    }
+
+    if (taker.remaining == 0) {
+        return;
+    }
+
+    if (request.type == OrderType::Limit) {
+        rest(std::move(taker));
+    } else {
+        events.emplace_back(OrderCanceled{
+            .sequence = next_sequence(),
+            .order_id = taker.order_id,
+            .canceled_quantity = taker.remaining,
+            .reason = CancelReason::UnfilledMarketRemainder,
+        });
+    }
+}
+
+EventBuffer MatchingEngine::cancel(OrderId order_id) {
+    EventBuffer events;
+    events.reserve(1);
+    cancel(order_id, events);
+    return events;
+}
+
+void MatchingEngine::cancel(OrderId order_id, EventBuffer &events) {
+    events.clear();
+
+    const auto handle_it = active_orders_.find(order_id);
+    if (handle_it == active_orders_.end()) {
+        events.emplace_back(CancelRejected{
+            .sequence = next_sequence(),
+            .order_id = order_id,
+        });
+        return;
+    }
+
+    const OrderHandle handle = handle_it->second;
+    const Quantity canceled_quantity = handle.iterator->remaining;
+
+    if (handle.side == Side::Buy) {
+        const auto level_it = bids_.find(handle.price);
+        assert(level_it != bids_.end());
+        PriceLevel &level = level_it->second;
+        assert(level.total_quantity >= canceled_quantity);
+        level.total_quantity -= canceled_quantity;
+        level.orders.erase(handle.iterator);
+        active_orders_.erase(handle_it);
+        if (level.orders.empty()) {
+            bids_.erase(level_it);
+        }
+    } else {
+        const auto level_it = asks_.find(handle.price);
+        assert(level_it != asks_.end());
+        PriceLevel &level = level_it->second;
+        assert(level.total_quantity >= canceled_quantity);
+        level.total_quantity -= canceled_quantity;
+        level.orders.erase(handle.iterator);
+        active_orders_.erase(handle_it);
+        if (level.orders.empty()) {
+            asks_.erase(level_it);
+        }
+    }
+
+    events.emplace_back(OrderCanceled{
+        .sequence = next_sequence(),
+        .order_id = order_id,
+        .canceled_quantity = canceled_quantity,
+        .reason = CancelReason::UserRequested,
+    });
+}
+
+bool MatchingEngine::contains(OrderId order_id) const noexcept {
+    return active_orders_.contains(order_id);
+}
+
+std::size_t MatchingEngine::active_order_count() const noexcept {
+    return active_orders_.size();
+}
+
+std::optional<Price> MatchingEngine::best_bid() const noexcept {
+    if (bids_.empty()) {
+        return std::nullopt;
+    }
+    return bids_.begin()->first;
+}
+
+std::optional<Price> MatchingEngine::best_ask() const noexcept {
+    if (asks_.empty()) {
+        return std::nullopt;
+    }
+    return asks_.begin()->first;
+}
+
+BookSnapshot MatchingEngine::snapshot(std::size_t depth) const {
+    BookSnapshot result;
+
+    const auto append_level = [](const auto &entry, std::vector<PriceLevelView> &output) {
+        const auto &[price, level] = entry;
+        PriceLevelView view{
+            .price = price,
+            .total_quantity = level.total_quantity,
+            .orders = {},
+        };
+        view.orders.reserve(level.orders.size());
+        for (const RestingOrder &order : level.orders) {
+            view.orders.push_back(OrderView{
+                .order_id = order.order_id,
+                .remaining = order.remaining,
+                .arrival_sequence = order.arrival_sequence,
+            });
+        }
+        output.push_back(std::move(view));
+    };
+
+    result.bids.reserve(depth == 0 ? bids_.size() : std::min(depth, bids_.size()));
+    for (const auto &entry : bids_) {
+        if (depth != 0 && result.bids.size() >= depth) {
+            break;
+        }
+        append_level(entry, result.bids);
+    }
+
+    result.asks.reserve(depth == 0 ? asks_.size() : std::min(depth, asks_.size()));
+    for (const auto &entry : asks_) {
+        if (depth != 0 && result.asks.size() >= depth) {
+            break;
+        }
+        append_level(entry, result.asks);
+    }
+
+    return result;
+}
+
+bool MatchingEngine::check_invariants(std::string *error) const {
+    std::size_t order_count = 0;
+
+    const auto check_side = [&](const auto &book, Side expected_side, std::string_view name) {
+        for (const auto &[price, level] : book) {
+            if (level.orders.empty()) {
+                set_error(error, std::string(name) + " contains an empty price level");
+                return false;
+            }
+
+            Quantity total = 0;
+            Sequence previous_sequence = 0;
+            for (const RestingOrder &order : level.orders) {
+                ++order_count;
+                if (order.side != expected_side || order.price != price || order.remaining == 0) {
+                    set_error(error, std::string(name) + " contains an invalid resting order");
+                    return false;
+                }
+                if (previous_sequence != 0 && order.arrival_sequence <= previous_sequence) {
+                    set_error(error, std::string(name) + " violates FIFO arrival order");
+                    return false;
+                }
+                previous_sequence = order.arrival_sequence;
+
+                if (std::numeric_limits<Quantity>::max() - total < order.remaining) {
+                    set_error(error, std::string(name) + " quantity overflow");
+                    return false;
+                }
+                total += order.remaining;
+
+                const auto handle_it = active_orders_.find(order.order_id);
+                if (handle_it == active_orders_.end()) {
+                    set_error(error, std::string(name) + " order is missing from the ID index");
+                    return false;
+                }
+                const OrderHandle &handle = handle_it->second;
+                if (handle.side != expected_side || handle.price != price ||
+                    handle.iterator->order_id != order.order_id) {
+                    set_error(error, std::string(name) + " has a stale ID index entry");
+                    return false;
+                }
+                if (!seen_order_ids_.contains(order.order_id)) {
+                    set_error(error, std::string(name) + " active order is missing from seen IDs");
+                    return false;
+                }
+            }
+
+            if (total != level.total_quantity) {
+                set_error(error, std::string(name) + " aggregate quantity is inconsistent");
+                return false;
+            }
+        }
+        return true;
+    };
+
+    if (!check_side(bids_, Side::Buy, "bid book")) {
+        return false;
+    }
+    if (!check_side(asks_, Side::Sell, "ask book")) {
+        return false;
+    }
+    if (order_count != active_orders_.size()) {
+        set_error(error, "ID index size differs from resting order count");
+        return false;
+    }
+    if (!bids_.empty() && !asks_.empty() && bids_.begin()->first >= asks_.begin()->first) {
+        set_error(error, "book is crossed after matching");
+        return false;
+    }
+
+    if (error != nullptr) {
+        error->clear();
+    }
+    return true;
+}
+
+Sequence MatchingEngine::last_event_sequence() const noexcept {
+    return event_sequence_;
+}
+
+TradeId MatchingEngine::last_trade_id() const noexcept {
+    return trade_id_;
+}
+
+void MatchingEngine::clear() noexcept {
+    bids_.clear();
+    asks_.clear();
+    active_orders_.clear();
+    seen_order_ids_.clear();
+    event_sequence_ = 0;
+    trade_id_ = 0;
+}
+
+Sequence MatchingEngine::next_sequence() noexcept {
+    return ++event_sequence_;
+}
+
+std::optional<RejectReason> MatchingEngine::validate(const NewOrder &request) const noexcept {
+    if (request.order_id == 0) {
+        return RejectReason::InvalidOrderId;
+    }
+    // Once an ID has been accepted, duplicate detection takes precedence over
+    // all mutable order fields supplied by a retrying client.
+    if (seen_order_ids_.contains(request.order_id)) {
+        return RejectReason::DuplicateOrderId;
+    }
+    if (request.quantity == 0) {
+        return RejectReason::InvalidQuantity;
+    }
+    if (request.type == OrderType::Limit && request.price <= 0) {
+        return RejectReason::InvalidPrice;
+    }
+    if (request.type == OrderType::Market && request.price != 0) {
+        return RejectReason::InvalidPrice;
+    }
+    if (request.type == OrderType::Limit) {
+        Quantity level_quantity = 0;
+        if (request.side == Side::Buy) {
+            const auto level_it = bids_.find(request.price);
+            if (level_it != bids_.end()) {
+                level_quantity = level_it->second.total_quantity;
+            }
+        } else {
+            const auto level_it = asks_.find(request.price);
+            if (level_it != asks_.end()) {
+                level_quantity = level_it->second.total_quantity;
+            }
+        }
+
+        if (std::numeric_limits<Quantity>::max() - level_quantity < request.quantity) {
+            return RejectReason::QuantityOverflow;
+        }
+    }
+    return std::nullopt;
+}
+
+void MatchingEngine::match_buy(RestingOrder &taker, OrderType type, EventBuffer &events) {
+    while (taker.remaining > 0 && !asks_.empty()) {
+        auto level_it = asks_.begin();
+        if (type == OrderType::Limit && taker.price < level_it->first) {
+            break;
+        }
+
+        match_level(taker, level_it->second, events);
+        if (level_it->second.orders.empty()) {
+            asks_.erase(level_it);
+        }
+    }
+}
+
+void MatchingEngine::match_sell(RestingOrder &taker, OrderType type, EventBuffer &events) {
+    while (taker.remaining > 0 && !bids_.empty()) {
+        auto level_it = bids_.begin();
+        if (type == OrderType::Limit && taker.price > level_it->first) {
+            break;
+        }
+
+        match_level(taker, level_it->second, events);
+        if (level_it->second.orders.empty()) {
+            bids_.erase(level_it);
+        }
+    }
+}
+
+void MatchingEngine::match_level(RestingOrder &taker, PriceLevel &level, EventBuffer &events) {
+    while (taker.remaining > 0 && !level.orders.empty()) {
+        auto maker_it = level.orders.begin();
+        RestingOrder &maker = *maker_it;
+
+        const Quantity matched = std::min(taker.remaining, maker.remaining);
+        maker.remaining -= matched;
+        taker.remaining -= matched;
+        assert(level.total_quantity >= matched);
+        level.total_quantity -= matched;
+
+        events.emplace_back(Trade{
+            .sequence = next_sequence(),
+            .trade_id = ++trade_id_,
+            .maker_order_id = maker.order_id,
+            .taker_order_id = taker.order_id,
+            .taker_side = taker.side,
+            .price = maker.price,
+            .quantity = matched,
+            .maker_remaining = maker.remaining,
+            .taker_remaining = taker.remaining,
+        });
+
+        if (maker.remaining == 0) {
+            active_orders_.erase(maker.order_id);
+            level.orders.erase(maker_it);
+        }
+    }
+}
+
+void MatchingEngine::rest(RestingOrder &&order) {
+    assert(order.remaining > 0);
+    const OrderId order_id = order.order_id;
+    const Side side = order.side;
+    const Price price = order.price;
+    const Quantity quantity = order.remaining;
+
+    if (side == Side::Buy) {
+        auto [level_it, inserted] = bids_.try_emplace(price);
+        static_cast<void>(inserted);
+        PriceLevel &level = level_it->second;
+        level.orders.push_back(std::move(order));
+        level.total_quantity += quantity;
+        active_orders_.emplace(order_id, OrderHandle{
+                                             .side = side,
+                                             .price = price,
+                                             .iterator = std::prev(level.orders.end()),
+                                         });
+    } else {
+        auto [level_it, inserted] = asks_.try_emplace(price);
+        static_cast<void>(inserted);
+        PriceLevel &level = level_it->second;
+        level.orders.push_back(std::move(order));
+        level.total_quantity += quantity;
+        active_orders_.emplace(order_id, OrderHandle{
+                                             .side = side,
+                                             .price = price,
+                                             .iterator = std::prev(level.orders.end()),
+                                         });
+    }
+}
+
+Sequence event_sequence(const Event &event) noexcept {
+    return std::visit([](const auto &value) { return value.sequence; }, event);
+}
+
+std::string_view to_string(Side value) noexcept {
+    return value == Side::Buy ? "BUY" : "SELL";
+}
+
+std::string_view to_string(OrderType value) noexcept {
+    return value == OrderType::Limit ? "LIMIT" : "MARKET";
+}
+
+std::string_view to_string(RejectReason value) noexcept {
+    switch (value) {
+    case RejectReason::InvalidOrderId:
+        return "INVALID_ORDER_ID";
+    case RejectReason::InvalidQuantity:
+        return "INVALID_QUANTITY";
+    case RejectReason::InvalidPrice:
+        return "INVALID_PRICE";
+    case RejectReason::QuantityOverflow:
+        return "QUANTITY_OVERFLOW";
+    case RejectReason::DuplicateOrderId:
+        return "DUPLICATE_ORDER_ID";
+    }
+    return "UNKNOWN_REJECT_REASON";
+}
+
+std::string_view to_string(CancelReason value) noexcept {
+    return value == CancelReason::UserRequested ? "USER_REQUESTED" : "UNFILLED_MARKET_REMAINDER";
+}
+
+} // namespace vnpy::matching

--- a/examples/cpp_matching_engine/tests/test_matching_engine.cpp
+++ b/examples/cpp_matching_engine/tests/test_matching_engine.cpp
@@ -1,0 +1,515 @@
+#include "matching_engine/matching_engine.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace vm = vnpy::matching;
+
+namespace {
+
+void require(bool condition, const char *expression, int line) {
+    if (!condition) {
+        throw std::runtime_error("line " + std::to_string(line) +
+                                 ": requirement failed: " + expression);
+    }
+}
+
+#define REQUIRE(expression) require(static_cast<bool>(expression), #expression, __LINE__)
+
+std::vector<vm::Trade> trades(const vm::EventBuffer &events) {
+    std::vector<vm::Trade> result;
+    for (const vm::Event &event : events) {
+        if (const auto *trade = std::get_if<vm::Trade>(&event)) {
+            result.push_back(*trade);
+        }
+    }
+    return result;
+}
+
+template <typename T> const T *find_event(const vm::EventBuffer &events) {
+    for (const vm::Event &event : events) {
+        if (const auto *value = std::get_if<T>(&event)) {
+            return value;
+        }
+    }
+    return nullptr;
+}
+
+void require_valid(const vm::MatchingEngine &engine) {
+    std::string error;
+    REQUIRE(engine.check_invariants(&error));
+    REQUIRE(error.empty());
+}
+
+void submit_ignored(vm::MatchingEngine &engine, const vm::NewOrder &order) {
+    vm::EventBuffer events;
+    engine.submit(order, events);
+}
+
+void cancel_ignored(vm::MatchingEngine &engine, vm::OrderId order_id) {
+    vm::EventBuffer events;
+    engine.cancel(order_id, events);
+}
+
+void limit_order_rests() {
+    vm::MatchingEngine engine;
+    const auto events = engine.submit({1, vm::Side::Buy, vm::OrderType::Limit, 100, 7});
+
+    REQUIRE(events.size() == 1);
+    REQUIRE(std::holds_alternative<vm::OrderAccepted>(events[0]));
+    REQUIRE(engine.contains(1));
+    REQUIRE(engine.best_bid() == 100);
+    REQUIRE(!engine.best_ask().has_value());
+
+    const auto book = engine.snapshot();
+    REQUIRE(book.bids.size() == 1);
+    REQUIRE(book.bids[0].total_quantity == 7);
+    REQUIRE(book.bids[0].orders[0].order_id == 1);
+    require_valid(engine);
+}
+
+void execution_uses_maker_price() {
+    vm::MatchingEngine engine;
+    submit_ignored(engine, {1, vm::Side::Sell, vm::OrderType::Limit, 100, 3});
+    const auto events = engine.submit({2, vm::Side::Buy, vm::OrderType::Limit, 105, 3});
+    const auto result = trades(events);
+
+    REQUIRE(result.size() == 1);
+    REQUIRE(result[0].price == 100);
+    REQUIRE(result[0].maker_order_id == 1);
+    REQUIRE(result[0].taker_order_id == 2);
+    REQUIRE(result[0].taker_side == vm::Side::Buy);
+    REQUIRE(engine.active_order_count() == 0);
+    require_valid(engine);
+}
+
+void better_price_matches_first() {
+    vm::MatchingEngine engine;
+    submit_ignored(engine, {1, vm::Side::Sell, vm::OrderType::Limit, 102, 2});
+    submit_ignored(engine, {2, vm::Side::Sell, vm::OrderType::Limit, 101, 2});
+    const auto result = trades(engine.submit({3, vm::Side::Buy, vm::OrderType::Market, 0, 3}));
+
+    REQUIRE(result.size() == 2);
+    REQUIRE(result[0].maker_order_id == 2);
+    REQUIRE(result[0].price == 101);
+    REQUIRE(result[0].quantity == 2);
+    REQUIRE(result[1].maker_order_id == 1);
+    REQUIRE(result[1].price == 102);
+    REQUIRE(result[1].quantity == 1);
+    require_valid(engine);
+}
+
+void fifo_within_price_level() {
+    vm::MatchingEngine engine;
+    submit_ignored(engine, {1, vm::Side::Sell, vm::OrderType::Limit, 100, 5});
+    submit_ignored(engine, {2, vm::Side::Sell, vm::OrderType::Limit, 100, 5});
+    const auto result = trades(engine.submit({3, vm::Side::Buy, vm::OrderType::Market, 0, 7}));
+
+    REQUIRE(result.size() == 2);
+    REQUIRE(result[0].maker_order_id == 1);
+    REQUIRE(result[0].quantity == 5);
+    REQUIRE(result[1].maker_order_id == 2);
+    REQUIRE(result[1].quantity == 2);
+
+    const auto book = engine.snapshot();
+    REQUIRE(book.asks[0].orders.size() == 1);
+    REQUIRE(book.asks[0].orders[0].order_id == 2);
+    REQUIRE(book.asks[0].orders[0].remaining == 3);
+    require_valid(engine);
+}
+
+void partial_fill_updates_aggregates() {
+    vm::MatchingEngine engine;
+    submit_ignored(engine, {10, vm::Side::Buy, vm::OrderType::Limit, 100, 10});
+    const auto result = trades(engine.submit({11, vm::Side::Sell, vm::OrderType::Limit, 99, 4}));
+
+    REQUIRE(result.size() == 1);
+    REQUIRE(result[0].maker_order_id == 10);
+    REQUIRE(result[0].maker_remaining == 6);
+    REQUIRE(result[0].taker_remaining == 0);
+
+    const auto book = engine.snapshot();
+    REQUIRE(book.bids[0].total_quantity == 6);
+    REQUIRE(book.bids[0].orders[0].remaining == 6);
+    require_valid(engine);
+}
+
+void market_remainder_is_canceled() {
+    vm::MatchingEngine engine;
+    submit_ignored(engine, {1, vm::Side::Sell, vm::OrderType::Limit, 100, 2});
+    const auto events = engine.submit({2, vm::Side::Buy, vm::OrderType::Market, 0, 5});
+
+    const auto *canceled = find_event<vm::OrderCanceled>(events);
+    REQUIRE(canceled != nullptr);
+    REQUIRE(canceled->order_id == 2);
+    REQUIRE(canceled->canceled_quantity == 3);
+    REQUIRE(canceled->reason == vm::CancelReason::UnfilledMarketRemainder);
+    REQUIRE(!engine.contains(2));
+    require_valid(engine);
+}
+
+void aggressive_limit_remainder_rests() {
+    vm::MatchingEngine engine;
+    submit_ignored(engine, {1, vm::Side::Sell, vm::OrderType::Limit, 100, 2});
+    const auto events = engine.submit({2, vm::Side::Buy, vm::OrderType::Limit, 105, 5});
+
+    const auto result = trades(events);
+    REQUIRE(result.size() == 1);
+    REQUIRE(result[0].quantity == 2);
+    REQUIRE(result[0].taker_remaining == 3);
+    REQUIRE(engine.contains(2));
+    REQUIRE(engine.best_bid() == 105);
+    REQUIRE(!engine.best_ask().has_value());
+    REQUIRE(engine.snapshot().bids[0].total_quantity == 3);
+    require_valid(engine);
+}
+
+void limit_price_is_a_hard_boundary() {
+    vm::MatchingEngine engine;
+    submit_ignored(engine, {1, vm::Side::Sell, vm::OrderType::Limit, 100, 1});
+    submit_ignored(engine, {2, vm::Side::Sell, vm::OrderType::Limit, 101, 1});
+    const auto events = engine.submit({3, vm::Side::Buy, vm::OrderType::Limit, 100, 2});
+
+    const auto result = trades(events);
+    REQUIRE(result.size() == 1);
+    REQUIRE(result[0].maker_order_id == 1);
+    REQUIRE(result[0].price == 100);
+    REQUIRE(engine.contains(2));
+    REQUIRE(engine.contains(3));
+    REQUIRE(engine.best_bid() == 100);
+    REQUIRE(engine.best_ask() == 101);
+    require_valid(engine);
+}
+
+void cancel_removes_order_and_level() {
+    vm::MatchingEngine engine;
+    submit_ignored(engine, {1, vm::Side::Buy, vm::OrderType::Limit, 100, 4});
+    const auto events = engine.cancel(1);
+
+    const auto *canceled = find_event<vm::OrderCanceled>(events);
+    REQUIRE(canceled != nullptr);
+    REQUIRE(canceled->canceled_quantity == 4);
+    REQUIRE(!engine.contains(1));
+    REQUIRE(!engine.best_bid().has_value());
+
+    const auto second_cancel = engine.cancel(1);
+    REQUIRE(find_event<vm::CancelRejected>(second_cancel) != nullptr);
+    require_valid(engine);
+}
+
+void cancel_middle_order_preserves_fifo() {
+    vm::MatchingEngine engine;
+    submit_ignored(engine, {1, vm::Side::Sell, vm::OrderType::Limit, 100, 1});
+    submit_ignored(engine, {2, vm::Side::Sell, vm::OrderType::Limit, 100, 1});
+    submit_ignored(engine, {3, vm::Side::Sell, vm::OrderType::Limit, 100, 1});
+    cancel_ignored(engine, 2);
+
+    const auto result = trades(engine.submit({4, vm::Side::Buy, vm::OrderType::Market, 0, 2}));
+    REQUIRE(result.size() == 2);
+    REQUIRE(result[0].maker_order_id == 1);
+    REQUIRE(result[1].maker_order_id == 3);
+    require_valid(engine);
+}
+
+void cancel_head_and_tail_preserves_remaining_order() {
+    vm::MatchingEngine engine;
+    submit_ignored(engine, {1, vm::Side::Sell, vm::OrderType::Limit, 100, 1});
+    submit_ignored(engine, {2, vm::Side::Sell, vm::OrderType::Limit, 100, 2});
+    submit_ignored(engine, {3, vm::Side::Sell, vm::OrderType::Limit, 100, 3});
+
+    cancel_ignored(engine, 1);
+    cancel_ignored(engine, 3);
+
+    const auto book = engine.snapshot();
+    REQUIRE(book.asks.size() == 1);
+    REQUIRE(book.asks[0].total_quantity == 2);
+    REQUIRE(book.asks[0].orders.size() == 1);
+    REQUIRE(book.asks[0].orders[0].order_id == 2);
+
+    const auto result = trades(engine.submit({4, vm::Side::Buy, vm::OrderType::Market, 0, 2}));
+    REQUIRE(result.size() == 1);
+    REQUIRE(result[0].maker_order_id == 2);
+    REQUIRE(!engine.best_ask().has_value());
+    require_valid(engine);
+}
+
+void partial_fill_then_cancel_uses_leaves_quantity() {
+    vm::MatchingEngine engine;
+    submit_ignored(engine, {1, vm::Side::Buy, vm::OrderType::Limit, 100, 10});
+    submit_ignored(engine, {2, vm::Side::Sell, vm::OrderType::Market, 0, 4});
+
+    const auto events = engine.cancel(1);
+    const auto *canceled = find_event<vm::OrderCanceled>(events);
+    REQUIRE(canceled != nullptr);
+    REQUIRE(canceled->canceled_quantity == 6);
+    REQUIRE(!engine.contains(1));
+    require_valid(engine);
+}
+
+void duplicate_id_is_rejected_after_terminal_state() {
+    vm::MatchingEngine engine;
+    submit_ignored(engine, {1, vm::Side::Buy, vm::OrderType::Limit, 100, 1});
+    cancel_ignored(engine, 1);
+    const auto events = engine.submit({1, vm::Side::Sell, vm::OrderType::Limit, 101, 1});
+
+    const auto *rejected = find_event<vm::OrderRejected>(events);
+    REQUIRE(rejected != nullptr);
+    REQUIRE(rejected->reason == vm::RejectReason::DuplicateOrderId);
+    require_valid(engine);
+}
+
+void filled_maker_and_taker_ids_cannot_be_reused() {
+    vm::MatchingEngine engine;
+    submit_ignored(engine, {1, vm::Side::Sell, vm::OrderType::Limit, 100, 1});
+    submit_ignored(engine, {2, vm::Side::Buy, vm::OrderType::Market, 0, 1});
+
+    auto events = engine.submit({1, vm::Side::Buy, vm::OrderType::Limit, 99, 1});
+    REQUIRE(find_event<vm::OrderRejected>(events)->reason == vm::RejectReason::DuplicateOrderId);
+    events = engine.submit({2, vm::Side::Buy, vm::OrderType::Limit, 99, 1});
+    REQUIRE(find_event<vm::OrderRejected>(events)->reason == vm::RejectReason::DuplicateOrderId);
+    require_valid(engine);
+}
+
+void invalid_orders_are_rejected() {
+    vm::MatchingEngine engine;
+
+    auto events = engine.submit({0, vm::Side::Buy, vm::OrderType::Limit, 100, 1});
+    REQUIRE(find_event<vm::OrderRejected>(events)->reason == vm::RejectReason::InvalidOrderId);
+
+    events = engine.submit({1, vm::Side::Buy, vm::OrderType::Limit, 100, 0});
+    REQUIRE(find_event<vm::OrderRejected>(events)->reason == vm::RejectReason::InvalidQuantity);
+
+    events = engine.submit({2, vm::Side::Buy, vm::OrderType::Limit, 0, 1});
+    REQUIRE(find_event<vm::OrderRejected>(events)->reason == vm::RejectReason::InvalidPrice);
+
+    // Rejected submissions do not consume their ID; a corrected order can reuse it.
+    events = engine.submit({1, vm::Side::Buy, vm::OrderType::Limit, 100, 1});
+    REQUIRE(find_event<vm::OrderAccepted>(events) != nullptr);
+
+    events = engine.submit({3, vm::Side::Buy, vm::OrderType::Market, 99, 1});
+    REQUIRE(find_event<vm::OrderRejected>(events)->reason == vm::RejectReason::InvalidPrice);
+
+    // A corrected request can reuse an ID that was never accepted.
+    events = engine.submit({3, vm::Side::Buy, vm::OrderType::Market, 0, 1});
+    REQUIRE(find_event<vm::OrderAccepted>(events) != nullptr);
+    REQUIRE(find_event<vm::OrderCanceled>(events) != nullptr);
+
+    // For an accepted ID, duplicate detection takes precedence on retries.
+    events = engine.submit({3, vm::Side::Buy, vm::OrderType::Limit, 0, 0});
+    REQUIRE(find_event<vm::OrderRejected>(events)->reason == vm::RejectReason::DuplicateOrderId);
+    require_valid(engine);
+}
+
+void price_level_quantity_overflow_is_rejected() {
+    vm::MatchingEngine engine;
+    submit_ignored(engine, {
+                               1,
+                               vm::Side::Buy,
+                               vm::OrderType::Limit,
+                               100,
+                               std::numeric_limits<vm::Quantity>::max(),
+                           });
+
+    const auto events = engine.submit({2, vm::Side::Buy, vm::OrderType::Limit, 100, 1});
+    const auto *rejected = find_event<vm::OrderRejected>(events);
+    REQUIRE(rejected != nullptr);
+    REQUIRE(rejected->reason == vm::RejectReason::QuantityOverflow);
+    REQUIRE(!engine.contains(2));
+    require_valid(engine);
+}
+
+void event_sequences_are_monotonic() {
+    vm::MatchingEngine engine;
+    vm::EventBuffer all;
+
+    const auto append = [&](vm::EventBuffer events) {
+        all.insert(all.end(), events.begin(), events.end());
+    };
+
+    append(engine.submit({1, vm::Side::Sell, vm::OrderType::Limit, 100, 2}));
+    append(engine.submit({2, vm::Side::Buy, vm::OrderType::Market, 0, 3}));
+    append(engine.cancel(999));
+
+    REQUIRE(!all.empty());
+    for (std::size_t i = 1; i < all.size(); ++i) {
+        REQUIRE(vm::event_sequence(all[i]) == vm::event_sequence(all[i - 1]) + 1);
+    }
+    REQUIRE(engine.last_event_sequence() == vm::event_sequence(all.back()));
+    REQUIRE(engine.last_trade_id() == 1);
+}
+
+void market_event_order_is_accepted_trades_canceled() {
+    vm::MatchingEngine engine;
+    submit_ignored(engine, {1, vm::Side::Sell, vm::OrderType::Limit, 100, 2});
+    const auto events = engine.submit({2, vm::Side::Buy, vm::OrderType::Market, 0, 5});
+
+    REQUIRE(events.size() == 3);
+    REQUIRE(std::holds_alternative<vm::OrderAccepted>(events[0]));
+    REQUIRE(std::holds_alternative<vm::Trade>(events[1]));
+    REQUIRE(std::holds_alternative<vm::OrderCanceled>(events[2]));
+    REQUIRE(vm::event_sequence(events[1]) == vm::event_sequence(events[0]) + 1);
+    REQUIRE(vm::event_sequence(events[2]) == vm::event_sequence(events[1]) + 1);
+}
+
+void caller_owned_event_buffer_is_reused_safely() {
+    vm::MatchingEngine engine;
+    vm::EventBuffer events{
+        vm::CancelRejected{.sequence = 999, .order_id = 999},
+    };
+
+    engine.submit({1, vm::Side::Buy, vm::OrderType::Limit, 100, 1}, events);
+    REQUIRE(events.size() == 1);
+    REQUIRE(std::holds_alternative<vm::OrderAccepted>(events[0]));
+    REQUIRE(vm::event_sequence(events[0]) == 1);
+
+    engine.cancel(1, events);
+    REQUIRE(events.size() == 1);
+    REQUIRE(std::holds_alternative<vm::OrderCanceled>(events[0]));
+    REQUIRE(vm::event_sequence(events[0]) == 2);
+}
+
+void snapshot_depth_and_clear_work() {
+    vm::MatchingEngine engine;
+    submit_ignored(engine, {1, vm::Side::Buy, vm::OrderType::Limit, 99, 1});
+    submit_ignored(engine, {2, vm::Side::Buy, vm::OrderType::Limit, 98, 1});
+    submit_ignored(engine, {3, vm::Side::Sell, vm::OrderType::Limit, 101, 1});
+    submit_ignored(engine, {4, vm::Side::Sell, vm::OrderType::Limit, 102, 1});
+
+    const auto top = engine.snapshot(1);
+    REQUIRE(top.bids.size() == 1);
+    REQUIRE(top.asks.size() == 1);
+    REQUIRE(top.bids[0].price == 99);
+    REQUIRE(top.asks[0].price == 101);
+
+    engine.clear();
+    REQUIRE(engine.active_order_count() == 0);
+    REQUIRE(!engine.best_bid().has_value());
+    REQUIRE(!engine.best_ask().has_value());
+    REQUIRE(engine.last_event_sequence() == 0);
+    REQUIRE(engine.last_trade_id() == 0);
+
+    // clear() starts a new engine lifecycle, so IDs can be used again.
+    const auto events = engine.submit({1, vm::Side::Buy, vm::OrderType::Limit, 99, 1});
+    REQUIRE(find_event<vm::OrderAccepted>(events) != nullptr);
+    require_valid(engine);
+}
+
+void replay_is_deterministic() {
+    const std::vector<vm::NewOrder> commands{
+        {1, vm::Side::Sell, vm::OrderType::Limit, 100, 2},
+        {2, vm::Side::Sell, vm::OrderType::Limit, 101, 3},
+        {3, vm::Side::Buy, vm::OrderType::Limit, 101, 4},
+        {4, vm::Side::Buy, vm::OrderType::Market, 0, 2},
+    };
+
+    vm::MatchingEngine first;
+    vm::MatchingEngine second;
+    for (const vm::NewOrder &command : commands) {
+        REQUIRE(first.submit(command) == second.submit(command));
+    }
+    REQUIRE(first.cancel(3) == second.cancel(3));
+    REQUIRE(first.snapshot() == second.snapshot());
+    REQUIRE(first.last_event_sequence() == second.last_event_sequence());
+    REQUIRE(first.last_trade_id() == second.last_trade_id());
+    require_valid(first);
+    require_valid(second);
+}
+
+void symmetric_sell_aggression() {
+    vm::MatchingEngine engine;
+    submit_ignored(engine, {1, vm::Side::Buy, vm::OrderType::Limit, 100, 2});
+    submit_ignored(engine, {2, vm::Side::Buy, vm::OrderType::Limit, 101, 2});
+    const auto result = trades(engine.submit({3, vm::Side::Sell, vm::OrderType::Market, 0, 3}));
+
+    REQUIRE(result.size() == 2);
+    REQUIRE(result[0].maker_order_id == 2);
+    REQUIRE(result[0].price == 101);
+    REQUIRE(result[1].maker_order_id == 1);
+    REQUIRE(result[1].price == 100);
+    require_valid(engine);
+}
+
+void randomized_operations_preserve_invariants() {
+    vm::MatchingEngine engine;
+    std::mt19937_64 rng(42);
+    vm::OrderId next_id = 1;
+
+    for (std::size_t i = 0; i < 5'000; ++i) {
+        const std::uint64_t choice = rng() % 10;
+        if (choice < 7) {
+            const vm::Side side = (rng() & 1U) == 0 ? vm::Side::Buy : vm::Side::Sell;
+            const vm::Price price = side == vm::Side::Buy
+                                        ? 9'900 - static_cast<vm::Price>(rng() % 50)
+                                        : 10'100 + static_cast<vm::Price>(rng() % 50);
+            submit_ignored(engine, {next_id++, side, vm::OrderType::Limit, price, 1 + rng() % 20});
+        } else if (choice < 9) {
+            const vm::Side side = (rng() & 1U) == 0 ? vm::Side::Buy : vm::Side::Sell;
+            submit_ignored(engine, {next_id++, side, vm::OrderType::Market, 0, 1 + rng() % 20});
+        } else {
+            const vm::OrderId candidate = next_id > 1 ? 1 + rng() % (next_id - 1) : 1;
+            cancel_ignored(engine, candidate);
+        }
+
+        if (i % 100 == 0) {
+            require_valid(engine);
+        }
+    }
+    require_valid(engine);
+}
+
+} // namespace
+
+int main() {
+    const std::vector<std::pair<std::string, std::function<void()>>> tests{
+        {"limit order rests", limit_order_rests},
+        {"execution uses maker price", execution_uses_maker_price},
+        {"better price matches first", better_price_matches_first},
+        {"FIFO within price level", fifo_within_price_level},
+        {"partial fill updates aggregates", partial_fill_updates_aggregates},
+        {"market remainder is canceled", market_remainder_is_canceled},
+        {"aggressive limit remainder rests", aggressive_limit_remainder_rests},
+        {"limit price is a hard boundary", limit_price_is_a_hard_boundary},
+        {"cancel removes order and level", cancel_removes_order_and_level},
+        {"cancel middle order preserves FIFO", cancel_middle_order_preserves_fifo},
+        {"cancel head and tail preserves remaining order",
+         cancel_head_and_tail_preserves_remaining_order},
+        {"partial fill then cancel uses leaves quantity",
+         partial_fill_then_cancel_uses_leaves_quantity},
+        {"duplicate ID rejected after terminal state",
+         duplicate_id_is_rejected_after_terminal_state},
+        {"filled maker and taker IDs cannot be reused",
+         filled_maker_and_taker_ids_cannot_be_reused},
+        {"invalid orders are rejected", invalid_orders_are_rejected},
+        {"price-level quantity overflow is rejected", price_level_quantity_overflow_is_rejected},
+        {"event sequences are monotonic", event_sequences_are_monotonic},
+        {"market event order is accepted-trades-canceled",
+         market_event_order_is_accepted_trades_canceled},
+        {"caller-owned event buffer is reused safely", caller_owned_event_buffer_is_reused_safely},
+        {"snapshot depth and clear work", snapshot_depth_and_clear_work},
+        {"replay is deterministic", replay_is_deterministic},
+        {"symmetric sell aggression", symmetric_sell_aggression},
+        {"randomized operations preserve invariants", randomized_operations_preserve_invariants},
+    };
+
+    std::size_t passed = 0;
+    for (const auto &[name, test] : tests) {
+        try {
+            test();
+            ++passed;
+            std::cout << "[PASS] " << name << '\n';
+        } catch (const std::exception &exception) {
+            std::cerr << "[FAIL] " << name << ": " << exception.what() << '\n';
+        }
+    }
+
+    std::cout << passed << '/' << tests.size() << " tests passed\n";
+    return passed == tests.size() ? 0 : 1;
+}


### PR DESCRIPTION
本 PR 新增一个用于 Quant Developer 入门学习和面试交流的独立 C++ 撮合引擎 Demo，不修改 vn.py 核心逻辑。

## 改进内容

1. 实现单品种、价格时间优先撮合，支持限价单、市价单、撤单及部分成交。
2. 提供命令行演示、订单重放和订单簿快照。
3. 增加 23 项测试、内部不变量检查、性能基准及学习文档。

后续的 vn.py Gateway 接入、持久化和多品种支持将拆分为独立 PR。