### PR TITLE
[Fix] calculate TA indicators separately by symbol

### DIFF
--- a/tests/alpha/test_ta_function.py
+++ b/tests/alpha/test_ta_function.py
@@ -1,0 +1,166 @@
+from collections.abc import Callable
+from datetime import datetime, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+import talib
+
+from vnpy.alpha.dataset.ta_function import ta_atr, ta_rsi
+from vnpy.alpha.dataset.utility import DataProxy
+
+
+WINDOW = 2
+
+
+def make_market_data() -> pl.DataFrame:
+    """Create two interleaved symbols with clearly different price paths."""
+    dates = [datetime(2025, 1, 1) + timedelta(days=i) for i in range(5)]
+    a_close = [10.0, 11.0, 12.0, 13.0, 14.0]
+    b_close = [100.0, 99.0, 98.0, 97.0, 96.0]
+
+    rows: list[dict[str, datetime | str | float]] = []
+    for i, dt in enumerate(dates):
+        rows.extend([
+            {
+                "datetime": dt,
+                "vt_symbol": "A.LOCAL",
+                "high": a_close[i] + 1,
+                "low": a_close[i] - 1,
+                "close": a_close[i],
+            },
+            {
+                "datetime": dt,
+                "vt_symbol": "B.LOCAL",
+                "high": b_close[i] + 4,
+                "low": b_close[i] - 4,
+                "close": b_close[i],
+            },
+        ])
+
+    return pl.DataFrame(rows)
+
+
+def make_proxy(df: pl.DataFrame, column: str) -> DataProxy:
+    """Build a feature proxy without changing its row order."""
+    return DataProxy(df.select(["datetime", "vt_symbol", column]))
+
+
+def get_symbol_positions(df: pl.DataFrame) -> list[np.ndarray]:
+    """Return row positions grouped by first-seen symbol order."""
+    symbols = df["vt_symbol"].to_numpy()
+    return [
+        np.flatnonzero(symbols == symbol)
+        for symbol in df["vt_symbol"].unique(maintain_order=True)
+    ]
+
+
+def calculate_by_symbol(
+    df: pl.DataFrame,
+    function: Callable[..., np.ndarray],
+    columns: list[str],
+) -> np.ndarray:
+    """Calculate a TA-Lib oracle independently for every symbol."""
+    result = np.full(df.height, np.nan)
+
+    for positions in get_symbol_positions(df):
+        arguments = [df[column].to_numpy()[positions] for column in columns]
+        result[positions] = function(*arguments, timeperiod=WINDOW)
+
+    return result
+
+
+def assert_result(
+    result: DataProxy,
+    source: pl.DataFrame,
+    expected: np.ndarray,
+) -> None:
+    """Assert values, key columns and original row order."""
+    assert result.df.columns == ["datetime", "vt_symbol", "data"]
+    assert result.df.select(["datetime", "vt_symbol"]).equals(
+        source.select(["datetime", "vt_symbol"])
+    )
+    np.testing.assert_allclose(result.df["data"].to_numpy(), expected, equal_nan=True)
+
+
+def assert_symbol_warmup(result: DataProxy, source: pl.DataFrame) -> None:
+    """Assert that TA-Lib lookback is applied independently per symbol."""
+    values = result.df["data"].to_numpy()
+
+    for positions in get_symbol_positions(source):
+        assert np.isnan(values[positions[:WINDOW]]).all()
+        assert np.isfinite(values[positions[WINDOW:]]).all()
+
+
+def test_ta_rsi_calculates_each_symbol_separately() -> None:
+    """RSI should not mix interleaved observations from other symbols."""
+    df = make_market_data()
+    expected = calculate_by_symbol(df, talib.RSI, ["close"])
+
+    result = ta_rsi(make_proxy(df, "close"), WINDOW)
+
+    assert_result(result, df, expected)
+    assert_symbol_warmup(result, df)
+
+
+def test_ta_atr_calculates_each_symbol_separately() -> None:
+    """ATR should use high, low and prior close from the same symbol."""
+    df = make_market_data()
+    expected = calculate_by_symbol(df, talib.ATR, ["high", "low", "close"])
+
+    result = ta_atr(
+        make_proxy(df, "high"),
+        make_proxy(df, "low"),
+        make_proxy(df, "close"),
+        WINDOW,
+    )
+
+    assert_result(result, df, expected)
+    assert_symbol_warmup(result, df)
+
+
+def test_ta_atr_aligns_inputs_by_key() -> None:
+    """ATR should align differently ordered inputs and keep high row order."""
+    df = make_market_data()
+    reversed_df = df.reverse()
+    expected = calculate_by_symbol(df, talib.ATR, ["high", "low", "close"])
+
+    result = ta_atr(
+        make_proxy(df, "high"),
+        make_proxy(reversed_df, "low"),
+        make_proxy(reversed_df, "close"),
+        WINDOW,
+    )
+
+    assert_result(result, df, expected)
+
+
+def test_ta_atr_rejects_duplicate_keys() -> None:
+    """Duplicate keys make one-to-one alignment ambiguous."""
+    df = make_market_data()
+    duplicate_high = pl.concat([df, df.head(1)])
+
+    with pytest.raises(ValueError, match="unique"):
+        ta_atr(
+            make_proxy(duplicate_high, "high"),
+            make_proxy(df, "low"),
+            make_proxy(df, "close"),
+            WINDOW,
+        )
+
+
+def test_ta_atr_rejects_mismatched_keys() -> None:
+    """Missing or extra keys should fail instead of silently misaligning data."""
+    df = make_market_data()
+    mismatched_low = pl.concat([
+        df.head(1).with_columns(pl.lit("OTHER.LOCAL").alias("vt_symbol")),
+        df.slice(1),
+    ])
+
+    with pytest.raises(ValueError, match="same keys"):
+        ta_atr(
+            make_proxy(df, "high"),
+            make_proxy(mismatched_low, "low"),
+            make_proxy(df, "close"),
+            WINDOW,
+        )

--- a/vnpy/alpha/dataset/ta_function.py
+++ b/vnpy/alpha/dataset/ta_function.py
@@ -2,6 +2,8 @@
 Technical Analysis Operators
 """
 
+from collections.abc import Callable
+
 import talib
 import polars as pl
 import pandas as pd
@@ -21,11 +23,57 @@ def to_pl_dataframe(series: pd.Series) -> pl.DataFrame:
     return df
 
 
+def _apply_by_symbol(
+    dataframe: pd.DataFrame,
+    function: Callable[[pd.DataFrame], pd.Series],
+) -> pd.Series:
+    """Apply a TA-Lib function to each symbol while preserving row order."""
+    result = pd.Series(index=dataframe.index, dtype=float, name="data")
+    groups = dataframe.groupby(level="vt_symbol", sort=False, dropna=False)
+
+    for positions in groups.indices.values():
+        group: pd.DataFrame = dataframe.iloc[positions, :]
+        values: pd.Series = function(group)
+        result.iloc[positions] = values.to_numpy()
+
+    return result
+
+
+def _align_atr_inputs(
+    high: pd.Series,
+    low: pd.Series,
+    close: pd.Series,
+) -> pd.DataFrame:
+    """Align ATR inputs by key, using high row order as the output order."""
+    inputs: dict[str, pd.Series] = {
+        "high": high,
+        "low": low,
+        "close": close,
+    }
+    reference_index: pd.Index = high.index
+
+    for name, series in inputs.items():
+        if not series.index.is_unique:
+            raise ValueError(f"ATR input keys must be unique: {name}")
+
+        if len(series.index) != len(reference_index) or not reference_index.isin(series.index).all():
+            raise ValueError("ATR inputs must contain the same keys")
+
+    aligned: pd.DataFrame = pd.concat(
+        [series.reindex(reference_index).rename(name) for name, series in inputs.items()],
+        axis="columns",
+    )
+    return aligned
+
+
 def ta_rsi(close: DataProxy, window: int) -> DataProxy:
     """Calculate RSI indicator by contract"""
     close_: pd.Series = to_pd_series(close)
 
-    result: pd.Series = talib.RSI(close_, timeperiod=window)   # type: ignore
+    result: pd.Series = _apply_by_symbol(
+        close_.rename("close").to_frame(),
+        lambda group: talib.RSI(group["close"], timeperiod=window),
+    )
 
     df: pl.DataFrame = to_pl_dataframe(result)
     return DataProxy(df)
@@ -37,7 +85,16 @@ def ta_atr(high: DataProxy, low: DataProxy, close: DataProxy, window: int) -> Da
     low_: pd.Series = to_pd_series(low)
     close_: pd.Series = to_pd_series(close)
 
-    result: pd.Series = talib.ATR(high_, low_, close_, timeperiod=window)   # type: ignore
+    inputs: pd.DataFrame = _align_atr_inputs(high_, low_, close_)
+    result: pd.Series = _apply_by_symbol(
+        inputs,
+        lambda group: talib.ATR(
+            group["high"],
+            group["low"],
+            group["close"],
+            timeperiod=window,
+        ),
+    )
 
     df: pl.DataFrame = to_pl_dataframe(result)
     return DataProxy(df)


### PR DESCRIPTION
## 改进内容

1. `ta_rsi`和`ta_atr`按`vt_symbol`分别调用TA-Lib，避免不同合约行情串入同一个指标序列。
2. ATR输入按`(datetime, vt_symbol)`键对齐，并保持high输入的原始行序；重复键或键集合不一致时明确报错，避免静默错位。
3. 新增回归测试，覆盖多合约交错数据、独立预热期、结果与逐合约TA-Lib一致、行序保持、输入乱序对齐及无效键。
4. 不改变公共函数签名或返回结构。

## 问题原因

原实现把带有`(datetime, vt_symbol)` MultiIndex的整列Series一次性传给TA-Lib。TA-Lib按一维数组计算，不会根据`vt_symbol`自动分组，导致多合约数据互相污染，ATR还可能读取另一个合约的前收盘价。

## 验证

- Python 3.10、3.13专项测试连续多轮通过（每轮`5 passed`）。
- `tests/alpha`、`ruff check .`、相关文件mypy和`uv build`通过。
- wheel、sdist安装、`pip check`和公共模块导入通过。
- 完整pytest在两个版本均为`106 passed, 4 failed`；4项失败是`origin/dev`既有的Alpha 62/64/65/68测试仍调用已删除的`cast_to_int`，与本PR无关。
- 当前上游`dev`的mypy门禁也因依赖存根使用Python 3.12语法而失败：[Actions基线](https://github.com/vnpy/vnpy/actions/runs/30319699678)。

## 相关的Issue号（如有）

Close #3793
