### PR TITLE
[Fix] update stale Alpha101 comparison tests

### DIFF
--- a/tests/test_alpha101.py
+++ b/tests/test_alpha101.py
@@ -433,7 +433,7 @@ class TestAlpha101:
 
     def test_alpha62(self, test_df: pl.DataFrame) -> None:
         """Test Alpha#62"""
-        expr = "cast_to_int(cs_rank(ts_corr(vwap, ts_sum(ts_mean(volume, 20), 22), 10)) < cs_rank(cast_to_int((cs_rank(open) + cs_rank(open)) < (cs_rank((high + low) / 2) + cs_rank(high))))) * -1"
+        expr = "(cs_rank(ts_corr(vwap, ts_sum(ts_mean(volume, 20), 22), 10)) < cs_rank((cs_rank(open) + cs_rank(open)) < (cs_rank((high + low) / 2) + cs_rank(high)))) * -1"
         result = calculate_by_expression(test_df, expr)
         assert "data" in result.columns
 
@@ -445,13 +445,13 @@ class TestAlpha101:
 
     def test_alpha64(self, test_df: pl.DataFrame) -> None:
         """Test Alpha#64"""
-        expr = "cast_to_int(cs_rank(ts_corr(ts_sum(((open * 0.178404) + (low * (1 - 0.178404))), 13), ts_sum(ts_mean(volume, 120), 13), 17)) < cs_rank(ts_delta((((high + low) / 2 * 0.178404) + (vwap * (1 - 0.178404))), 4))) * -1"
+        expr = "(cs_rank(ts_corr(ts_sum(((open * 0.178404) + (low * (1 - 0.178404))), 13), ts_sum(ts_mean(volume, 120), 13), 17)) < cs_rank(ts_delta((((high + low) / 2 * 0.178404) + (vwap * (1 - 0.178404))), 4))) * -1"
         result = calculate_by_expression(test_df, expr)
         assert "data" in result.columns
 
     def test_alpha65(self, test_df: pl.DataFrame) -> None:
         """Test Alpha#65"""
-        expr = "cast_to_int(cs_rank(ts_corr(((open * 0.00817205) + (vwap * (1 - 0.00817205))), ts_sum(ts_mean(volume, 60), 9), 6)) < cs_rank(open - ts_min(open, 14))) * -1"
+        expr = "(cs_rank(ts_corr(((open * 0.00817205) + (vwap * (1 - 0.00817205))), ts_sum(ts_mean(volume, 60), 9), 6)) < cs_rank(open - ts_min(open, 14))) * -1"
         result = calculate_by_expression(test_df, expr)
         assert "data" in result.columns
 
@@ -469,7 +469,7 @@ class TestAlpha101:
 
     def test_alpha68(self, test_df: pl.DataFrame) -> None:
         """Test Alpha#68"""
-        expr = "cast_to_int(ts_rank(ts_corr(cs_rank(high), cs_rank(ts_mean(volume, 15)), 9), 14) < cs_rank(ts_delta((close * 0.518371 + low * (1 - 0.518371)), 1))) * -1"
+        expr = "(ts_rank(ts_corr(cs_rank(high), cs_rank(ts_mean(volume, 15)), 9), 14) < cs_rank(ts_delta((close * 0.518371 + low * (1 - 0.518371)), 1))) * -1"
         result = calculate_by_expression(test_df, expr)
         assert "data" in result.columns
 


### PR DESCRIPTION
## TL;DR

Alpha62、64、65、68 的测试还在调用已经删除的 `cast_to_int`，导致 `tests/test_alpha101.py` 固定报错。本次只同步这四条测试表达式，不改生产代码和因子结果。

## 改动点

1. 移除四条测试里过期的 `cast_to_int` 调用。
2. 让测试表达式与当前 Alpha101 实现保持一致。
3. 修改范围仅限 `tests/test_alpha101.py`。

## 测试

- 修改前专项：`4 failed, 96 deselected`，四项均为 `cast_to_int` 未定义。
- 修改后专项：`4 passed, 96 deselected`。
- `tests/test_alpha101.py`：`100 passed`。
- 完整测试：`105 passed`。
- `ruff check --no-cache .`：通过。
- `uv build`：wheel 和 sdist 构建成功。
- `mypy vnpy` 按仓库的 Python 3.10 配置会被当前 NumPy stubs 的 Python 3.12 语法提前阻断；显式使用 Python 3.13 后，`60` 个源码文件通过。该问题与本次测试文件改动无关。

## 相关的 Issue 号（如有）

无。