### PR TITLE
[Fix] keep RPC client usable after request timeout

### DIFF
--- a/tests/rpc/test_rpc_client.py
+++ b/tests/rpc/test_rpc_client.py
@@ -1,0 +1,113 @@
+from threading import Event
+from typing import Any, cast
+from uuid import uuid4
+
+import pytest
+import zmq
+
+from vnpy.rpc import RpcClient, RpcServer
+from vnpy.rpc.client import RemoteException
+
+
+class RequestSocketProxy:
+    """Release the delayed reply only after the second request is sent."""
+
+    def __init__(self, socket: zmq.Socket, release: Event) -> None:
+        self._socket: zmq.Socket = socket
+        self._release: Event = release
+        self._send_count: int = 0
+
+    def send_pyobj(self, *args: Any, **kwargs: Any) -> Any:
+        result: Any = self._socket.send_pyobj(*args, **kwargs)
+        self._send_count += 1
+
+        if self._send_count == 2:
+            self._release.set()
+
+        return result
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._socket, name)
+
+
+class RpcTestClient(RpcClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.ready: Event = Event()
+
+    def callback(self, topic: str, data: Any) -> None:
+        if topic == "ready":
+            self.ready.set()
+
+
+class RpcTestServer(RpcServer):
+    def __init__(self, entered: Event, release: Event) -> None:
+        super().__init__()
+        self.entered: Event = entered
+        self.release: Event = release
+        self.register(self.slow)
+        self.register(self.ping)
+
+    def slow(self) -> str:
+        self.entered.set()
+        self.release.wait()
+        return "late reply"
+
+    def ping(self) -> str:
+        return "pong"
+
+
+def test_client_remains_usable_after_request_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A late reply must not poison the client or satisfy the next call."""
+    context: zmq.Context = zmq.Context()
+    monkeypatch.setattr(zmq, "Context", lambda: context)
+
+    entered: Event = Event()
+    release: Event = Event()
+    server: RpcTestServer = RpcTestServer(entered, release)
+    client: RpcTestClient = RpcTestClient()
+    client._socket_req = cast(
+        zmq.Socket,
+        RequestSocketProxy(client._socket_req, release),
+    )
+
+    endpoint: str = uuid4().hex
+    rep_address: str = f"inproc://rpc-request-{endpoint}"
+    pub_address: str = f"inproc://rpc-publish-{endpoint}"
+
+    server.start(rep_address, pub_address)
+    client.subscribe_topic("")
+    client.start(rep_address, pub_address)
+    server_thread = server._thread
+    client_thread = client._thread
+    assert server_thread is not None
+    assert client_thread is not None
+
+    try:
+        for _ in range(100):
+            server.publish("ready", None)
+            if client.ready.wait(0.01):
+                break
+        assert client.ready.is_set()
+
+        with pytest.raises(RemoteException, match="Timeout of 100ms reached"):
+            client.slow(timeout=100)
+        assert entered.wait(1)
+
+        assert client.ping(timeout=1_000) == "pong"
+    finally:
+        release.set()
+
+        client.stop()
+        server.publish("stop", None)
+        client.join()
+
+        server.stop()
+        server.join()
+
+        context.term()
+
+    assert not client_thread.is_alive()
+    assert not server_thread.is_alive()

--- a/vnpy/rpc/client.py
+++ b/vnpy/rpc/client.py
@@ -36,6 +36,8 @@ class RpcClient:
 
         # Request socket (Request–reply pattern)
         self._socket_req: zmq.Socket = self._context.socket(zmq.REQ)
+        self._socket_req.setsockopt(zmq.REQ_RELAXED, 1)
+        self._socket_req.setsockopt(zmq.REQ_CORRELATE, 1)
 
         # Subscribe socket (Publish–subscribe pattern)
         self._socket_sub: zmq.Socket = self._context.socket(zmq.SUB)


### PR DESCRIPTION
## 改进内容

1. 为`RpcClient`的REQ socket同时启用`REQ_RELAXED`和`REQ_CORRELATE`。
2. 新增确定性本地回环测试，验证一次请求超时后同一客户端仍能调用，并且迟到的旧响应不会被误认为新请求结果。
3. 不改变RPC公共API、调用参数或现有序列化协议。

## 问题原因

REQ socket默认严格交替执行send/recv。请求超时后旧响应尚未接收，socket仍处于等待响应状态，下一次发送会抛出EFSM错误。只启用`REQ_RELAXED`又会导致迟到响应误配，因此需要同时启用请求关联校验。

## 验证

- Python 3.10、3.13专项测试连续多轮通过（每轮`1 passed`）。
- 回归测试在缺少`REQ_RELAXED`时稳定触发EFSM，在缺少`REQ_CORRELATE`时稳定收到错误的迟到响应。
- `ruff check .`、相关文件mypy和`uv build`通过。
- wheel、sdist安装、`pip check`和公共模块导入通过。
- 完整pytest在两个版本均为`102 passed, 4 failed`；4项失败是`origin/dev`既有的Alpha 62/64/65/68测试仍调用已删除的`cast_to_int`，与本PR无关。
- 当前上游`dev`的mypy门禁也因依赖存根使用Python 3.12语法而失败：[Actions基线](https://github.com/vnpy/vnpy/actions/runs/30319699678)。

## 相关的Issue号（如有）

Close #3792
