### PR TITLE
[Fix] recalculate frozen position after position update

### DIFF
--- a/tests/trader/test_converter.py
+++ b/tests/trader/test_converter.py
@@ -1,0 +1,109 @@
+import pytest
+
+from vnpy.trader.constant import (
+    Direction,
+    Exchange,
+    Offset,
+    OrderType,
+    Product,
+    Status,
+)
+from vnpy.trader.converter import PositionHolding
+from vnpy.trader.object import ContractData, OrderData, OrderRequest, PositionData
+
+
+def create_holding() -> PositionHolding:
+    contract = ContractData(
+        gateway_name="CTP",
+        symbol="rb",
+        exchange=Exchange.SHFE,
+        name="Rebar",
+        product=Product.FUTURES,
+        size=10,
+        pricetick=1,
+    )
+    return PositionHolding(contract)
+
+
+def create_close_order(
+    direction: Direction,
+    volume: float,
+    traded: float = 0,
+) -> OrderData:
+    return OrderData(
+        gateway_name="CTP",
+        symbol="rb",
+        exchange=Exchange.SHFE,
+        orderid="1",
+        direction=direction,
+        offset=Offset.CLOSETODAY,
+        type=OrderType.LIMIT,
+        volume=volume,
+        traded=traded,
+        status=Status.PARTTRADED if traded > 0 else Status.NOTTRADED,
+    )
+
+
+def create_position(direction: Direction, volume: float) -> PositionData:
+    return PositionData(
+        gateway_name="CTP",
+        symbol="rb",
+        exchange=Exchange.SHFE,
+        direction=direction,
+        volume=volume,
+        yd_volume=0,
+    )
+
+
+@pytest.mark.parametrize(
+    ("position_direction", "order_direction", "td_frozen", "pos_frozen"),
+    [
+        (Direction.LONG, Direction.SHORT, "long_td_frozen", "long_pos_frozen"),
+        (Direction.SHORT, Direction.LONG, "short_td_frozen", "short_pos_frozen"),
+    ],
+)
+def test_position_update_recalculates_frozen_for_existing_order(
+    position_direction: Direction,
+    order_direction: Direction,
+    td_frozen: str,
+    pos_frozen: str,
+) -> None:
+    holding = create_holding()
+    order = create_close_order(order_direction, volume=5, traded=2)
+
+    holding.update_order(order)
+    holding.update_position(create_position(position_direction, volume=5))
+
+    assert len(holding.active_orders) == 1
+    assert getattr(holding, td_frozen) == 3
+    assert getattr(holding, pos_frozen) == 3
+
+
+def test_position_update_caps_frozen_at_reduced_position() -> None:
+    holding = create_holding()
+    holding.update_position(create_position(Direction.LONG, volume=10))
+    holding.update_order(create_close_order(Direction.SHORT, volume=8))
+
+    holding.update_position(create_position(Direction.LONG, volume=5))
+
+    assert holding.long_td_frozen == 5
+    assert holding.long_pos_frozen == 5
+
+
+def test_shfe_fully_frozen_position_rejects_additional_close() -> None:
+    holding = create_holding()
+    holding.update_order(create_close_order(Direction.SHORT, volume=5))
+    holding.update_position(create_position(Direction.LONG, volume=5))
+    request = OrderRequest(
+        symbol="rb",
+        exchange=Exchange.SHFE,
+        direction=Direction.SHORT,
+        type=OrderType.LIMIT,
+        volume=5,
+        offset=Offset.CLOSE,
+    )
+
+    converted = holding.convert_order_request_shfe(request)
+
+    assert holding.long_pos_frozen == holding.long_pos == 5
+    assert converted == []

--- a/vnpy/trader/converter.py
+++ b/vnpy/trader/converter.py
@@ -51,6 +51,8 @@ class PositionHolding:
             self.short_yd = position.yd_volume
             self.short_td = self.short_pos - self.short_yd
 
+        self.calculate_frozen()
+
     def update_order(self, order: OrderData) -> None:
         """"""
         if order.is_active():


### PR DESCRIPTION
## 改进内容

1. 在`PositionHolding.update_position()`更新最新持仓后，根据已有活动委托重新计算冻结量。
2. 新增回归测试，覆盖活动委托早于持仓推送、多空方向、部分成交、持仓缩减后的冻结上限，以及SHFE持仓全部冻结后拒绝重复平仓。
3. 不改变公共API、配置格式或委托转换接口。

## 问题原因

活动委托先于持仓快照到达时，首次冻结量会受当时的零持仓限制。后续`update_position()`仅更新持仓字段，没有再次遍历`active_orders`，导致冻结量长期保持为0，并可能再次生成平仓委托。

## 验证

- Python 3.10、3.13专项测试连续多轮通过（每轮`4 passed`）。
- `ruff check .`和`uv build`通过。
- wheel、sdist安装、`pip check`和公共模块导入通过。
- 完整pytest在两个版本均为`105 passed, 4 failed`；4项失败是`origin/dev`既有的Alpha 62/64/65/68测试仍调用已删除的`cast_to_int`，与本PR无关。
- 当前上游`dev`的mypy门禁也因依赖存根使用Python 3.12语法而失败：[Actions基线](https://github.com/vnpy/vnpy/actions/runs/30319699678)。

## 相关的Issue号（如有）

Close #3791
